### PR TITLE
Add an alias for texting applications.

### DIFF
--- a/src/fr/neamar/summon/dataprovider/AliasProvider.java
+++ b/src/fr/neamar/summon/dataprovider/AliasProvider.java
@@ -47,6 +47,11 @@ public class AliasProvider extends Provider {
 
 			String marketApp = getAppByCategory(pm, Intent.CATEGORY_APP_MARKET);
 			alias.put("market", marketApp);
+
+			String messagingApp = getAppByCategory(pm, Intent.CATEGORY_APP_MESSAGING);
+			alias.put("text", messagingApp);
+			alias.put("sms", messagingApp);
+
 		}
 
 		private String getApp(PackageManager pm, String action)


### PR DESCRIPTION
I did not bother installing a dev environment for that, hence, it is not tested. I used [1](http://developer.android.com/reference/android/content/Intent.html#CATEGORY_APP_MESSAGING) as my resource, not sure if this is adequate.
