### PR TITLE
Desk clock app intents correction and Improvement

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAliasPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAliasPojos.java
@@ -64,7 +64,7 @@ public class LoadAliasPojos extends LoadPojos<AliasPojo> {
             }
 
             String clockApp = getClockApp(pm);
-            if (messagingApp != null) {
+            if (clockApp != null) {
                 String clockAlias = context.getResources().getString(R.string.alias_clock);
                 addAliasesPojo(alias, clockAlias.split(","), clockApp);
             }
@@ -131,6 +131,8 @@ public class LoadAliasPojos extends LoadPojos<AliasPojo> {
                 {"com.motorola.blur.alarmclock", "com.motorola.blur.alarmclock.AlarmClock"},
                 // Sony
                 {"com.sonyericsson.organizer", "com.sonyericsson.organizer.Organizer_WorldClock"}
+                // ASUS Tablets
+                {"com.asus.deskclock","com.asus.deskclock.DeskClock"}
         };
 
         for (int i = 0; i < clockImpls.length; i++) {

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAliasPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAliasPojos.java
@@ -130,9 +130,9 @@ public class LoadAliasPojos extends LoadPojos<AliasPojo> {
                 // Motorola
                 {"com.motorola.blur.alarmclock", "com.motorola.blur.alarmclock.AlarmClock"},
                 // Sony
-                {"com.sonyericsson.organizer", "com.sonyericsson.organizer.Organizer_WorldClock"}
+                {"com.sonyericsson.organizer", "com.sonyericsson.organizer.Organizer_WorldClock"},
                 // ASUS Tablets
-                {"com.asus.deskclock","com.asus.deskclock.DeskClock"}
+                {"com.asus.deskclock", "com.asus.deskclock.DeskClock"}
         };
 
         for (int i = 0; i < clockImpls.length; i++) {


### PR DESCRIPTION
In ***ASUS Tablets***, searching for the clock app related strings didn't emerge any results:
On further code inspections finally the answer was in the palm of **LoadAliasPojos.java** class!!

As I edited the answer in the **SO** [provided link](http://stackoverflow.com/questions/3590955/intent-to-launch-the-clock-application-on-android), the package names added according to the predefined form. and then in the last if condition, it seems not correct to be messagingApp string there, so replaced by clockApp string already defined in the previous line.