### PR TITLE
Cleanup in permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,23 +5,20 @@
     android:versionCode="48"
     android:versionName="2.6.4">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
-
-    <!-- Contacts provider : -->
+    <!-- Self explanatory -->
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <!-- To call a phone number directly without displaying the dialer -->
     <uses-permission android:name="android.permission.CALL_PHONE"/>
-    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
+    <!-- To enable / disable cellular data -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
-
-    <!-- Toggles provider -->
+    <!-- To enable / disable wifi -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <!-- To enable / disable bluetooth -->
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-
-    <!-- Incoming SMS history -->
+    <!-- Incoming SMS sender history -->
     <uses-permission android:name="android.permission.RECEIVE_SMS"/>
 
     <uses-feature


### PR DESCRIPTION
Removed three permissions:

* `WRITE_SETTINGS`, added in 8fb486ce6898d99124f7f26d083267f8587a4d30. Looks unused now. Hopefully ><
* `INTERNET`, not used since we're out of beta
* `GET_ACCOUNTS`, idem.