### PR TITLE
Load activity icons on initial load

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.loader;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -50,6 +51,14 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 
                 app.packageName = info.activityInfo.applicationInfo.packageName;
                 app.activityName = info.activityInfo.name;
+
+                try {
+                    app.packageImage = manager.getActivityIcon(
+                            new ComponentName(info.activityInfo.applicationInfo.packageName,
+                                    info.activityInfo.name));
+                } catch (PackageManager.NameNotFoundException e) {
+                    app.packageImage = null;
+                }
 
                 apps.add(app);
             }

--- a/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
@@ -1,6 +1,9 @@
 package fr.neamar.kiss.pojo;
 
+import android.graphics.drawable.Drawable;
+
 public class AppPojo extends Pojo {
     public String packageName;
     public String activityName;
+    public Drawable packageImage;
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -43,17 +43,18 @@ public class AppResult extends Result {
         appName.setText(enrichText(appPojo.displayName));
 
         final ImageView appIcon = (ImageView) v.findViewById(R.id.item_app_icon);
-        if (position < 15) {
-            appIcon.setImageDrawable(this.getDrawable(context));
-        } else {
+        if (appPojo.packageImage == null) {
             // Do actions on a message queue to avoid performance issues on main thread
             Handler handler = new Handler();
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    appIcon.setImageDrawable(getDrawable(context));
+                    appPojo.packageImage = getDrawable(context);
+                    appIcon.setImageDrawable(appPojo.packageImage);
                 }
             });
+        } else {
+            appIcon.setImageDrawable(appPojo.packageImage);
         }
 
         return v;


### PR DESCRIPTION
Removing the constant image load from the display function (called by
RecordAdapter.getView) improves scrolling speed.
The same could be made for the others data types.