### PR TITLE
Hide keyboard when displaying KISS bar

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -515,6 +515,8 @@ public class MainActivity extends ListActivity implements QueryInterface {
             for (int i = favoritesPojo.size(); i < favsIds.length; i++) {
                 findViewById(favsIds[i]).setVisibility(View.GONE);
             }
+
+            hideKeyboard();
         } else {
             // Hide the bar
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
This is useless to show the keyboard when the KISS bar is visible, so this pull requests hides it when the user clicks on the button.

This is an answer to @aeuii's comment in #199.