### PR TITLE
Add support for USSD code

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/PhoneProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/PhoneProvider.java
@@ -25,7 +25,7 @@ public class PhoneProvider extends Provider<PhonePojo> {
         ArrayList<Pojo> pojos = new ArrayList<>();
 
         // Append an item only if query looks like a phone number and device has phone capabilities
-        if (deviceIsPhone && query.matches("^[0-9+ .-]{2,}$")) {
+        if (deviceIsPhone && query.matches("^([0-9+ .-]{2,}|[*#]{1,3}[0-9]{1,3}[*a-zA-Z0-9]*#)$")) {
             pojos.add(getResult(query));
         }
 

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -32,7 +32,7 @@ public class PhoneResult extends Result {
     @Override
     public void doLaunch(Context context, View v) {
         Intent phone = new Intent(Intent.ACTION_CALL);
-        phone.setData(Uri.parse("tel:" + phonePojo.phone));
+        phone.setData(Uri.parse("tel:" + Uri.encode(phonePojo.phone)));
 
         phone.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 


### PR DESCRIPTION
Here is a simple fix for #219.

The regex was made from this wikipedia page : https://fr.wikipedia.org/wiki/Unstructured_Supplementary_Service_Data

> The USSD code format is (%)(%)%XYZ(*text)#, where () indicates an optionnal element, % is either # or *, X, Y and Z are digits and text is an alphanumeric text.

(This quote has been modified a bit because the first digit can be something else than a 1, contrary to what is said)