### PR TITLE
Properly set torch state on releaseCamera() method

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CameraHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/CameraHandler.java
@@ -46,6 +46,7 @@ public class CameraHandler {
 		} finally {
 			camera = null;
 			surfaceTexture = null;
+			torchState = false;
 		}
 	}
 


### PR DESCRIPTION
This fix a bug that not properly set torch state to false when releasing camera.
To reproduce issue, light on torch and launch something. KISS release camera (and light off torch), but toggle state remains wrong.