### PR TITLE
Fix torch mode detection

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CameraHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/CameraHandler.java
@@ -103,6 +103,11 @@ public class CameraHandler {
                 openCamera();
                 List<String> torchModes = camera.getParameters().getSupportedFlashModes();
                 releaseCamera();
+                
+                //no flash
+                if (torchModes == null)
+                    return false;
+                
                 for (String mode : torchModes) {
                     if (mode.equalsIgnoreCase(Camera.Parameters.FLASH_MODE_TORCH))
                         torchAvailable = true;

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadTogglePojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadTogglePojos.java
@@ -32,8 +32,7 @@ public class LoadTogglePojos extends LoadPojos<TogglePojo> {
             // See http://stackoverflow.com/questions/26539445/the-setmobiledataenabled-method-is-no-longer-callable-as-of-android-l-and-later
             toggles.add(createPojo(context.getString(R.string.toggle_data), "data", R.drawable.toggle_data));
         }
-        if (pm.hasSystemFeature(PackageManager.FEATURE_CAMERA) && pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH) &&
-                KissApplication.getCameraHandler().isTorchAvailable()) {
+        if (pm.hasSystemFeature(PackageManager.FEATURE_CAMERA) && KissApplication.getCameraHandler().isTorchAvailable()) {
             toggles.add(createPojo(context.getString(R.string.toggle_torch), "torch", R.drawable.toggle_torch));
         }
 


### PR DESCRIPTION
I've noticed that on another android phone (JellyBean 4.2.2) torch not work only with kiss.
I've discovered that for some strange reason

`pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)`

return false, but flash is present and also `FLASH_MODE_TORCH`.
Then I've modified code to check the presence of flash and torch mode in another way.

Cheers
Michele