### PR TITLE
Initial attempt to search within apps from KISS

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/SearchProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/SearchProvider.java
@@ -1,8 +1,11 @@
 package fr.neamar.kiss.dataprovider;
 
+import android.content.Context;
+
 import java.util.ArrayList;
 
 import fr.neamar.kiss.loader.LoadSearchPojos;
+import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.SearchPojo;
 
@@ -13,13 +16,17 @@ public class SearchProvider extends Provider<SearchPojo> {
         this.initialize(new LoadSearchPojos(this));
     }
 
-    public ArrayList<Pojo> getResults(String query) {
-        ArrayList<Pojo> pojos = new ArrayList<>();
 
-        SearchPojo pojo = new SearchPojo();
-        pojo.query = query;
-        pojo.relevance = 10;
-        pojos.add(pojo);
-        return pojos;
+    public ArrayList<Pojo> getResults(String query) {
+        ArrayList<Pojo> records = new ArrayList<>();
+
+        for (Pojo pojo : pojos) {
+            ((SearchPojo) pojo).query = query;
+            // consider search pojos less relevant than apps
+            pojo.relevance = 1;
+            records.add(pojo);
+        }
+
+        return records;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadSearchPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadSearchPojos.java
@@ -1,19 +1,108 @@
 package fr.neamar.kiss.loader;
 
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import fr.neamar.kiss.normalizer.StringNormalizer;
 import fr.neamar.kiss.pojo.SearchPojo;
 
 public class LoadSearchPojos extends LoadPojos<SearchPojo> {
 
+    private static String KISS_PACKAGE_NAME;
+    /**
+     * Search activities that we know work when given a query
+     */
+    private static List<String> knownSearchActivities = Arrays.asList(
+            "com.amazon.mShop.search.SearchActivity",
+            "com.andrew.apollo.ui.activities.SearchActivity",
+            "com.android.calendar.SearchActivity",
+            "com.android.contacts.activities.PeopleActivity",
+            "com.android.mms.ui.SearchResultBoxActivity",
+            "com.android.music.QueryBrowserActivity",
+            "com.android.vending.AssetBrowserActivity",
+            "com.boardgamegeek.ui.SearchResultsActivity",
+            "com.github.mobile.ui.search.SearchActivity",
+            "com.google.android.apps.chromecast.app.search.SearchResultsActivity",
+            "com.google.android.apps.youtube.app.WatchWhileActivity",
+            "com.google.android.finsky.activities.MainActivity",
+            "com.lge.music.QueryBrowserActivity",
+            "com.netflix.mediaclient.ui.search.SearchActivity",
+            "com.Prismatic.android.ui.SearchActivity",
+            "com.soundcloud.android.search.SearchActivity",
+            "com.ted.android.view.activity.SearchActivity",
+            "com.twitter.android.SearchActivity",
+            "org.fdroid.fdroid.SearchResults"
+    );
+
     public LoadSearchPojos(Context context) {
-        super(context, "none://");
+        super(context, "search://");
+
+        KISS_PACKAGE_NAME = context.getPackageName();
     }
 
     @Override
     protected ArrayList<SearchPojo> doInBackground(Void... params) {
-        return null;
+        List<ResolveInfo> appsWithSearch = context.getPackageManager().queryIntentActivities(new Intent(Intent.ACTION_SEARCH),
+                PackageManager.GET_INTENT_FILTERS);
+        ArrayList<SearchPojo> searchPojos = new ArrayList<>();
+        Map<String, String> added = new HashMap<>();
+        PackageManager manager = context.getPackageManager();
+
+        for (ResolveInfo info : appsWithSearch) {
+            String packageName = info.activityInfo.applicationInfo.packageName;
+            String activityName = info.activityInfo.name;
+
+            if (!KISS_PACKAGE_NAME.equals(packageName) &&
+                    // thanks http://stackoverflow.com/a/11411881
+                    info.activityInfo.exported &&
+                    !added.containsKey(packageName)) {
+
+                // Use a whitelist of known-good search activities.
+                // Unfortunately, choosing a random activity that can fulfil Intent.ACTION_SEARCH
+                // isn't foolproof, as some of them:
+                // - Require more data than just a query
+                // - Crash
+                // - Open the search activity, then don't preform a search
+                // See the discussion around https://github.com/Neamar/KISS/pull/288 for more info
+                if (!knownSearchActivities.contains(activityName)) {
+                    continue;
+                }
+
+                SearchPojo app = new SearchPojo();
+
+                app.id = pojoScheme + packageName + "/" + activityName;
+
+                try {
+                    app.name = manager.getApplicationLabel(manager.getApplicationInfo(packageName, 0)).toString();
+                } catch (PackageManager.NameNotFoundException e) {
+                    // fall back to this activity's name
+                    // sometimes app devs name their search activities "Search"
+                    // which isn't useful in our case because our search activities
+                    // are displayed as 'App Name: "query"'
+                    app.name = info.loadLabel(manager).toString();
+                }
+
+                //Ugly hack to remove accented characters.
+                //Note Java 5 provides a Normalizer method, unavailable for Android :\
+                app.nameNormalized = StringNormalizer.normalize(app.name);
+
+                app.packageName = packageName;
+                app.activityName = activityName;
+
+                added.put(packageName, activityName);
+                searchPojos.add(app);
+            }
+        }
+
+        return searchPojos;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/pojo/SearchPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/SearchPojo.java
@@ -1,5 +1,5 @@
 package fr.neamar.kiss.pojo;
 
-public class SearchPojo extends Pojo {
+public class SearchPojo extends AppPojo {
     public String query = "";
 }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -39,12 +39,13 @@ public abstract class Result {
     Pojo pojo = null;
 
     public static Result fromPojo(QueryInterface parent, Pojo pojo) {
-        if (pojo instanceof AppPojo)
+        // Note: SearchPojo _must_ be before AppPojo because it extends AppPojo
+        if (pojo instanceof SearchPojo)
+            return new SearchResult((SearchPojo) pojo);
+        else if (pojo instanceof AppPojo)
             return new AppResult((AppPojo) pojo);
         else if (pojo instanceof ContactsPojo)
             return new ContactsResult(parent, (ContactsPojo) pojo);
-        else if (pojo instanceof SearchPojo)
-            return new SearchResult((SearchPojo) pojo);
         else if (pojo instanceof SettingsPojo)
             return new SettingsResult((SettingsPojo) pojo);
         else if (pojo instanceof TogglesPojo)

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -3,11 +3,13 @@ package fr.neamar.kiss.result;
 import android.annotation.TargetApi;
 import android.app.SearchManager;
 import android.content.ActivityNotFoundException;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Handler;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
@@ -17,48 +19,55 @@ import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.SearchPojo;
 
-public class SearchResult extends Result {
+public class SearchResult extends AppResult {
     private final SearchPojo searchPojo;
 
+    private final ComponentName className;
+
     public SearchResult(SearchPojo searchPojo) {
-        super();
+        super(searchPojo);
+
         this.pojo = this.searchPojo = searchPojo;
+
+        className = new ComponentName(searchPojo.packageName, searchPojo.activityName);
     }
 
     @Override
-    public View display(Context context, int position, View v) {
+    public View display(final Context context, int position, View v) {
         if (v == null)
-            v = inflateFromId(context, R.layout.item_search);
+            v = inflateFromId(context, R.layout.item_app);
 
-        TextView appName = (TextView) v.findViewById(R.id.item_search_text);
-        String text = context.getString(R.string.ui_item_search);
-        appName.setText(enrichText(String.format(text, "{" + searchPojo.query + "}")));
+        TextView appName = (TextView) v.findViewById(R.id.item_app_name);
 
-        ((ImageView) v.findViewById(R.id.item_search_icon)).setColorFilter(getThemeFillColor(context), PorterDuff.Mode.SRC_IN);
+        final ImageView appIcon = (ImageView) v.findViewById(R.id.item_app_icon);
+        if (position < 15) {
+            appIcon.setImageDrawable(this.getDrawable(context));
+        } else {
+            // Do actions on a message queue to avoid performance issues on main thread
+            Handler handler = new Handler();
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    appIcon.setImageDrawable(getDrawable(context));
+                }
+            });
+        }
+
+        appName.setText(enrichText(String.format(context.getString(R.string.ui_item_search),
+                searchPojo.name, "{" + searchPojo.query + "}")));
+
         return v;
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Override
     public void doLaunch(Context context, View v) {
-        Intent search = new Intent(Intent.ACTION_WEB_SEARCH);
+        Intent search = new Intent(Intent.ACTION_SEARCH);
+        search.setComponent(className);
         search.putExtra(SearchManager.QUERY, searchPojo.query);
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            // In the latest Google Now version, ACTION_WEB_SEARCH is broken when used with FLAG_ACTIVITY_NEW_TASK.
-            // Adding FLAG_ACTIVITY_CLEAR_TASK seems to fix the problem.
-            search.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        }
-        search.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
-        try {
-            context.startActivity(search);
-        } catch (ActivityNotFoundException e) {
-            // This exception gets thrown if Google Search has been deactivated:
-            Uri uri = Uri.parse("https://encrypted.google.com/search?q=" + searchPojo.query);
-            search = new Intent(Intent.ACTION_VIEW, uri);
-            search.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            context.startActivity(search);
-        }
+        search.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT |
+                Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        context.startActivity(search);
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)

--- a/app/src/main/res/values-ar-rAR/strings.xml
+++ b/app/src/main/res/values-ar-rAR/strings.xml
@@ -2,7 +2,6 @@
 <resources><string name="app_name">KISS قاذفة</string>
     <string name="activity_setting">إعدادات KISS</string>
     <string name="ui_search_hint">بحث التطبيقات، والاتصالات، …</string>
-    <string name="ui_item_search">البحث عن \"%s\"</string>
     <string name="ui_item_phone">اتصال \"%s\"</string>
     <string name="ui_item_contact_hint_message">الرسالة</string>
     <string name="ui_item_contact_hint_call">مكالمة</string>

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -2,7 +2,6 @@
 <resources><string name="app_name">Llanzador KISS</string>
     <string name="activity_setting">Axustes de KISS</string>
     <string name="ui_search_hint">Gueta aplicaciones, contautos…</string>
-    <string name="ui_item_search">Guetar «%s»</string>
     <string name="ui_item_phone">Llamar a «%s»</string>
     <string name="ui_item_contact_hint_message">Mensaxe</string>
     <string name="title_ui">Interfaz d\'usuariu</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS başladıcı</string>
     <string name="activity_setting">KISS parametrləri</string>
     <string name="ui_search_hint">Axtar: Proqramlar, kontaktlar, …</string>
-    <string name="ui_item_search">Şunu axtar: \"%s\"</string>
     <string name="ui_item_contact_hint_message">Mesaj</string>
     <string name="title_ui">İstifadəçi İnterfeysi</string>
     <string name="title_history">Tarix</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">Llançador KISS</string>
     <string name="activity_setting">Ajustaments de KISS</string>
     <string name="ui_search_hint">Buscar apps, contactes, …</string>
-    <string name="ui_item_search">Cercar “%s”</string>
     <string name="ui_item_phone">Trucar “%s”</string>
     <string name="ui_item_contact_hint_message">Missatge</string>
     <string name="ui_item_contact_hint_call">Trucar</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="activity_setting">Nastavení KISS</string>
     <string name="ui_search_hint">Vyhledávat aplikace, kontanty…</string>
-    <string name="ui_item_search">Vyhledávat “%s”</string>
     <string name="ui_item_phone">Hovor “%s”</string>
     <string name="ui_item_contact_hint_message">Zpráva</string>
     <string name="ui_item_contact_hint_call">Hovor</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -4,7 +4,6 @@
     <string name="activity_setting">KISS Einstellungen</string>
     <string name="ui_search_hint">Nach Apps, Kontakten, … suchen</string>
     <string name="ui_item_phone">„%s‟ anrufen</string>
-    <string name="ui_item_search">Nach „%s‟ suchen</string>
     <string name="ui_item_contact_hint_message">Nachricht</string>
     <string name="ui_item_contact_hint_call">Anrufen</string>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">Ρυθμίσεις KISS</string>
     <string name="ui_search_hint">Αναζήτηση εφαρμογών, επαφών…</string>
-    <string name="ui_item_search">Αναζήτησε “%s”</string>
     <string name="ui_item_phone">Κάλεσε “%s”</string>
     <string name="ui_item_contact_hint_message">Μήνυμα</string>
     <string name="ui_item_contact_hint_call">Κλήση</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">Ajustes de KISS</string>
     <string name="ui_search_hint">Buscar aplicaciones, contactos, …</string>
-    <string name="ui_item_search">Buscar “%s”</string>
     <string name="ui_item_phone">Llamar “%s”</string>
     <string name="ui_item_contact_hint_message">Mensaje</string>
     <string name="ui_item_contact_hint_call">Llamar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">Paramètres de KISS</string>
     <string name="ui_search_hint">Rechercher des applications, contacts…</string>
-    <string name="ui_item_search">Rechercher « %s »</string>
     <string name="ui_item_phone">Appeler « %s »</string>
     <string name="ui_item_contact_hint_message">SMS</string>
     <string name="ui_item_contact_hint_call">Appeler</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -2,7 +2,6 @@
 <resources><string name="app_name">KISS launcher</string>
     <string name="activity_setting">Axustes de KISS</string>
     <string name="ui_search_hint">Buscar aplicativos, contactos, …</string>
-    <string name="ui_item_search">Buscar \"%s\"</string>
     <string name="ui_item_phone">Chamar a \"%s\"</string>
     <string name="ui_item_contact_hint_message">Mensaxe</string>
     <string name="ui_item_contact_hint_call">Chamar</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">KISS postavke</string>
     <string name="ui_search_hint">Pretraži aplikacije, kontakte, &#8230;</string>
-    <string name="ui_item_search">Potraži “%s”</string>
     <string name="ui_item_phone">Nazovi “%s”</string>
     <string name="ui_item_contact_hint_message">Poruka</string>
     <string name="ui_item_contact_hint_call">Poziv</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS indító</string>
     <string name="activity_setting">KISS beállítások</string>
     <string name="ui_search_hint">App-ok, névjegyek keresése, …</string>
-    <string name="ui_item_search">Keresés “%s”</string>
     <string name="ui_item_phone">Hívás “%s”</string>
     <string name="ui_item_contact_hint_message">Üzenet</string>
     <string name="ui_item_contact_hint_call">Hívás</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">Impostazioni di KISS</string>
     <string name="ui_search_hint">Cerca applicazioni, contatti, …</string>
-    <string name="ui_item_search">Cerca “%s”</string>
     <string name="ui_item_phone">Chiama “%s”</string>
     <string name="ui_item_contact_hint_message">Messaggio</string>
     <string name="ui_item_contact_hint_call">Chiama</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS ランチャー</string>
     <string name="activity_setting">KISS 設定</string>
     <string name="ui_search_hint">アプリ、連絡先、などを検索…</string>
-    <string name="ui_item_search">“%s” の検索</string>
     <string name="ui_item_phone">“%s” の通話</string>
     <string name="ui_item_contact_hint_message">メッセージ</string>
     <string name="ui_item_contact_hint_call">通話</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -36,7 +36,6 @@
 
     <string name="ui_empty_2">Loggen er alltid tilgjengelig</string>
     <string name="ui_empty_2_sub">For hurtig tilgang</string>
-    <string name="ui_item_search">Søk etter «%s»</string>
     <string name="ui_item_contact_hint_message">Melding</string>
     <string name="stub_application">Appnavn</string>
     <string name="stub_contact">Kontaktnavn</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">KISS instellingen</string>
     <string name="ui_search_hint">Zoek naar apps, contacten, …</string>
-    <string name="ui_item_search">Zoek naar “%s”</string>
     <string name="ui_item_phone">Bel “%s”</string>
     <string name="ui_item_contact_hint_message">SMS</string>
     <string name="ui_item_contact_hint_call">Bel</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">Ustawienia KISS</string>
     <string name="ui_search_hint">Wyszukaj aplikacje, kontakty, …</string>
-    <string name="ui_item_search">Wyszukaj “%s”</string>
     <string name="ui_item_phone">Połącz z “%s”</string>
     <string name="ui_item_contact_hint_message">Wiadomość</string>
     <string name="ui_item_contact_hint_call">Zadzwoń</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -42,7 +42,6 @@
     <string name="history_onclick_desc">Clique na barra de pesquisa para mostrar o histórico</string>
     <string name="history_onclick_name">Interface minimalista: Mostrar histórico ao clicar</string>
     <string name="portrait_title">Forçar modo de retrato</string>
-    <string name="ui_item_search">Pesquisar por \"%s\"</string>
     <string name="ui_search_hint">Pesquisar apps, contatos, …</string>
     <string name="ui_empty_2">Veja sempre seu histórico</string>
     <string name="ui_empty_3">Acesso rápido aos aplicativos mais usados</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS лаунчер</string>
     <string name="activity_setting">Настройки KISS</string>
     <string name="ui_search_hint">Искать приложения, контакты, …</string>
-    <string name="ui_item_search">Поиск по “%s”</string>
     <string name="ui_item_phone">Звонки “%s”</string>
     <string name="ui_item_contact_hint_message">Сообщение</string>
     <string name="ui_item_contact_hint_call">Звонки</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -2,7 +2,6 @@
 <resources><string name="app_name">KISS launcher</string>
     <string name="activity_setting">KISS nastavenia</string>
     <string name="ui_search_hint">Hľadaj aplikácie, kontakty, …</string>
-    <string name="ui_item_search">Vyhľadať “%s”</string>
     <string name="ui_item_phone">Volaj “%s”</string>
     <string name="ui_item_contact_hint_message">Správa</string>
     <string name="ui_item_contact_hint_call">Hovor</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -4,7 +4,6 @@
     <string name="app_name">КИС покретач</string>
     <string name="activity_setting">Поставке</string>
     <string name="ui_search_hint">Тражите апликације, контакте…</string>
-    <string name="ui_item_search">Тражите “%s”</string>
     <string name="ui_item_phone">Позив “%s”</string>
     <string name="ui_item_contact_hint_message">Порука</string>
     <string name="ui_item_contact_hint_call">Позив</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">KISS başlatıcı</string>
     <string name="activity_setting">KISS ayarları</string>
     <string name="ui_search_hint">Ara: Uygulamalar, kişiler, …</string>
-    <string name="ui_item_search">Şunu ara: \"%s\"</string>
     <string name="ui_item_phone">Çağrı yap: “%s”</string>
     <string name="ui_item_contact_hint_message">Mesaj</string>
     <string name="ui_item_contact_hint_call">Çağrı</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">KISS settings</string>
     <string name="ui_search_hint">Search apps, contacts, …</string>
-    <string name="ui_item_search">Search for “%s”</string>
+    <string name="ui_item_search">%1$s: “%2$s”</string>
     <string name="ui_item_phone">Call “%s”</string>
     <string name="ui_item_contact_hint_message">Message</string>
     <string name="ui_item_contact_hint_call">Call</string>


### PR DESCRIPTION
WARNING: this is probably not ready to be merged yet, because of the issues below. It's good enough for daily use though, and is probably worth discussing.

See https://github.com/Neamar/KISS/issues/157

Issues:
- Not all apps provide a search activity
  - The most notable missing apps are:
    - The Google app
    - The DuckDuckGo app
    - Browsers
    - Wikipedia
- Some apps provide a search activity, but it crashes
  - For example Google Newsstand
- Some apps provide a search activity, but it requires more than just a
  query
  - For example Gmail
- Some apps provide a search activity, but when you give it a query, it
  opens without preforming a search
  - For example Podcast Addict, Amazon Kindle, and Coursera
- Search results are not retained in the recent apps list
  - I don't care if the searches are stored, but it'd be nice if the
    apps that were searched showed up. This proved difficult to do
    because Providers all maintain their own list of recent Pojos