### PR TITLE
Hide history - issue #238

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -32,6 +32,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
@@ -44,6 +45,7 @@ import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.result.Result;
 import fr.neamar.kiss.searcher.ApplicationsSearcher;
 import fr.neamar.kiss.searcher.HistorySearcher;
+import fr.neamar.kiss.searcher.NullSearcher;
 import fr.neamar.kiss.searcher.QueryInterface;
 import fr.neamar.kiss.searcher.QuerySearcher;
 import fr.neamar.kiss.searcher.Searcher;
@@ -572,7 +574,18 @@ public class MainActivity extends ListActivity implements QueryInterface {
         }
 
         if (query.length() == 0) {
-            searcher = new HistorySearcher(this);
+            if (prefs.getBoolean("history-hide", false))
+            {
+                searcher = new NullSearcher(this);
+                //Hide default scrollview
+                ((LinearLayout)findViewById(R.id.main_empty)).setVisibility(View.INVISIBLE);
+
+            }
+            else {
+                searcher = new HistorySearcher(this);
+                //Show default scrollview
+                ((LinearLayout)findViewById(R.id.main_empty)).setVisibility(View.VISIBLE);
+            }
         } else {
             searcher = new QuerySearcher(this, query);
         }

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -578,13 +578,13 @@ public class MainActivity extends ListActivity implements QueryInterface {
             {
                 searcher = new NullSearcher(this);
                 //Hide default scrollview
-                ((LinearLayout)findViewById(R.id.main_empty)).setVisibility(View.INVISIBLE);
+                findViewById(R.id.main_empty).setVisibility(View.INVISIBLE);
 
             }
             else {
                 searcher = new HistorySearcher(this);
                 //Show default scrollview
-                ((LinearLayout)findViewById(R.id.main_empty)).setVisibility(View.VISIBLE);
+                findViewById(R.id.main_empty).setVisibility(View.VISIBLE);
             }
         } else {
             searcher = new QuerySearcher(this, query);

--- a/app/src/main/java/fr/neamar/kiss/searcher/NullSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/NullSearcher.java
@@ -1,0 +1,23 @@
+package fr.neamar.kiss.searcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import fr.neamar.kiss.KissApplication;
+import fr.neamar.kiss.MainActivity;
+import fr.neamar.kiss.pojo.Pojo;
+
+/**
+ * Retrieve pojos from history
+ */
+public class NullSearcher extends Searcher {
+
+    public NullSearcher(MainActivity activity) {
+        super(activity);
+    }
+
+    @Override
+    protected List<Pojo> doInBackground(Void... voids) {
+        return new ArrayList<Pojo>();
+    }
+}

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -124,14 +124,14 @@
         android:layout_above="@id/searchEditLayout"
         android:visibility="gone">
 
-        <include layout="@layout/main_empty"/>
+        <include android:id="@+id/main_empty" layout="@layout/main_empty"/>
     </ScrollView>
 
     <include
         android:id="@+id/main_kissbar"
         layout="@layout/main_kissbar"
         android:layout_width="fill_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_alignParentLeft="true"
         android:layout_below="@android:id/list"

--- a/app/src/main/res/layout/main_kissbar.xml
+++ b/app/src/main/res/layout/main_kissbar.xml
@@ -25,7 +25,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="42dp"
         android:layout_toRightOf="@+id/whiteLauncherButton"
         android:gravity="center_vertical"
         android:orientation="horizontal"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="keyboard_name">Display keyboard</string>
     <string name="spellcheck_name">Enable spellcheck</string>
     <string name="spellcheck_desc">Provide suggestions when typing</string>
+    <string name="history_hide_desc">Hide history and intro screen</string>
+    <string name="history_hide_name">Minimalistic UI</string>
     <string name="portrait_title">Force portrait mode</string>
     <string name="portrait_summary">Always rotate screen to portrait mode when showing the launcher</string>
     <string name="root_mode_desc">Enable root features if available (to hibernate applications)</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -37,6 +37,12 @@
             android:title="@string/spellcheck_name">
         </CheckBoxPreference>
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="history-hide"
+            android:summary="@string/history_hide_desc"
+            android:title="@string/history_hide_name">
+        </CheckBoxPreference>
+        <CheckBoxPreference
             android:defaultValue="true"
             android:key="force-portrait"
             android:title="@string/portrait_title"


### PR DESCRIPTION
When selected in settings, history and default scrollview are hidden.

![screenshot_2015-10-11-23-08-40](https://cloud.githubusercontent.com/assets/7504889/10419193/b256be6c-706f-11e5-9d04-b820d93e31a6.png)

To avoid visual artifacts while animation, I had to fix the size of kissbar to 42 --> 32 for the icon and +5x2 for padding

At the current implementation, if this mode is enabled the history can not be shown. 
I am thinking that the kiss button could have three "states": A) Show history B) Show KissBar and apps C) Show empty
Any opinions / suggestions?
