### PR TITLE
Trim the string before normalization

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -82,7 +82,7 @@ public class DataHandler extends BroadcastReceiver {
      * @return ordered list of records
      */
     public ArrayList<Pojo> getResults(Context context, String query) {
-        query = query.toLowerCase().replaceAll("<", "&lt;");
+        query = query.toLowerCase().trim().replaceAll("<", "&lt;");
 
         currentQuery = query;
 

--- a/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
@@ -91,6 +91,6 @@ public class StringNormalizer {
      * @see StringNormalizer#normalizeWithMap(String)
      */
     public static String normalize(String input) {
-        return StringNormalizer.normalizeWithMap(input.trim()).first;
+        return StringNormalizer.normalizeWithMap(input).first;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
@@ -91,6 +91,6 @@ public class StringNormalizer {
      * @see StringNormalizer#normalizeWithMap(String)
      */
     public static String normalize(String input) {
-        return StringNormalizer.normalizeWithMap(input).first;
+        return StringNormalizer.normalizeWithMap(input.trim()).first;
     }
 }


### PR DESCRIPTION
When using some keyboard+spellchecker (e.g. swiftkey keyboard does this) the inserted word automatically has a trailing space. In some cases the query (for instance “store ”) does not match the intended result (for instance “Play store”)

I think trimming the string in the string normalizer should fix this problem (and do no harm) however please note that *I did not test my code*. 