### PR TITLE
Fixing sd card issue (missing apps)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,7 +100,7 @@
                 <action android:name="android.intent.action.ACTION_MEDIA_MOUNTED" />
                 <action android:name="android.intent.action.ACTION_MEDIA_REMOVED" />
 
-
+                <data android:scheme="file" />
                 <data android:scheme="package" />
             </intent-filter>
         </receiver>


### PR DESCRIPTION
it seems that this is what was missing for the problem at #291 
I don't really know how the data scheme is working for android but it solves the problem.

To test, I used a note II and mounted / unmounted the sdcard (fortunately without removing the battery). On mount the apps were reloaded
I also tested on kitkat where some apps are stored in sdcard and on boot, all apps are visible.

