### PR TITLE
Fixed null launchIntent

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/broadcast/NewAppInstalledHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/NewAppInstalledHandler.java
@@ -23,12 +23,18 @@ public class NewAppInstalledHandler extends BroadcastReceiver {
         if ("android.intent.action.PACKAGE_ADDED".equals(intent.getAction()) && !intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
             // Add new package to history
             String packageName = intent.getData().getSchemeSpecificPart();
-            String className = ctx.getPackageManager().getLaunchIntentForPackage(packageName).getComponent().getClassName();
+
+            Intent launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(packageName);
+            if (launchIntent == null) {//for some plugin app
+                return ;
+            }
+
+            String className = launchIntent.getComponent().getClassName();
             if (className != null) {
                 KissApplication.getDataHandler(ctx).addToHistory(ctx, "app://" + packageName + "/" + className);
             }
         }
-        
+
         if ("android.intent.action.PACKAGE_REMOVED".equals(intent.getAction())) {
             // Removed all installed shortcuts
             String packageName = intent.getData().getSchemeSpecificPart();


### PR DESCRIPTION
Installing some apps, for example this

https://f-droid.org/repository/browse/?fdfilter=unified&fdid=org.fitchfamily.android.gsmlocation

crash launcher.
This is because not all apps can be called directly (plugin, backend for some other app etc etc etc)
I've fixed this little bug.

Cheers
Michele