### PR TITLE
Small fixes:

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -206,8 +206,11 @@ public class MainActivity extends ListActivity implements QueryInterface {
             @Override
             public void onClick(View v) {
                 if (prefs.getBoolean("history-hide", false) && prefs.getBoolean("history-onclick", false)) {
-                    searcher = new HistorySearcher(MainActivity.this);
-                    searcher.execute();
+                    //show history only if no search text is added
+                    if (((EditText)v).getText().toString().length()==0) {
+                        searcher = new HistorySearcher(MainActivity.this);
+                        searcher.execute();
+                    }
                 }
             }
         });

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -48,9 +48,9 @@ public class AppResult extends Result {
         appName.setText(enrichText(appPojo.displayName));
 
 
-        if (!PreferenceManager.getDefaultSharedPreferences(context).getBoolean("icons-hide", false)) {
+        final ImageView appIcon = (ImageView) v.findViewById(R.id.item_app_icon);
 
-            final ImageView appIcon = (ImageView) v.findViewById(R.id.item_app_icon);
+        if (!PreferenceManager.getDefaultSharedPreferences(context).getBoolean("icons-hide", false)) {
             if (position < 15) {
                 appIcon.setImageDrawable(this.getDrawable(context));
             } else {
@@ -63,6 +63,9 @@ public class AppResult extends Result {
                     }
                 });
             }
+        }
+        else {
+            appIcon.setVisibility(View.INVISIBLE);
         }
         return v;
     }

--- a/app/src/main/java/fr/neamar/kiss/result/ToggleResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ToggleResult.java
@@ -48,6 +48,10 @@ public class ToggleResult extends Result {
         final CompoundButton toggleButton = (CompoundButton) v
                 .findViewById(R.id.item_toggle_action_toggle);
 
+        //set listener to null to avoid calling the listener of the older toggle item
+        //(due to recycling)
+        toggleButton.setOnCheckedChangeListener(null);
+
         Boolean state = togglesHandler.getState(togglePojo);
         if (state != null)
             toggleButton.setChecked(togglesHandler.getState(togglePojo));


### PR DESCRIPTION
- #212 : Hide app icons completely when hide icons is selected
- #318 : Setting listener to null before change state on toggles. This might be a fix
- On minimalistic ui when clicking the search text, history is shown only if the editText is empty