### PR TITLE
fix for circle ci failure.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+dependencies:
+  pre:
+    - echo y | android update sdk --no-ui --all --filter tools,extra-android-m2repository,extra-android-support,extra-google-google_play_services,extra-google-m2repository,android-23
+    - echo y | android update sdk --no-ui --all --filter build-tools-23.0.2
 test:
   pre:
     # start the emulator


### PR DESCRIPTION
I think commit 273056c that changed the android build tools broke the circle ci tests.
This is a workaround.


check here: https://discuss.circleci.com/t/android-build-tools-23-0-2-not-available/455/4