### PR TITLE
 Bug fix on pin favorites

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import fr.neamar.kiss.dataprovider.ShortcutProvider;
 import fr.neamar.kiss.dataprovider.ToggleProvider;
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.db.ValuedHistoryRecord;
+import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoComparator;
 
@@ -283,4 +285,19 @@ public class DataHandler extends BroadcastReceiver {
         ((MainActivity)context).retrieveFavorites();
 
     }
+
+    public void excludeFromAppList(Context context, AppPojo appPojo)
+    {
+
+        String excludedAppList = PreferenceManager.getDefaultSharedPreferences(context).
+                getString("excluded-apps-list", context.getPackageName() + ";");
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
+        //remove app pojo from appProvider results - no need to reset handler
+        KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
+
+        removeFromFavorites(appPojo, context);
+    }
+
+
 }

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -269,4 +269,18 @@ public class DataHandler extends BroadcastReceiver {
 
         return null;
     }
+
+    public void removeFromFavorites(Pojo pojo, Context context) {
+        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
+                getString("favorite-apps-list", "");
+        if (!favApps.contains(pojo.id + ";")) {
+            return;
+        }
+
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString("favorite-apps-list", favApps.replace(pojo.id+";", "")).commit();
+
+        ((MainActivity)context).retrieveFavorites();
+
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -24,7 +24,6 @@ import fr.neamar.kiss.dataprovider.ShortcutProvider;
 import fr.neamar.kiss.dataprovider.ToggleProvider;
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.db.ValuedHistoryRecord;
-import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoComparator;
 

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -285,19 +284,5 @@ public class DataHandler extends BroadcastReceiver {
         ((MainActivity)context).retrieveFavorites();
 
     }
-
-    public void excludeFromAppList(Context context, AppPojo appPojo)
-    {
-
-        String excludedAppList = PreferenceManager.getDefaultSharedPreferences(context).
-                getString("excluded-apps-list", context.getPackageName() + ";");
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
-                .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
-        //remove app pojo from appProvider results - no need to reset handler
-        KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
-
-        removeFromFavorites(appPojo, context);
-    }
-
 
 }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/PhoneProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/PhoneProvider.java
@@ -42,6 +42,7 @@ public class PhoneProvider extends Provider<PhonePojo> {
         pojo.id = PHONE_SCHEME + phoneNumber;
         pojo.phone = phoneNumber;
         pojo.relevance = 20;
+        pojo.name = phoneNumber;
         return pojo;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -80,7 +80,7 @@ public class AppResult extends Result {
         PopupMenu menu = new PopupMenu(context, parentView);
         menu.getMenuInflater().inflate(R.menu.menu_item_app, menu.getMenu());
 
-        //removeMenuItemFavoritesIfPinned(menu, context);
+        removeMenuItemFavoritesIfPinned(menu, context);
         try {
             // app installed under /system can't be uninstalled
             ApplicationInfo ai = context.getPackageManager().getApplicationInfo(this.appPojo.packageName, 0);
@@ -130,13 +130,12 @@ public class AppResult extends Result {
                 .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
         //remove app pojo from appProvider results - no need to reset handler
         KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
-
         KissApplication.getDataHandler(context).removeFromFavorites(appPojo, context);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
 
     }
 
-    /**+
+    /**
      * Open an activity displaying details regarding the current package
      */
     private void launchAppDetails(Context context, AppPojo app) {

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -124,7 +124,14 @@ public class AppResult extends Result {
     }
 
     private void excludeFromAppList(Context context, AppPojo appPojo) {
-        KissApplication.getDataHandler(context).excludeFromAppList(context, appPojo);
+            String excludedAppList = PreferenceManager.getDefaultSharedPreferences(context).
+                    getString("excluded-apps-list", context.getPackageName() + ";");
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
+        //remove app pojo from appProvider results - no need to reset handler
+        KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
+
+        KissApplication.getDataHandler(context).removeFromFavorites(appPojo, context);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
 
     }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -76,7 +76,8 @@ public class AppResult extends Result {
     protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
         PopupMenu menu = new PopupMenu(context, parentView);
         menu.getMenuInflater().inflate(R.menu.menu_item_app, menu.getMenu());
-        removeMenuItemFavoritesIfPinned(menu, context);
+
+        //removeMenuItemFavoritesIfPinned(menu, context);
         try {
             // app installed under /system can't be uninstalled
             ApplicationInfo ai = context.getPackageManager().getApplicationInfo(this.appPojo.packageName, 0);
@@ -119,31 +120,9 @@ public class AppResult extends Result {
         return super.popupMenuClickHandler(context, parent, item);
     }
 
-    private void excludeFromAppList(Context context, AppPojo appPojo)
-    {
-
-        String excludedAppList = PreferenceManager.getDefaultSharedPreferences(context).
-                getString("excluded-apps-list", context.getPackageName() + ";");
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
-                .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
-        //remove app pojo from appProvider results - no need to reset handler
-        KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
-
-        removeFromFavorites(context);
+    private void excludeFromAppList(Context context, AppPojo appPojo) {
+        KissApplication.getDataHandler(context).excludeFromAppList(context, appPojo);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
-    }
-
-    private void removeFromFavorites(Context context)
-    {
-        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
-                getString("favorite-apps-list", "");
-        if (favApps.contains(this.pojo.id + ";")) {
-            KissApplication.getDataHandler(context).removeFromFavorites(this.pojo, context);
-        }
-        //refresh favorites to remove this app from the fav.list (in case it was there)
-        if (context instanceof MainActivity) {
-            ((MainActivity) context).retrieveFavorites();
-        }
 
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -76,7 +76,7 @@ public class AppResult extends Result {
     protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
         PopupMenu menu = new PopupMenu(context, parentView);
         menu.getMenuInflater().inflate(R.menu.menu_item_app, menu.getMenu());
-
+        removeMenuItemFavoritesIfPinned(menu, context);
         try {
             // app installed under /system can't be uninstalled
             ApplicationInfo ai = context.getPackageManager().getApplicationInfo(this.appPojo.packageName, 0);
@@ -92,8 +92,6 @@ public class AppResult extends Result {
         if (KissApplication.getRootHandler(context).isRootActivated() && KissApplication.getRootHandler(context).isRootAvailable()) {
             menu.getMenuInflater().inflate(R.menu.menu_item_app_root, menu.getMenu());
         }
-
-        inflateBaseMenu(context, menu);
         return menu;
     }
 
@@ -130,14 +128,26 @@ public class AppResult extends Result {
                 .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
         //remove app pojo from appProvider results - no need to reset handler
         KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
-        //refresh favorites to remove this app from the fav.list (in case it was there)
-        if(context instanceof MainActivity) {
-            ((MainActivity) context).retrieveFavorites();
-        }
+
+        removeFromFavorites(context);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
     }
 
-    /**
+    private void removeFromFavorites(Context context)
+    {
+        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
+                getString("favorite-apps-list", "");
+        if (favApps.contains(this.pojo.id + ";")) {
+            KissApplication.getDataHandler(context).removeFromFavorites(this.pojo, context);
+        }
+        //refresh favorites to remove this app from the fav.list (in case it was there)
+        if (context instanceof MainActivity) {
+            ((MainActivity) context).retrieveFavorites();
+        }
+
+    }
+
+    /**+
      * Open an activity displaying details regarding the current package
      */
     private void launchAppDetails(Context context, AppPojo app) {

--- a/app/src/main/java/fr/neamar/kiss/result/ContactResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactResult.java
@@ -110,8 +110,8 @@ public class ContactResult extends Result {
     protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
         PopupMenu menu = new PopupMenu(context, parentView);
         menu.getMenuInflater().inflate(R.menu.menu_item_contact, menu.getMenu());
+        removeMenuItemFavoritesIfPinned(menu, context);
 
-        inflateBaseMenu(context, menu);
         return menu;
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -45,8 +45,8 @@ public class PhoneResult extends Result {
     protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
         PopupMenu menu = new PopupMenu(context, parentView);
         menu.getMenuInflater().inflate(R.menu.menu_item_phone, menu.getMenu());
+        removeMenuItemFavoritesIfPinned(menu, context);
 
-        inflateBaseMenu(context, menu);
         return menu;
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -93,8 +93,17 @@ public abstract class Result {
         PopupMenu menu = new PopupMenu(context, parentView);
         menu.getMenuInflater().inflate(R.menu.menu_item_default, menu.getMenu());
 
-        inflateBaseMenu(context, menu);
+        removeMenuItemFavoritesIfPinned(menu, context);
         return menu;
+    }
+
+    protected void removeMenuItemFavoritesIfPinned(PopupMenu menu, Context context) {
+        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
+                getString("favorite-apps-list", "");
+        if (favApps.contains(this.pojo.id + ";")) {
+            menu.getMenu().removeItem(R.id.item_favorites_add);
+        }
+
     }
 
     /**
@@ -213,14 +222,5 @@ public abstract class Result {
         int[] attrs = new int[] { R.attr.resultColor /* index 0 */};
         TypedArray ta = context.obtainStyledAttributes(attrs);
         return ta.getColor(0, Color.WHITE);
-    }
-
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    protected void inflateBaseMenu(Context context, PopupMenu menu) {
-        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
-                getString("favorite-apps-list", "");
-        if (!favApps.contains(this.pojo.id + ";")) {
-            menu.getMenuInflater().inflate(R.menu.menu_item_favorite_add, menu.getMenu());
-        }
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/SettingResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SettingResult.java
@@ -5,15 +5,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageView;
-import android.widget.PopupMenu;
 import android.widget.TextView;
 import fr.neamar.kiss.R;
-import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.SettingPojo;
 
 public class SettingResult extends Result {
@@ -38,15 +35,6 @@ public class SettingResult extends Result {
         settingIcon.setColorFilter(getThemeFillColor(context), Mode.SRC_IN);
 
         return v;
-    }
-
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    @Override
-    protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
-        PopupMenu menu = new PopupMenu(context, parentView);
-
-        inflateBaseMenu(context, menu);
-        return menu;
     }
 
     @SuppressWarnings("deprecation")

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutResult.java
@@ -82,8 +82,8 @@ public class ShortcutResult extends Result {
         
         //add uninstall menu
         menu.getMenuInflater().inflate(R.menu.menu_item_app_uninstall, menu.getMenu());
+        removeMenuItemFavoritesIfPinned(menu, context);
 
-        inflateBaseMenu(context, menu);
         return menu;
     }
     

--- a/app/src/main/java/fr/neamar/kiss/result/ToggleResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ToggleResult.java
@@ -5,20 +5,17 @@ import android.content.Context;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.ImageView;
-import android.widget.PopupMenu;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
-import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.TogglePojo;
 import fr.neamar.kiss.toggles.TogglesHandler;
 
@@ -109,15 +106,6 @@ public class ToggleResult extends Result {
     @Override
     public Drawable getDrawable(Context context) {
         return context.getResources().getDrawable(togglePojo.icon);
-    }
-
-    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    @Override
-    protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
-        PopupMenu menu = new PopupMenu(context, parentView);
-
-        inflateBaseMenu(context, menu);
-        return menu;
     }
 
     @Override

--- a/app/src/main/res/menu/menu_item_app.xml
+++ b/app/src/main/res/menu/menu_item_app.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/item_favorites_add"
+        android:title="@string/menu_favorites_add"/>
+    <item
         android:id="@+id/item_remove"
         android:title="@string/menu_remove"/>
 

--- a/app/src/main/res/menu/menu_item_contact.xml
+++ b/app/src/main/res/menu/menu_item_contact.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/item_favorites_add"
+        android:title="@string/menu_favorites_add"/>
+    <item
         android:id="@+id/item_remove"
         android:title="@string/menu_remove"/>
     <item

--- a/app/src/main/res/menu/menu_item_default.xml
+++ b/app/src/main/res/menu/menu_item_default.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/item_favorites_add"
+        android:title="@string/menu_favorites_add"/>
+    <item
         android:id="@+id/item_remove"
         android:title="@string/menu_remove"/>
 </menu>

--- a/app/src/main/res/menu/menu_item_phone.xml
+++ b/app/src/main/res/menu/menu_item_phone.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/item_favorites_add"
+        android:title="@string/menu_favorites_add"/>
+    <item
         android:id="@+id/item_remove"
         android:title="@string/menu_remove"/>
 


### PR DESCRIPTION
Unfortunately, with #354, some results (e.g. settings) do not have the "remove from history" menu anymore...
Sorry for that, I fix it with this commit.

I followed @Neamar suggestion to include the "add to favorites" menu in the xml files and not add them programmatically.  However, the build menu calls the method removeMenuItemFavoritesIfPinned in order to remove the "add to favorites" if the result is already in the favorites.

 