### PR TITLE
Update Spanish translations (app → aplicación)

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="app_name">KISS launcher</string>
     <string name="activity_setting">Ajustes de KISS</string>
-    <string name="ui_search_hint">Buscar apps, contactos, …</string>
+    <string name="ui_search_hint">Buscar aplicaciones, contactos, …</string>
     <string name="ui_item_search">Buscar “%s”</string>
     <string name="ui_item_phone">Llamar “%s”</string>
     <string name="ui_item_contact_hint_message">Mensaje</string>
@@ -15,13 +15,12 @@
     <string name="title_advanced">Ajustes avanzados</string>
     <string name="menu_settings">Ajustes del dispositivo</string>
     <string name="menu_preferences">Ajustes de KISS</string>
-    <string name="no_favorites">Sin Favoritos. Arranque una app y se añadirá a Favoritos.</string>
+    <string name="no_favorites">Sin Favoritos. Arranque una aplicación y se añadirá a Favoritos.</string>
 
     <string name="ui_empty_1">Empiece a buscar cualquier cosa</string>
-    <string name="ui_empty_1_sub">Apps, contactos, ajustes, …</string>
     <string name="ui_empty_2">Siempre ver su historial</string>
     <string name="ui_empty_2_sub">Para acceder más rápidamente</string>
-    <string name="ui_empty_3">Acceso directo a las apps más usadas</string>
+    <string name="ui_empty_3">Acceso directo a las aplicaciones más usadas</string>
     <string name="ui_empty_3_sub">KISS launcher aprende de sus hábitos</string>
 
     <string name="toggles_desc">Permitir cambios de estado (Wi-Fi, Bluetooth)</string>
@@ -47,7 +46,7 @@
     <string name="shortcuts_desc">Buscar en los atajos instalados</string>
     <string name="shortcuts_name">Atajos</string>
     
-    <string name="stub_application">Nombre de la App</string>
+    <string name="stub_application">Nombre de la Aplicación</string>
     <string name="stub_contact">Contacto</string>
     <string name="stub_contact_phone">+330 12 34 56 78</string>
     <string name="stub_setting">Nombre del ajuste</string>
@@ -55,7 +54,7 @@
     <string name="stub_phone">Llamar al +330 12 34 56 78</string>
     <string name="main_menu">Menú</string>
     <string name="main_clear">Borrar texto</string>
-    <string name="main_kiss">Mostrar favoritos y lista de apps</string>
+    <string name="main_kiss">Mostrar favoritos y lista de aplicaciones</string>
     <string name="main_kiss_back">Mostrar historial</string>
     <string name="reset_desc">Resetear el historial de KISS</string>
     <string name="reset_name">Resetear el historial</string>


### PR DESCRIPTION
"App" is a word that is not correctly used in Spanish because it doesn't even exist in Spanish. The correct word is "aplicación".

Sorry for making 2 pull requests so immediately. 