### PR TITLE
Better fuzzy search

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -71,14 +71,11 @@ public class AppProvider extends Provider<AppPojo> {
             }
 
             if (queryPos == query.length() && matchPositions != null) {
-                // Base score for all matching apps of 20
-                relevance += 20;
+                // Add percentage of matched letters, but at a weight of 40
+                relevance += (int)(((double)queryPos / appNameNormalized.length()) * 40);
 
-                // Add percentage of matched letters, but at a weight of 30
-                relevance += (int)(((double)queryPos / appNameNormalized.length()) * 30);
-
-                // Add percentage of matched upper case letters (start of word), but at a weight of 50
-                relevance += (int)(((double)matchedWordStarts / totalWordStarts) * 50);
+                // Add percentage of matched upper case letters (start of word), but at a weight of 60
+                relevance += (int)(((double)matchedWordStarts / totalWordStarts) * 60);
 
                 // The more fragmented the matches are, the less the result is important
                 relevance *= (0.2 + 0.8 * (1.0 / matchPositions.size()));

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -71,13 +71,13 @@ public class AppProvider extends Provider<AppPojo> {
             }
 
             if (queryPos == query.length() && matchPositions != null) {
-                // Base score for all matching apps of 20%
+                // Base score for all matching apps of 20
                 relevance += 20;
 
-                // Add percentage of matched letters, but at a weight of 30%
+                // Add percentage of matched letters, but at a weight of 30
                 relevance += (int)(((double)queryPos / appNameNormalized.length()) * 30);
 
-                // Add percentage of matched upper case letters (start of word), but at a weight of 50%
+                // Add percentage of matched upper case letters (start of word), but at a weight of 50
                 relevance += (int)(((double)matchedWordStarts / totalWordStarts) * 50);
 
                 // The more fragmented the matches are, the less the result is important

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.dataprovider;
 
+import android.util.Pair;
 import java.util.ArrayList;
 
 import fr.neamar.kiss.loader.LoadAppPojos;
@@ -19,30 +20,68 @@ public class AppProvider extends Provider<AppPojo> {
         ArrayList<Pojo> records = new ArrayList<>();
 
         int relevance;
-        int matchPositionStart;
-        int matchPositionEnd;
         String appNameNormalized;
 
-        final String queryWithSpace = " " + query;
         for (Pojo pojo : pojos) {
             relevance = 0;
             appNameNormalized = pojo.nameNormalized;
 
-            matchPositionEnd = 0;
-            if (appNameNormalized.startsWith(query)) {
-                relevance = 100;
-                matchPositionStart = 0;
-                matchPositionEnd = query.length();
-            } else if ((matchPositionStart = appNameNormalized.indexOf(queryWithSpace)) > -1) {
-                relevance = 50;
-                matchPositionEnd = matchPositionStart + queryWithSpace.length();
-            } else if ((matchPositionStart = appNameNormalized.indexOf(query)) > -1) {
-                relevance = 1;
-                matchPositionEnd = matchPositionStart + query.length();
+            ArrayList<Pair<Integer, Integer>> matchPositions = new ArrayList<>();
+
+            int queryPos = 0;
+            int appPos = 0;
+            int beginMatch = 0;
+            int matchedWordStarts = 0;
+            int totalWordStarts = 0;
+
+            boolean match = false;
+            for (char cApp : appNameNormalized.toCharArray()) {
+                if (queryPos < query.length() && query.charAt(queryPos) == cApp) {
+                    // If we aren't already matching something, let's save the beginning of the match
+                    if (!match) {
+                        beginMatch = appPos;
+                        match = true;
+                    }
+
+                    // If we are at the beginning of a word, add it to matchedWordStarts
+                    if (Character.isUpperCase(pojo.name.charAt(appPos)) || appPos == 0 || Character.isWhitespace(pojo.name.charAt(appPos - 1)))
+                        matchedWordStarts += 1;
+
+                    // Increment the position in the query
+                    queryPos++;
+                }
+                else if (match) {
+                    matchPositions.add(Pair.create(beginMatch, appPos));
+                    match = false;
+                }
+
+                // If we are at the beginning of a word, add it to totalWordsStarts
+                if (Character.isUpperCase(pojo.name.charAt(appPos)) || appPos == 0 || Character.isWhitespace(pojo.name.charAt(appPos - 1)))
+                    totalWordStarts += 1;
+
+                appPos++;
+            }
+
+            if (match) {
+                matchPositions.add(Pair.create(beginMatch, appPos));
+            }
+
+            if (queryPos == query.length()) {
+                // Base score for all matching apps of 20%
+                relevance += 20;
+
+                // Add percentage of matched letters, but at a weight of 30%
+                relevance += (int)(((double)queryPos / appNameNormalized.length()) * 30);
+
+                // Add percentage of matched upper case letters (start of word), but at a weight of 50%
+                relevance += (int)(((double)matchedWordStarts / totalWordStarts) * 50);
+
+                // The more fragmented the matches are, the less the result is important
+                relevance *= (0.2 + 0.8 * (1.0 / matchPositions.size()));
             }
 
             if (relevance > 0) {
-                pojo.setDisplayNameHighlightRegion(matchPositionStart, matchPositionEnd);
+                pojo.setDisplayNameHighlightRegion(matchPositions);
                 pojo.relevance = relevance;
                 records.add(pojo);
             }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -21,12 +21,12 @@ public class AppProvider extends Provider<AppPojo> {
 
         int relevance;
         String appNameNormalized;
+        ArrayList<Pair<Integer, Integer>> matchPositions;
 
         for (Pojo pojo : pojos) {
             relevance = 0;
             appNameNormalized = pojo.nameNormalized;
-
-            ArrayList<Pair<Integer, Integer>> matchPositions = new ArrayList<>();
+            matchPositions = null;
 
             int queryPos = 0;
             int appPos = 0;
@@ -51,6 +51,8 @@ public class AppProvider extends Provider<AppPojo> {
                     queryPos++;
                 }
                 else if (match) {
+                    if (matchPositions == null)
+                        matchPositions = new ArrayList<>();
                     matchPositions.add(Pair.create(beginMatch, appPos));
                     match = false;
                 }
@@ -63,10 +65,12 @@ public class AppProvider extends Provider<AppPojo> {
             }
 
             if (match) {
+                if (matchPositions == null)
+                    matchPositions = new ArrayList<>();
                 matchPositions.add(Pair.create(beginMatch, appPos));
             }
 
-            if (queryPos == query.length()) {
+            if (queryPos == query.length() && matchPositions != null) {
                 // Base score for all matching apps of 20%
                 relevance += 20;
 

--- a/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss.pojo;
 
 import android.util.Pair;
+import java.util.ArrayList;
 
 import fr.neamar.kiss.normalizer.StringNormalizer;
 
@@ -87,5 +88,19 @@ public abstract class Pojo {
         this.displayName = this.name.substring(0, positionStart)
                 + '{' + this.name.substring(positionStart, positionEnd) + '}'
                 + this.name.substring(positionEnd);
+    }
+
+    public void setDisplayNameHighlightRegion(ArrayList<Pair<Integer, Integer>> positions) {
+        this.displayName = "";
+        int lastPositionEnd = 0;
+        for (Pair<Integer, Integer> position : positions) {
+            int positionStart = this.mapPosition(position.first);
+            int positionEnd = this.mapPosition(position.second);
+
+            this.displayName += this.name.substring(lastPositionEnd, positionStart)
+                    + '{' + this.name.substring(positionStart, positionEnd) + '}';
+            lastPositionEnd = positionEnd;
+        }
+        this.displayName += this.name.substring(lastPositionEnd);
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -188,7 +188,7 @@ public abstract class Result {
      * @return text displayable on a textview
      */
     Spanned enrichText(String text) {
-        return Html.fromHtml(text.replaceAll("\\{(.*)\\}", "<font color=#4caf50>$1</font>"));
+        return Html.fromHtml(text.replaceAll("\\{", "<font color=#4caf50>").replaceAll("\\}", "</font>"));
     }
 
     /**


### PR DESCRIPTION
So I was motivated to solve #282 in a better way than #361 (not a Levenshtein distance, but the real thing like in sublime-text, as requested in the issue).

Sorry @nmitsou ^_^'

It looks like this for now:
![screenshot from 2016-02-01 23-15-52](https://cloud.githubusercontent.com/assets/1615426/12733282/395a5b62-c93a-11e5-9005-4ff84f6b7ed5.png)

Comparaison with #361:
- Highlighting of the matched text
- Maybe faster
- Cannot auto-correct typos (`clogk -> clock`)

This PR also adds support for multi-part highlighting.

Here is how the score is calculated:
- A positive match is given the base score of 20
- 30 points are given gradually with the percentage of characters matched
- 50 points are given gradually with the percentage of word starting characters matched (uppercase, or preceded by a whitespace). This allows queries that contain the beginning of a word to have a much better ranking.
- => This totals to a score going from 20 to 100
- The more fragmented the matches are, the less the result is significant (see [this line for the actual formula](https://github.com/Neamar/KISS/compare/fuzzysearch?expand=1#diff-e39439cc0b190cd66e530d81fd898679R80)).

Can someone test it and provide some feedback, especially on the ranking of the apps?

/cc @Neamar @nmitsou @emersion