### PR TITLE
Remove duplicate descriptions

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -98,7 +98,7 @@ public class SettingsActivity extends PreferenceActivity implements
     private void fixSummaries(SharedPreferences prefs) {
         int historyLength = KissApplication.getDataHandler(this).getHistoryLength();
         if (historyLength > 5) {
-            findPreference("reset").setSummary(getString(R.string.reset_name) + " (" + historyLength + " items)");
+            findPreference("reset").setSummary(historyLength + " " + getString(R.string.items_title));
         }
     }
     

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -98,7 +98,7 @@ public class SettingsActivity extends PreferenceActivity implements
     private void fixSummaries(SharedPreferences prefs) {
         int historyLength = KissApplication.getDataHandler(this).getHistoryLength();
         if (historyLength > 5) {
-            findPreference("reset").setSummary(getString(R.string.reset_desc) + " (" + historyLength + " items)");
+            findPreference("reset").setSummary(getString(R.string.reset_name) + " (" + historyLength + " items)");
         }
     }
     

--- a/app/src/main/res/menu/menu_settings.xml
+++ b/app/src/main/res/menu/menu_settings.xml
@@ -4,7 +4,7 @@
         android:id="@+id/preferences"
         android:icon="@drawable/ic_launcher"
         android:showAsAction="ifRoom|withText"
-        android:title="@string/menu_preferences"/>
+        android:title="@string/activity_setting"/>
     <item
         android:id="@+id/wallpaper"
         android:showAsAction="never"

--- a/app/src/main/res/values-ar-rAR/strings.xml
+++ b/app/src/main/res/values-ar-rAR/strings.xml
@@ -12,7 +12,6 @@
     <string name="title_providers">اختيار مقدمي</string>
     <string name="title_advanced">إعدادات متقدمة</string>
     <string name="menu_settings">إعدادات الجهاز</string>
-    <string name="menu_preferences">إعدادات KISS</string>
     <string name="no_favorites">لا المفضلة حتى الان. إضافتها من خلال نقرة طويلة.</string>
 
     <string name="ui_empty_1">البدء في البحث عن أي شيء</string>
@@ -22,27 +21,20 @@
     <string name="ui_empty_3">الوصول السريع إلى التطبيقات الأكثر استخداما</string>
     <string name="ui_empty_3_sub">KISS قاذفة يتعلم من عاداتك</string>
 
-    <string name="toggles_desc">تمكين المسامير (واي فاي، بلوتوث، ...)</string>
     <string name="toggles_name">المسامير</string>
     <string name="toggles_on">s% تفعيلها</string>
     <string name="toggles_off">s% المعطلة</string>
 
-    <string name="aliases_desc">تمكين الأسماء المستعارة (اختصارات الراحة)</string>
     <string name="aliases_name">اسماء مستعارة</string>
 
-    <string name="contacts_desc">البحث في اتصالاتي</string>
     <string name="contacts_name">جهات الاتصال</string>
 
-    <string name="search_desc">تمكين البحث في الويب من جوجل</string>
     <string name="search_name">بحث جوجل</string>
 
-    <string name="settings_desc">البحث في إعدادات جهازي</string>
     <string name="settings_name">إعدادات</string>
 
-    <string name="phone_desc">طالب المباشر لأرقام الهواتف</string>
     <string name="phone_name">هاتف</string>
 
-    <string name="shortcuts_desc">البحث في اختصارات المثبتة</string>
     <string name="shortcuts_name">الاختصارات</string>
 
     <string name="stub_application">اسم التطبيق</string>
@@ -55,24 +47,18 @@
     <string name="main_clear">حقل البحث واضح</string>
     <string name="main_kiss">عرض قائمة التطبيقات المفضلة</string>
     <string name="main_kiss_back">عرض التاريخ</string>
-    <string name="reset_desc">إعادة تعيين تاريخ KISS</string>
     <string name="reset_name">إعادة تعيين التاريخ</string>
-    <string name="reset_excluded_apps_desc">إعادة تعيين قائمة المستبعدين من التطبيقات KISS</string>
     <string name="reset_excluded_apps_name">إعادة تعيين قائمة التطبيق مستبعدة</string>
     <string name="reset_excluded_apps_warn">هل تريد حقا أن إعادة الخاص بك قائمة التطبيق تم استبعادها؟</string>
     <string name="reset_warn">هل تريد حقا أن إعادة تاريخكم؟</string>
-    <string name="reset_favorites_desc">إعادة تعيين قائمتك المفضلة</string>
     <string name="reset_favorites_name">المفضلة إعادة تعيين</string>
     <string name="reset_favorites_warn">هل تريد حقا أن إعادة المفضلة لديك؟</string>
-    <string name="keyboard_desc">عرض لوحة المفاتيح دائما عند بدء التشغيل</string>
     <string name="keyboard_name">لوحة المفاتيح عرض</string>
     <string name="spellcheck_name">تمكين التدقيق الإملائي</string>
-    <string name="spellcheck_desc">تقديم اقتراحات عند كتابة</string>
     <string name="history_hide_desc">إخفاء التاريخ وشاشة مقدمات</string>
     <string name="history_hide_name">واجهة أضيق الحدود</string>
     <string name="history_onclick_name">واجهة أضيق الحدود: عرض التاريخ على اتصال</string>
     <string name="portrait_title">وضع صورة القوة</string>
-    <string name="portrait_summary">تدوير دائما الشاشة لوضع صورة عندما تظهر قاذفة</string>
     <string name="icons_hide_main">إخفاء التطبيقات</string>
     <string name="icons_hide_desc">تمكين على الأجهزة البطيئة</string>
     <string name="root_mode_desc">تمكين ميزات الجذر إذا كان متوفرا (إلى السبات التطبيقات)</string>
@@ -119,18 +105,13 @@
     <string name="toast_hibernate_error">%s لا مسبوت بنجاح.</string>
     <string name="menu_contact_copy_phone">رقم الهاتف نسخة</string>
     <string name="theme_name">موضوع</string>
-    <string name="theme_desc">تحديث موضوع KISS</string>
     <string name="menu_phone_create">إنشاء اتصال</string>
 
     <string name="toast_favorites_added">تمت إضافة%s إلى المفضلة</string>
 
     <string name="order_apps_name">التطبيق ترتيب القائمة</string>
-    <string name="order_apps_desc">من الألف إلى الياء أو Z إلى A</string>
-    <string name="enable_sms_desc">إضافة الرسائل الواردة المرسل إلى التاريخ</string>
     <string name="enable_sms">تجميع التاريخ من الرسائل النصية</string>
-    <string name="enable_phone_desc">إضافة المكالمات الواردة إلى التاريخ</string>
     <string name="enable_phone">تجميع التاريخ من المكالمات الهاتفية</string>
-    <string name="enable_app_desc">إضافة تطبيقات جديدة للتاريخ</string>
     <string name="enable_app">تجميع التاريخ من التطبيق تثبيت</string>
     <string name="shortcut_added">وأضاف اختصار لـ KISS.</string>
 

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -9,7 +9,6 @@
     <string name="title_history">Historia</string>
     <string name="title_advanced">Axustes avanzaos</string>
     <string name="menu_settings">Axustes del preséu</string>
-    <string name="menu_preferences">Axustes de KISS</string>
     <string name="no_favorites">Entá nun hai favoritos. Amiéstalos pente un clic llargu.</string>
 
     <string name="ui_empty_1">Entama guetando daqué</string>
@@ -58,33 +57,21 @@
     <string name="toast_hibernate_error">%s nun s\'ivernó con ésitu.</string>
     <string name="menu_contact_copy_phone">Copiar númberu de teléfonu</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Anueva\'l tema de KISS</string>
     <string name="menu_phone_create">Crear contautu</string>
 
     <string name="order_apps_name">Orde del llistáu d\'aplicaciones</string>
-    <string name="order_apps_desc">A a Z ó Z a A</string>
 
 <string name="title_providers">Esbilla de fornidores</string>
     <string name="ui_empty_2">Mira siempres la to historia</string>
     <string name="ui_empty_2_sub">Pa un accesu rápidu</string>
-    <string name="toggles_desc">Habilita los alternadores (Wi-Fi, Bluetooth…)</string>
-    <string name="aliases_desc">Habilita los nomatos (atayos convenientes)</string>
     <string name="aliases_name">Nomatos</string>
 
     <string name="ui_item_contact_hint_call">Llamar a</string>
 
-    <string name="contacts_desc">Gueta nos mios contautos</string>
-    <string name="search_desc">Habilita la gueta web de Google</string>
-    <string name="settings_desc">Gueta nos axustes del mio preséu</string>
-    <string name="phone_desc">Marcador direutu pa númberos de teléfonu</string>
-    <string name="reset_desc">Reafita la historia de KISS</string>
     <string name="reset_name">Reafitar historia</string>
-    <string name="keyboard_desc">Siempres s\'amuesa\'l tecláu nel aniciu</string>
     <string name="keyboard_name">Amosar tecláu</string>
     <string name="spellcheck_name">Habilitar comprobación ortográfica</string>
-    <string name="spellcheck_desc">Apurre suxerencies al escribir</string>
     <string name="portrait_title">Forciar mou vertical</string>
-    <string name="portrait_summary">Siempres rota la pantalla al mou vertical cuando s\'amuesa\'l llanzador</string>
     <string name="root_mode_desc">Habilita les carauterístiques root si tán disponibles (pa ivernar aplicaciones)</string>
     <string name="alias_phone">marcar,llamar,llamada,teléfonu,marcáu,telefonazu,telefonada</string>
     <string name="alias_contacts">conautos,contautar,xente,persones,rellaciones</string>
@@ -111,10 +98,6 @@
 
     <string name="reset_warn">¿De xuru que quies reafitar la to historia?</string>    
     <string name="toggle_autorotate">Auto-rotar</string>
-    <string name="shortcuts_desc">Gueta nos atayos instalaos</string>
-    <string name="enable_sms_desc">Amiesta los mensaxes entrantes de remitentes a la historia</string>
-    <string name="enable_phone_desc">Amiesta aplicaciones nueves a la historia</string>
-    <string name="enable_app_desc">Amiesta aplicaciones nueves a la historia</string>
     <string name="enable_sms">Poblar historia con mensaxes de testu</string>
     <string name="enable_phone">Poblar historia con llamaes telefóniques</string>
     <string name="enable_app">Poblar historia con instalaciones d\'aplicaciones</string>
@@ -125,9 +108,7 @@
     <string name="excluded_app_list_erased">Desanicióse\'l llistáu d\'aplicaciones escluyíes.</string>
     <string name="toast_favorites_added">%s amestóse a favoritos</string>
 
-    <string name="reset_favorites_desc">Reafita\'l to llistáu de favoritos</string>
     <string name="reset_favorites_name">Reafitar favoritos</string>
-    <string name="reset_excluded_apps_desc">Reafita\'l llistáu d\'aplicaciones escluyíes de KISS</string>
     <string name="reset_excluded_apps_name">Reafitar el llistáu d\'aplicaciones escluyíes</string>
     <string name="menu_favorites_add">Amestar a favoritos</string>
     <string name="settings_nfc">NFC</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -9,7 +9,6 @@
     <string name="title_history">Tarix</string>
     <string name="title_providers">Neler Göstərilə</string>
     <string name="menu_settings">Cihaz Parametrləri</string>
-    <string name="menu_preferences">KISS parametrləri</string>
     <string name="no_favorites">Hələ tez istifadə proqram yoxdur. Proqramı kullandıkça tez istifadə edilənlər görünəcək.</string>
 
     <string name="ui_empty_1">Bir şeyləri axtarmağa başlayın</string>
@@ -19,22 +18,16 @@
     <string name="ui_empty_3">Ən çox istifadə proqramlara sürətli giriş</string>
     <string name="ui_empty_3_sub">KISS başladıcı vərdişlərinizə görə çalışır</string>
 
-    <string name="toggles_desc">Aç/Bağla düymələrini aktivləşdir (Wi-Fi, Bluetooth, ...)</string>
     <string name="toggles_name">Aç/Bağla düymələri</string>
 
-    <string name="aliases_desc">Armaları aktivləşdir (qısayol)</string>
     <string name="aliases_name">Armalar</string>
 
-    <string name="contacts_desc">Kontaktlarımda axtar</string>
     <string name="contacts_name">Kontaktlar</string>
 
-    <string name="search_desc">Google Web axtarışını aktivləşdir</string>
     <string name="search_name">Google axtarışı</string>
 
-    <string name="settings_desc">Cihaz parametrlərində axtar</string>
     <string name="settings_name">Parametrlər</string>
 
-    <string name="phone_desc">Telefon nömrələri üçün çevirici</string>
     <string name="phone_name">Telefon</string>
 
     <string name="stub_application">Proqram adı</string>
@@ -47,9 +40,7 @@
     <string name="main_clear">Mətni sil</string>
     <string name="main_kiss">Tez istifadə edilənləri və proqram siyahısını göstər</string>
     <string name="main_kiss_back">Keçmişi göstər</string>
-    <string name="reset_desc">KISS keçmişini sil</string>
     <string name="reset_name">Keçmişi sil</string>
-    <string name="keyboard_desc">Başlanğıcda klaviaturanı həmişə göstər</string>
     <string name="keyboard_name">Klaviaturanı göstər</string>
 
     <string name="alias_phone">zəng,ara,telefon</string>
@@ -80,7 +71,6 @@
     <string name="menu_app_uninstall">Yükləməyi qaldır</string>
     <string name="menu_contact_copy_phone">Telefon nömrəsini kopyala</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">KISS təmasını dəyişdir</string>
 
     <string name="ui_item_phone">Zəng et: \"%s\"</string>
     <string name="ui_item_contact_hint_call">Zəng et</string>
@@ -96,14 +86,11 @@
     <string name="toast_hibernate_completed">%s yuxu rejimine alındı, oyandırmaq üçün yenidən açın.</string>
     <string name="toast_hibernate_error">%s yuxu rejimine alınamadı.</string>
     <string name="spellcheck_name">İmla yoxlamasını aktivləşdir</string>
-    <string name="spellcheck_desc">Yazarkən təklifləri göstər</string>
 <string name="portrait_title">Dikey rejimi zorla</string>
-    <string name="portrait_summary">Başlatıcıyı göstərərkən ekranı hər zaman dikey rejimǝ döndər</string>
     <string name="toggle_sync">Sinxronizasiya</string>
     <string name="menu_phone_create">Kontakt yarat</string>
 
     <string name="order_apps_name">Proqram siyahı sırası</string>
-    <string name="order_apps_desc">A\'dan Z\'ye və ya Z\'den A\'ya</string>
 
 <string name="history_hide_desc">Keçmişi və daxil ekranını gizlət</string>
     <string name="history_hide_name">Minimalistik interfeys</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_history">Historial</string>
     <string name="title_providers">Selecció de proveïdors</string>
     <string name="menu_settings">Configuració del dispositiu</string>
-    <string name="menu_preferences">Ajustaments de KISS</string>
     <string name="no_favorites">Sense no preferits. Afegiu-los a través de clic de llarg.</string>
 
     <string name="ui_empty_1">Comenceu cercant qualsevol cosa</string>
@@ -23,22 +22,16 @@
     <string name="ui_empty_3">Accés ràpid a les aplicacions més emprades</string>
     <string name="ui_empty_3_sub">KISS launcher aprèn dels vostres hàbits</string>
 
-    <string name="toggles_desc">Permet el canvi d\'estat (wifi, bluetooth)</string>
     <string name="toggles_name">Canvia d\'estat</string>
 
-    <string name="aliases_desc">Permet àlies (enllaços directes)</string>
     <string name="aliases_name">Àlies</string>
 
-    <string name="contacts_desc">Cerca als contactes</string>
     <string name="contacts_name">Contactes</string>
 
-    <string name="search_desc">Permet cercar en Google Web Search</string>
     <string name="search_name">Cerca de Google</string>
 
-    <string name="settings_desc">Cerca a la configuració del dispositiu</string>
     <string name="settings_name">Configuració</string>
 
-    <string name="phone_desc">Marcador de números de telèfon</string>
     <string name="phone_name">Telèfon</string>
 
     <string name="stub_application">Nom de l\'aplicació</string>
@@ -51,9 +44,7 @@
     <string name="main_clear">Neteja el text</string>
     <string name="main_kiss">Mostra els preferits i la llista d\'aplicacions</string>
     <string name="main_kiss_back">Mostra l\'historial</string>
-    <string name="reset_desc">Reinicia l\'historial de KISS</string>
     <string name="reset_name">Reinicia l\'historial</string>
-    <string name="keyboard_desc">Mostra sempre el teclat a l\'inici</string>
     <string name="keyboard_name">Mostra el teclat</string>
 
     <string name="alias_phone">marcar,escriure,telèfon</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -11,25 +11,19 @@
     <string name="title_history">Nastavení historie</string>
     <string name="title_providers">Výběr poskytovatelů</string>
     <string name="menu_settings">Nastavení zařízení</string>
-    <string name="menu_preferences">Nastavení KISS</string>
     <string name="ui_empty_1_sub">Aplikace, kontakty, nastavení</string>
     <string name="ui_empty_2">Vždy zobrazovat historii.</string>
     <string name="ui_empty_2_sub">Pro rychlý přístup</string>
     <string name="ui_empty_3">Rychlý přístup k nejvíce používaným aplikacím</string>
     <string name="app_name">KISS launcher</string>
-    <string name="toggles_desc">Povolí přepínače (wifi, bluetooth)</string>
     <string name="toggles_name">Přepínače</string>
 
     <string name="aliases_name">Přezdívky</string>
 
-    <string name="aliases_desc">Povolí přezdívky (zjednošující zkratky)</string>
-    <string name="contacts_desc">Vyhledávat v kontaktech</string>
     <string name="contacts_name">Kontakty</string>
 
-    <string name="search_desc">Povolit vyhledávání na webu Google</string>
     <string name="search_name">Vyhledávání Google</string>
 
-    <string name="settings_desc">Vyhledat v nastaveních</string>
     <string name="settings_name">Nastavení</string>
 
     <string name="phone_name">Telefon</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -12,7 +12,6 @@
     <string name="title_history">Verlauf</string>
     <string name="title_providers">Anbieterauswahl</string>
     <string name="menu_settings">Geräteeinstellungen</string>
-    <string name="menu_preferences">KISS-Einstellungen</string>
     <string name="no_favorites">Keine Favoriten vorhanden. Einträge durch langes Drücken hinzufügen.</string>
 
     <string name="ui_empty_1">Suche nach allem starten</string>
@@ -22,22 +21,16 @@
     <string name="ui_empty_3">Schneller Zugriff auf die meistgenutzten Anwendungen</string>
     <string name="ui_empty_3_sub">KISS Launcher lernt von Ihren Gewohnheiten</string>
 
-    <string name="toggles_desc">Umschalter verwenden (WLAN, Bluetooth)</string>
     <string name="toggles_name">Umschalter</string>
 
-    <string name="aliases_desc">Aliase/Kürzel verwenden</string>
     <string name="aliases_name">Aliase</string>
 
-    <string name="contacts_desc">In Kontakten suchen</string>
     <string name="contacts_name">Kontakte</string>
 
-    <string name="search_desc">Google Web-Suche verwenden</string>
     <string name="search_name">Google Suche</string>
 
-    <string name="settings_desc">In den Geräteeinstellungen suchen</string>
     <string name="settings_name">Einstellungen</string>
 
-    <string name="phone_desc">Anrufen von Telefonnummern ermöglichen</string>
     <string name="phone_name">Telefon</string>
 
     <string name="stub_application">Anwendungsname</string>
@@ -50,9 +43,7 @@
     <string name="main_clear">Suchfeld leeren</string>
     <string name="main_kiss">Favoriten und Anwendungsliste anzeigen</string>
     <string name="main_kiss_back">Verlauf anzeigen</string>
-    <string name="reset_desc">Den KISS Verlauf leeren</string>
     <string name="reset_name">Verlauf leeren</string>
-    <string name="keyboard_desc">Tastatur beim Start immer anzeigen</string>
     <string name="keyboard_name">Tastatur anzeigen</string>
 
     <string name="alias_phone">anrufen,wählen,telefon</string>
@@ -83,7 +74,6 @@
     <string name="menu_app_uninstall">Deinstallieren</string>
 
     <string name="theme_name">Thema</string>
-    <string name="theme_desc">KISS Thema ändern</string>
 
     <string name="title_advanced">Erweiterte Einstellungen</string>
     <string name="root_mode_desc">Wenn möglich: Root-Funktionen einschalten (um Apps schlafen zu legen)</string>
@@ -97,19 +87,15 @@
     <string name="menu_app_hibernate">Schlafenlegen</string>
 
     <string name="spellcheck_name">Rechtschreibprüfung aktivieren</string>
-    <string name="spellcheck_desc">Beim Schreiben Vorschläge anzeigen</string>
 
     <string name="portrait_title">Hochformat erzwingen</string>
-    <string name="portrait_summary">Bildschirm immer in das Hochformat drehen, wenn der Launcher angezeigt wird</string>
 
     <string name="toggle_sync">Synchronisation</string>
 
 <string name="menu_phone_create">Kontakt erstellen</string>
 
     <string name="order_apps_name">Reihenfolge der Anwendungsliste</string>
-    <string name="order_apps_desc">A bis Z oder Z bis A</string>
 
-<string name="shortcuts_desc">In, zum Startbildschirm hinzugefügten, Verknüpfungen suchen</string>
     <string name="shortcuts_name">Verknüpfungen</string>    
 
     <string name="reset_warn">Wollen Sie wirklich Ihren gesamten Verlauf leeren?</string>    
@@ -119,24 +105,19 @@
     <string name="icons_hide_main">Anwendungssymbole ausblenden</string>
     <string name="icons_hide_desc">Empfohlen für langsame Geräte</string>
     <string name="toggle_autorotate">Automatisch Drehen</string>
-    <string name="reset_excluded_apps_desc">Liste der von KISS ausgeblendeten Apps leeren</string>
     <string name="reset_excluded_apps_name">Liste der ausgeblendeten Apps leeren</string>
     <string name="reset_excluded_apps_warn">Sind Sie sicher, dass Sie die Liste der ausgeblendeten Apps leeren möchten?</string>
     <string name="excluded_app_list_erased">Liste der ausgeblendeten Apps geleert.</string>
     <string name="excluded_app_list_added">App ausgeblendet. Kann in den Einstellungen wiederhergestellt werden</string>
 
     <string name="menu_exclude">App ausblenden</string>
-    <string name="enable_sms_desc">Absender von eingehenden Nachrichten zum Verlauf hinzufügen</string>
     <string name="enable_sms">Verlauf durch Textnachrichten befüllen</string>
-    <string name="enable_phone_desc">Anrufer von eingehenden Anrufen zum Verlauf hinzufügen</string>
     <string name="enable_phone">Verlauf durch Anrufe befüllen</string>
-    <string name="enable_app_desc">Neuinstallierte Apps zum Verlauf hinzufügen</string>
     <string name="enable_app">Verlauf mit neuinstallierten Apps befüllen</string>
 
 <string name="toggles_on">%s eingeschaltet</string>
     <string name="toggles_off">%s ausgeschaltet</string>
 
-    <string name="reset_favorites_desc">Alle Einträge aus der Favoritenleiste entfernen</string>
     <string name="reset_favorites_name">Favoriten zurücksetzen</string>
     <string name="reset_favorites_warn">Wollen Sie wirklich alle Einträge aus der Favoritenleiste entfernen?</string>
     <string name="favorites_erased">Favoriten entfernt.</string>
@@ -145,7 +126,6 @@
 
     <string name="shortcut_added">Verknüpfung zu KISS hinzugefügt.</string>
 
-<string name="history_onclick_desc">Verlauf anzeigen, wenn Bildschirm berührt wird</string>
     <string name="settings_nfc">NFC</string>
     <string name="settings_tethering">Tethering</string>
     </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -12,23 +12,19 @@
     <string name="title_history">Ιστορικό</string>
     <string name="title_providers">Επιλογή Πηγών</string>
     <string name="menu_settings">Ρυθμίσεις Συσκευής</string>
-    <string name="menu_preferences">Ρυθμίσεις KISS</string>
     <string name="no_favorites">Προσωρινή έλλειψη αγαπημένων. Θα εμφανιστούν με την περαιτέρω χρήση της εφαρμογής.</string>
 
     <string name="ui_empty_1_sub">Εφαρμογές, επαφές, ρυθμίσεις, ...</string>
     <string name="ui_empty_2_sub">Για γρήγορη πρόσβαση</string>
-    <string name="contacts_desc">Αναζήτηση στις επαφές</string>
     <string name="contacts_name">Επαφές</string>
 
     <string name="ui_empty_3">Γρήγορη πρόσβαση στις αγαπημένες σου εφαρμογές</string>
     <string name="ui_empty_3_sub">το KISS μαθαίνει απο τις συνήθειες σου</string>
 
-    <string name="search_desc">Ενεργοποίηση αναζήτησης στο Google</string>
     <string name="search_name">Αναζήτηση στο Google</string>
 
     <string name="settings_name">Ρυθμίσεις</string>
 
-    <string name="phone_desc">Απευθείας κλήσεις</string>
     <string name="phone_name">Τηλέφωνο</string>
 
     <string name="stub_application">Ονομασία εφαρμογής</string>
@@ -40,8 +36,6 @@
     <string name="main_clear">Καθαρισμός</string>
     <string name="main_kiss">Εμφάνιση αγαπημένων και λίστας εφαρμογών</string>
     <string name="main_kiss_back">Εμφάνιση ιστορικού</string>
-    <string name="reset_desc">Διαγραφή ιστορικού χρήσης KISS</string>
-    <string name="keyboard_desc">Μόνιμη εμφάνιση πληκτρολογίου</string>
     <string name="keyboard_name">Εμφάνιση πληκτρολογίου</string>
 
     <string name="alias_web">διαδίκτυο, ιστός, περιηγητής</string>
@@ -57,15 +51,12 @@
 
     <string name="toast_hibernate_completed">%s αδρανοποιήθηκε επιτυχώς, relaunch to awake.</string>
     <string name="theme_name"/>
-    <string name="theme_desc">Ενημέρωση KISS θέματος</string>
 
     <string name="toggles_name">Διακόπτες</string>
 
-    <string name="settings_desc">Αναζήτηση στις Ρυθμίσεις συσκευής</string>
     <string name="reset_name">Διαγραφή ιστορικού</string>
     <string name="title_advanced">Ρυθμίσεις για προχωρημένους</string>
     <string name="ui_empty_1">Αναζήτησε κάτι</string>
-    <string name="toggles_desc">Ενεργοποίησε διακόπτες (Wi-Fi, Bluetooth,...)</string>
     <string name="root_mode_name">Λειτουργία υπερχρήστη</string>
     <string name="alias_contacts">επαφές,άνθρωποι,σχέσεις</string>
     <string name="alias_mail">μαιλ,εμαιλ</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,7 +14,6 @@
     <string name="title_providers">Seleccionar proveedores</string>
     <string name="title_advanced">Ajustes avanzados</string>
     <string name="menu_settings">Ajustes del dispositivo</string>
-    <string name="menu_preferences">Ajustes de KISS</string>
     <string name="no_favorites">Sin Favoritos. Arranque una aplicación y se añadirá a Favoritos.</string>
 
     <string name="ui_empty_1">Empiece a buscar cualquier cosa</string>
@@ -23,27 +22,20 @@
     <string name="ui_empty_3">Acceso directo a las aplicaciones más usadas</string>
     <string name="ui_empty_3_sub">KISS launcher aprende de sus hábitos</string>
 
-    <string name="toggles_desc">Permitir cambios de estado (Wi-Fi, Bluetooth)</string>
     <string name="toggles_name">Cambiar estado</string>
     <string name="toggles_on">%s activados</string>
     <string name="toggles_off">%s desactivados</string>
 
-    <string name="aliases_desc">Permitir alias (bueno para enlaces directos)</string>
     <string name="aliases_name">Alias</string>
 
-    <string name="contacts_desc">Buscar en contactos</string>
     <string name="contacts_name">Contactos</string>
 
-    <string name="search_desc">Permitir buscar en Google Web Search</string>
     <string name="search_name">Buscar en Google</string>
 
-    <string name="settings_desc">Buscar en los ajustes del dispositivo</string>
     <string name="settings_name">Ajustes</string>
 
-    <string name="phone_desc">Marcador de números de teléfono</string>
     <string name="phone_name">Teléfono</string>
     
-    <string name="shortcuts_desc">Buscar en los atajos instalados</string>
     <string name="shortcuts_name">Atajos</string>
     
     <string name="stub_application">Nombre de la Aplicación</string>
@@ -56,24 +48,18 @@
     <string name="main_clear">Borrar texto</string>
     <string name="main_kiss">Mostrar favoritos y lista de aplicaciones</string>
     <string name="main_kiss_back">Mostrar historial</string>
-    <string name="reset_desc">Resetear el historial de KISS</string>
     <string name="reset_name">Resetear el historial</string>
-    <string name="reset_excluded_apps_desc">Resetear la lista de aplicaciones excluidas de KISS</string>
     <string name="reset_excluded_apps_name">Resetear la lista de aplicaciones</string>
     <string name="reset_excluded_apps_warn">¿Seguro que quieres resetear tu lista de aplicaciones excluidas?</string>
     <string name="reset_warn">¿Seguro que quieres resetear tu historial?</string>
-    <string name="reset_favorites_desc">Resetear la lista de favoritos</string>
     <string name="reset_favorites_name">Resetear favoritos</string>
     <string name="reset_favorites_warn">¿Seguro que quieres resetear tus favoritos?</string>
-    <string name="keyboard_desc">Mostrar siempre el teclado al inicio</string>
     <string name="keyboard_name">Mostrar teclado</string>
     <string name="spellcheck_name">Activar corrector</string>
-    <string name="spellcheck_desc">Mostrar sugerencias cuando escribas</string>
     <string name="history_hide_desc">Ocultar historial y la pantalla de inicio</string>
     <string name="history_hide_name">Interfaz minimalista</string>
     <string name="history_onclick_name">Interfaz minimalista: Mostrar historial al tocar</string>
     <string name="portrait_title">Forzar modo vertical</string>
-    <string name="portrait_summary">Siempre rotar la pantalla al modo vertical cuando se muestre el lanzador</string>
     <string name="icons_hide_main">Ocultar iconos de las aplicaciones</string>
     <string name="icons_hide_desc">Activar en dispositivos lentos</string>
     <string name="root_mode_desc">Activar características de súper-usuario si están disponibles (para hibernar aplicaciones)</string>
@@ -120,18 +106,13 @@
     <string name="toast_hibernate_error">%s no ha podido ser hibernado.</string>
     <string name="menu_contact_copy_phone">Copiar número de teléfono</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Actualizar tema de KISS</string>
     <string name="menu_phone_create">Crear contacto</string>
 
     <string name="toast_favorites_added">%s ha sido añadido a favoritos</string>
 
     <string name="order_apps_name">Orden de la lista de aplicacions</string>
-    <string name="order_apps_desc">De A a Z o de Z a A</string>
-    <string name="enable_sms_desc">Añadir mensajes entrantes al historial</string>
     <string name="enable_sms">Incluir datos de los mensajes de texto en el historial</string>
-    <string name="enable_phone_desc">Añadir llamadas entrantes en el historial</string>
     <string name="enable_phone">Incluir datos de las llamadas en el historial</string>
-    <string name="enable_app_desc">Añadir nuevas aplicaciones al historial</string>
     <string name="enable_app">Incluir datos de aplicaciones instaladas en el historial</string>
 
     </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_history">Historique</string>
     <string name="title_providers">Source de données</string>
     <string name="menu_settings">Paramètres du périphérique</string>
-    <string name="menu_preferences">Paramètres de KISS</string>
     <string name="no_favorites">Aucun favori pour l\'instant ! Utilisez l\'application, puis réessayez.</string>
 
     <string name="ui_empty_1">Recherchez… partout</string>
@@ -23,22 +22,16 @@
     <string name="ui_empty_3">Accès rapide aux applis les plus utilisées</string>
     <string name="ui_empty_3_sub">KISS launcher apprend de vos habitudes</string>
 
-    <string name="toggles_desc">Activer les toggles (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">Toggles</string>
 
-    <string name="aliases_desc">Activez les alias (raccourcis de commodité)</string>
     <string name="aliases_name">Alias</string>
 
-    <string name="contacts_desc">Rechercher dans mes contacts</string>
     <string name="contacts_name">Contacts</string>
 
-    <string name="search_desc">Activer la recherche Google</string>
     <string name="search_name">Recherche Google</string>
 
-    <string name="settings_desc">Chercher dans les paramètres du périphérique</string>
     <string name="settings_name">Paramètres</string>
 
-    <string name="phone_desc">Appeler directement un numéro de téléphone</string>
     <string name="phone_name">Téléphone</string>
 
     <string name="stub_application">Nom de l\'application</string>
@@ -51,12 +44,9 @@
     <string name="main_clear">Vider le champ de recherche</string>
     <string name="main_kiss">Afficher les favoris et la liste d\'applications</string>
     <string name="main_kiss_back">Afficher l\'historique</string>
-    <string name="reset_desc">Vider tout l\'historique KISS</string>
     <string name="reset_name">Vider l\'historique</string>
-    <string name="keyboard_desc">Toujours afficher le clavier au lancement</string>
     <string name="keyboard_name">Afficher le clavier</string>
     <string name="spellcheck_name">Activer la vérification orthographique</string>
-    <string name="spellcheck_desc">Proposer des corrections pendant une recherche</string>
 
     <string name="alias_phone">téléphone,numéroteur,composeur,appeler</string>
     <string name="alias_contacts">contacts,personnes,relations</string>
@@ -87,7 +77,6 @@
     <string name="menu_contact_copy_phone">Copier le numéro de téléphone</string>
 
     <string name="theme_name">Thème</string>
-    <string name="theme_desc">Modifier le thème</string>
 
     <string name="title_advanced">Paramètres avancés</string>
     <string name="root_mode_desc">Activer les fonctionnalités superutilisateur (pour hiberner des applications)</string>
@@ -100,32 +89,24 @@
     <string name="toast_hibernate_completed">%s a été hibernée avec succès, relancez-la pour la réveiller.</string>
     <string name="toast_hibernate_error">%s n\'a pas pu être hibernée.</string>
     <string name="menu_phone_create">Créer un contact</string>
-    <string name="order_apps_desc">A à Z ou Z à A</string>
     <string name="order_apps_name">Ordre de la liste d\'applications</string>
-    <string name="portrait_summary">Empêcher la rotation de l\'écran en mode paysage</string>
     <string name="portrait_title">Forcer le mode portrait</string>
     <string name="toggle_sync">Synchronisation</string>
     <string name="history_hide_name">Interface minimaliste</string>
     <string name="history_hide_desc">Cacher l\'historique et l\'écran d\'introduction</string>
     <string name="toggle_autorotate">Rotation de l\'écran</string>
     <string name="shortcuts_name">Raccourcis</string>
-    <string name="shortcuts_desc">Rechercher dans les raccourcis</string>
     <string name="reset_warn">Voulez-vous vraiment supprimer votre historique ?</string>
     <string name="icons_hide_main">Masquer les icones des applications</string>
     <string name="icons_hide_desc">Pour les petits périphériques </string>
     <string name="history_onclick_name">Afficher l\'historique au touch</string>
-    <string name="history_onclick_desc">Cliquer n\'importe où pour afficher l\'historique</string>
-    <string name="enable_app_desc">Remplir l\'historique lors d\'une installation d\'application</string>
     <string name="enable_app">Ajouter les nouvelles apps</string>
     <string name="enable_phone">Ajouter les appels entrants</string>
-    <string name="enable_phone_desc">Remplir l\'historique lors d\'un appel entrant</string>
     <string name="enable_sms">Ajouter les expéditeurs de SMS entrants</string>
-    <string name="enable_sms_desc">Remplir l\'historique à la réception d\'un SMS</string>
     <string name="toggles_on">%s activé</string>
     <string name="toggles_off">%s désactivé</string>
 
     <string name="reset_excluded_apps_name">Réinitialiser la liste des applications masquées</string>
-    <string name="reset_favorites_desc">Réinitialiser votre liste de favoris</string>
     <string name="reset_favorites_warn">Voulez-vous vraiment réinitialiser vos favoris ?</string>
     <string name="favorites_erased">Favoris effacés.</string>
     <string name="menu_favorites_add">Ajouter aux favoris</string>
@@ -139,7 +120,6 @@
     <string name="settings_nfc">NFC</string>
     <string name="settings_tethering">Hotspot</string>
     <string name="icons_pack_default_name">Icones par défaut</string>
-    <string name="icons_pack_desc">Choisir un thème (ADW.Launcher)</string>
     <string name="icons_pack_name">Thème des icones</string>
 
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -12,7 +12,6 @@
     <string name="title_providers">Selecciona proveedor</string>
     <string name="title_advanced">Axustes avanzados</string>
     <string name="menu_settings">Axustes do dispositivo</string>
-    <string name="menu_preferences">Axustes de KISS</string>
     <string name="no_favorites">Non hai favoritos. Use os seus aplicativos favoritos para que se mostren.</string>
 
     <string name="ui_empty_1">Comeza a buscar cousas</string>
@@ -22,22 +21,16 @@
     <string name="ui_empty_3">Acceso directo ós aplicativos máis utilizados</string>
     <string name="ui_empty_3_sub">KISS launcher aprende dos teus hábitos</string>
 
-    <string name="toggles_desc">Permitir cambios de estado (Wi-Fi, Bluetooth, ...)</string>
     <string name="toggles_name">Cambiar estado</string>
 
-    <string name="aliases_desc">Permitir pseudónimos (ligazóns directas)</string>
     <string name="aliases_name">Pseudónimos</string>
 
-    <string name="contacts_desc">Buscar en contactos</string>
     <string name="contacts_name">Contactos</string>
 
-    <string name="search_desc">Activar a búsqueda de Google</string>
     <string name="search_name">Búsqueda de Google</string>
 
-    <string name="settings_desc">Buscar nos axustes do dispositivo</string>
     <string name="settings_name">Axustes</string>
 
-    <string name="phone_desc">Marcador de números telefónicos</string>
     <string name="phone_name">Teléfono</string>
 
     <string name="stub_application">Nome do aplicativo</string>
@@ -50,16 +43,12 @@
     <string name="main_clear">Limpa o campo de búsqueda</string>
     <string name="main_kiss">Amosa os favoritos e o listado de aplicativos</string>
     <string name="main_kiss_back">Amosa o historial</string>
-    <string name="reset_desc">Restablece o teu historial de KISS</string>
     <string name="reset_name">Restablece o historial</string>
-    <string name="keyboard_desc">Amosar sempre o teclado no inicio</string>
     <string name="keyboard_name">Amosar teclado</string>
     <string name="spellcheck_name">Activar corrector</string>
-    <string name="spellcheck_desc">Amosar suxerencias cando se escribe</string>
     <string name="history_hide_desc">Ocultar historial e pantalla de inicio</string>
     <string name="history_hide_name">Interface minimalista</string>
     <string name="portrait_title">Forcar modo vertical</string>
-    <string name="portrait_summary">Rotar sempre ó modo vertical cando se amosa o lanzador</string>
     <string name="root_mode_desc">Activar características de root se están dispoñibles (para hibernar aplicativos)</string>
     <string name="root_mode_name">Modo root</string>
     <string name="root_mode_error">Non foi posíbel obter privilexios de Root.</string>
@@ -98,13 +87,10 @@
     <string name="toast_hibernate_error">%s non se hibernou correctamente.</string>
     <string name="menu_contact_copy_phone">Copiar número telefónico</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Actualizar tema KISS</string>
     <string name="menu_phone_create">Crear contacto</string>
 
     <string name="order_apps_name">Orden da listaxe</string>
-    <string name="order_apps_desc">A a Z ou Z a A</string>
 
-<string name="shortcuts_desc">Buscar en atallos instalados</string>
     <string name="shortcuts_name">Atallos</string>    
 
     <string name="reset_warn">Realmente desexas reiniciar o teu historial?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -14,7 +14,6 @@
     <string name="title_providers">Odaberi poslužitelja</string>
     <string name="title_advanced">Napredne postavke</string>
     <string name="menu_settings">Postavke uređaja</string>
-    <string name="menu_preferences">KISS postavke</string>
     <string name="no_favorites">Favoriti još ne postoje. Koristite aplikaciju da se pojave.</string>
 
     <string name="ui_empty_1">Samo počmite tipkati, KISS automatski pretražuje</string>
@@ -24,22 +23,16 @@
     <string name="ui_empty_3">Brzi pristup do najkorištenijih aplikacija</string>
     <string name="ui_empty_3_sub">KISS uči iz vaših navika</string>
 
-    <string name="toggles_desc">Prekidači (Wi-Fi, Bluetooth, &#8230;)</string>
     <string name="toggles_name">Uključi/isključi</string>
 
-    <string name="aliases_desc">Omogući alijase (prečaci)</string>
     <string name="aliases_name">Alijasi</string>
 
-    <string name="contacts_desc">Pretraži moje kontakte</string>
     <string name="contacts_name">Kontakti</string>
 
-    <string name="search_desc">Uključi Google pretraživanje</string>
     <string name="search_name">Google pretraživanje</string>
 
-    <string name="settings_desc">Traži u postavkama uređaja</string>
     <string name="settings_name">Postavke</string>
 
-    <string name="phone_desc">Biraj telefonski broj</string>
     <string name="phone_name">Telefon</string>
 
     <string name="stub_application">Ime aplikacije</string>
@@ -52,12 +45,9 @@
     <string name="main_clear">Očisti tekst</string>
     <string name="main_kiss">Pokaži favorite i listu aplikacija</string>
     <string name="main_kiss_back">Pokaži povjest</string>
-    <string name="reset_desc">Resetiraj KISS povjest</string>
     <string name="reset_name">Resetiraj povjest</string>
-    <string name="keyboard_desc">Uvijek prikaži tipkovnicu pri pokretanju</string>
     <string name="keyboard_name">Pokaži tipkovnicu</string>
     <string name="spellcheck_name">Omogući provjeru pravopisa</string>
-    <string name="spellcheck_desc">Predloži sugestije dok tipkam</string>
     <string name="root_mode_desc">Omogući root značajke ako su moguće (hiberniranje aplikacija)</string>
     <string name="root_mode_name">Root način rada</string>
     <string name="root_mode_error">Nemoguće dobiti root privilegije.</string>
@@ -95,6 +85,5 @@
     <string name="toast_hibernate_error">%s nije uspješno poslana na hibernaciju.</string>
     <string name="menu_contact_copy_phone">Kopiraj telefonski broj</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Postavi KISS temu</string>
 
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -12,7 +12,6 @@
     <string name="title_history">Előzmények</string>
     <string name="title_providers">Források beállításai</string>
     <string name="menu_settings">Eszköz beállítások</string>
-    <string name="menu_preferences">KISS beállítások</string>
     <string name="no_favorites">Nincsenek kedvencek. Az indító használatával idővel megjelennek a kedvencek.</string>
 
     <string name="ui_empty_1">Keress rá bármire</string>
@@ -22,19 +21,14 @@
     <string name="ui_empty_3">Gyors hozzáférés a gyakran használt app-okhoz</string>
     <string name="ui_empty_3_sub">A KISS indító tanul a szokásaidból</string>
 
-    <string name="toggles_desc">Kapcsolók engedélyezése (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">Kapcsolók</string>
 
-    <string name="contacts_desc">Keresés a névjegyek között</string>
     <string name="contacts_name">Névjegyek</string>
 
-    <string name="search_desc">Google webes keresés engedélyezése</string>
     <string name="search_name">Google keresés</string>
 
-    <string name="settings_desc">Keresés az eszköz beállítások között</string>
     <string name="settings_name">Beállítások</string>
 
-    <string name="phone_desc">Közvetlen tárcsázás telefonszám esetén</string>
     <string name="phone_name">Telefon</string>
 
     <string name="stub_application">App neve</string>
@@ -47,9 +41,7 @@
     <string name="main_clear">Szöveg törlése</string>
     <string name="main_kiss">Kedvencek és app lista megjelenítése</string>
     <string name="main_kiss_back">Előzmények megjelenítése</string>
-    <string name="reset_desc">KISS előzmények törlése</string>
     <string name="reset_name">Előzmények törlése</string>
-    <string name="keyboard_desc">Billentyűzet mutatása induláskor</string>
     <string name="keyboard_name">Billentyűzet mutatása</string>
 
     <string name="alias_phone">tárcsázás,hívás,telefon</string>
@@ -79,14 +71,11 @@
     <string name="menu_app_details">App adatai</string>
     <string name="menu_app_uninstall">Eltávolítás</string>
     <string name="theme_name">Téma</string>
-    <string name="theme_desc">KISS téma megváltoztatása</string>
 
-    <string name="aliases_desc">Álnevek engedélyezése (kényelmes alternatív elnevezések)</string>
     <string name="aliases_name">Álnevek</string>
 
     <string name="title_advanced">Haladó beállítások</string>
     <string name="spellcheck_name">Helyesírás-ellenőrző engedélyezése</string>
-    <string name="spellcheck_desc">Javaslatok mutatása írás közben</string>
     <string name="root_mode_desc">Root funkciók engedélyezése, ha elérhető (app-ok hibernálásához)</string>
     <string name="root_mode_name">Root mód</string>
     <string name="root_mode_error">Nem sikerült root jogot szerezni.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -14,7 +14,6 @@
     <string name="title_providers">Seleziona Provider</string>
     <string name="title_advanced">Impostazioni Avanzate</string>
     <string name="menu_settings">Impostazioni Dispositivo</string>
-    <string name="menu_preferences">Impostazioni KISS</string>
     <string name="no_favorites">Ancora nessun preferito. Aggiungile premendo a lungo.</string>
 
     <string name="ui_empty_1">Inizia cercando qualcosa</string>
@@ -24,25 +23,18 @@
     <string name="ui_empty_3">Accesso rapido per le applicazioni più usate</string>
     <string name="ui_empty_3_sub">KISS launcher impara dalle tue abitudini</string>
 
-    <string name="toggles_desc">Abilita tasti (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">Tasti</string>
 
-    <string name="aliases_desc">Attiva alias (collegamenti convenienti)</string>
     <string name="aliases_name">Alias</string>
 
-    <string name="contacts_desc">Cerca nei miei contatti</string>
     <string name="contacts_name">Contatti</string>
 
-    <string name="search_desc">Abilita ricerca web Google</string>
     <string name="search_name">Ricerca Google</string>
 
-    <string name="settings_desc">Cerca nelle impostazioni del dispositivo</string>
     <string name="settings_name">Impostazioni</string>
 
-    <string name="phone_desc">Chiamata diretta per i numeri di telefono</string>
     <string name="phone_name">Telefono</string>
 
-    <string name="shortcuts_desc">Ricerca nei collegamenti installati</string>
     <string name="shortcuts_name">Collegamenti</string>    
 
     <string name="stub_application">Nome dell\'applicazione</string>
@@ -55,10 +47,8 @@
     <string name="main_clear">Cancella i dati di ricerca</string>
     <string name="main_kiss">Mostra preferiti e lista applicazioni</string>
     <string name="main_kiss_back">Mostra storia</string>
-    <string name="reset_desc">Cancella la storia di KISS</string>
     <string name="reset_name">Cancella storia</string>
     <string name="reset_warn">Sei sicuro di voler cancellare la storia?</string>
-    <string name="keyboard_desc">Mostra sempre la tastiera all\'avvio</string>
     <string name="keyboard_name">Mostra tastiera</string>
     <string name="root_mode_desc">Abilità funzionalità superutente se disponibili (per ibernare le applicazioni)</string>
     <string name="root_mode_name">Modalità superutente</string>
@@ -100,11 +90,9 @@
     <string name="toast_hibernate_error">%s non ibernata correttamente.</string>
     <string name="menu_contact_copy_phone">Copia numero di telefono</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Aggiorna il tema di KISS</string>
     <string name="menu_phone_create">Crea contatto</string>
 
     <string name="spellcheck_name">Abilita correttore ortografico</string>
-    <string name="spellcheck_desc">Propone suggerimenti durante la digitazione</string>
     <string name="history_hide_desc">Nasconde la storia e la schermata introduttiva</string>
     <string name="history_hide_name">Interfaccia minimale</string>
     <string name="history_onclick_name">Interfaccia minimale: Mostra la cronologia al tocco</string>
@@ -112,24 +100,19 @@
     <string name="icons_hide_desc">Attivala per dispositivi lenti</string>
     <string name="root_mode_error">Impossibile ottenere privilegi da superutente.</string>
 
-    <string name="icons_pack_desc">Scegli un tema per le icone (compatibile con ADW.Launcher)</string>
     <string name="icons_pack_name">Temi icone</string>    
     <string name="icons_pack_default_name">Icone di sistema</string>
 
     <string name="order_apps_name">Ordinamento applicazioni</string>
-    <string name="order_apps_desc">A alla Z oppure Z alla A</string>
 
     <string name="toggles_on">%s attivato</string>
     <string name="toggles_off">%s disattivato</string>
 
-    <string name="reset_excluded_apps_desc">Resetta la lista delle applicazioni escluse da KISS</string>
     <string name="reset_excluded_apps_name">Resetta la lista delle applicazioni escluse</string>
     <string name="reset_excluded_apps_warn">Vuoi davvero resettare la tua lista di applicazioni escluse?</string>
-    <string name="reset_favorites_desc">Resetta la lista dei preferiti</string>
     <string name="reset_favorites_name">Resetta preferiti</string>
     <string name="reset_favorites_warn">Vuoi davvero resettare i tuoi preferiti?</string>
     <string name="portrait_title">Forza la modalità verticale</string>
-    <string name="portrait_summary">Ruota sempre lo schermo in verticale quando mostra il launcher</string>
     <string name="favorites_erased">Preferiti cancellati.</string>
     <string name="menu_favorites_add">Aggiungi ai preferiti</string>
     <string name="excluded_app_list_erased">Lista delle applicazioni escluse cancellata.</string>
@@ -138,11 +121,8 @@
     <string name="menu_exclude">Escludi applicazione da KISS</string>
     <string name="toast_favorites_added">%s è stato aggiunto ai preferiti</string>
 
-    <string name="enable_sms_desc">Aggiungi i messaggi in entrata del mittente alla cronologia</string>
     <string name="enable_sms">Riempi la cronologia di messaggi di testo</string>
-    <string name="enable_phone_desc">Aggiungi chiamate in entrata nella cronologia</string>
     <string name="enable_phone">Riempi la cronologia di chiamate</string>
-    <string name="enable_app_desc">Aggiungi nuove applicazioni alla cronologia</string>
     <string name="enable_app">Riempi la cronologia da installazione di applicazioni</string>
     <string name="shortcut_added">Aggiunto collegamento</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_providers">プロバイダーの選択</string>
     <string name="title_advanced">高度な設定</string>
     <string name="menu_settings">デバイスの設定</string>
-    <string name="menu_preferences">KISS 設定</string>
     <string name="no_favorites">まだお気に入りはありません。長押しすると追加します。</string>
 
     <string name="ui_empty_1">何でも検索しましょう</string>
@@ -23,22 +22,16 @@
     <string name="ui_empty_3">最も使用するアプリに素早くアクセス</string>
     <string name="ui_empty_3_sub">KISS ランチャーはあなたの習慣から学習します</string>
 
-    <string name="toggles_desc">切り替えを有効にします (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">切り替え</string>
 
-    <string name="aliases_desc">エイリアスを有効にします (便利なショートカット)</string>
     <string name="aliases_name">エイリアス</string>
 
-    <string name="contacts_desc">私の連絡先を検索します</string>
     <string name="contacts_name">連絡先</string>
 
-    <string name="search_desc">Google Web 検索を有効にします</string>
     <string name="search_name">Google 検索</string>
 
-    <string name="settings_desc">私のデバイス設定で検索します</string>
     <string name="settings_name">設定</string>
 
-    <string name="phone_desc">電話番号を直接ダイヤルします</string>
     <string name="phone_name">電話</string>
 
     <string name="stub_application">アプリケーション名</string>
@@ -51,9 +44,7 @@
     <string name="main_clear">検索フィールドをクリア</string>
     <string name="main_kiss">お気に入りとアプリ一覧を表示</string>
     <string name="main_kiss_back">履歴を表示</string>
-    <string name="reset_desc">KISS の履歴をリセットします</string>
     <string name="reset_name">履歴をリセット</string>
-    <string name="keyboard_desc">起動時に常にキーボードを表示します</string>
     <string name="keyboard_name">キーボードを表示</string>
     <string name="root_mode_desc">利用可能な場合、root 機能を有効にします (アプリケーション休止状態)</string>
     <string name="root_mode_name">Root モード</string>
@@ -92,36 +83,27 @@
     <string name="toast_hibernate_error">%s は休止状態になりませんでした。</string>
     <string name="menu_contact_copy_phone">電話番号をコピー</string>
     <string name="theme_name">テーマ</string>
-    <string name="theme_desc">KISS のテーマを更新します</string>
 
     <string name="spellcheck_name">スペルチェックを有効にする</string>
-    <string name="spellcheck_desc">入力時に提案を提供します</string>
     <string name="toggle_sync">同期</string>
 <string name="portrait_title">強制的に縦向き</string>
-    <string name="portrait_summary">ランチャーを表示するとき、常に縦に画面を回転します</string>
     <string name="menu_phone_create">連絡先を作成</string>
 
     <string name="order_apps_name">アプリ一覧の順序</string>
-    <string name="order_apps_desc">A から Z または Z から A</string>
 
 <string name="history_hide_desc">履歴と導入画面を非表示にします</string>
     <string name="history_hide_name">最小限の UI</string>
     <string name="history_onclick_name">最小限の UI: タッチして履歴を表示</string>
     <string name="icons_hide_main">アプリケーションのアイコンを非表示</string>
     <string name="icons_hide_desc">遅いデバイスで有効にします</string>
-    <string name="shortcuts_desc">インストールされたショートカットを検索します</string>
     <string name="shortcuts_name">ショートカット</string>    
 
     <string name="reset_warn">履歴をリセットしてもよろしいですか?</string>    
     <string name="toggle_autorotate">自動回転</string>
-    <string name="enable_sms_desc">送信者の受信メッセージを履歴に追加します</string>
     <string name="enable_sms">テキストメッセージからの履歴を表示</string>
-    <string name="enable_phone_desc">着信履歴を追加します</string>
     <string name="enable_phone">電話からの履歴を表示します</string>
-    <string name="enable_app_desc">履歴に新しいアプリを追加します</string>
     <string name="enable_app">アプリのインストール履歴を表示します</string>
 
-<string name="reset_excluded_apps_desc">KISS アプリから除外の一覧をリセットします</string>
     <string name="reset_excluded_apps_name">除外アプリの一覧をリセット</string>
     <string name="reset_excluded_apps_warn">除外アプリ一覧をリセットしてもよろしいですか?</string>
     <string name="excluded_app_list_erased">除外アプリの一覧が消去されました。</string>
@@ -131,7 +113,6 @@
     <string name="toggles_on">%s アクティブにしました</string>
     <string name="toggles_off">%s 非アクティブにしました</string>
 
-    <string name="reset_favorites_desc">お気に入りの一覧をリセットします</string>
     <string name="reset_favorites_name">お気に入りをリセット</string>
     <string name="reset_favorites_warn">お気に入りをリセットしてもよろしいですか?</string>
     <string name="favorites_erased">お気に入りを消去しました。</string>
@@ -142,8 +123,6 @@
 
 <string name="settings_nfc">NFC</string>
     <string name="settings_tethering">テザリング</string>
-    <string name="history_onclick_desc">どこかをタッチすると、履歴を表示します</string>
-    <string name="icons_pack_desc">アイコン テーマの選択 (ADW ランチャー テーマ)</string>
     <string name="icons_pack_name">アイコン テーマ</string>    
     <string name="icons_pack_default_name">システム アイコン</string>
 

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -8,23 +8,17 @@
     <string name="menu_settings">Enhetsinnstillinger</string>
     <string name="ui_empty_1">Søk etter hva som helst</string>
     <string name="ui_empty_1_sub">Apper, kontakter, innstillinger, …</string>
-    <string name="menu_preferences">KISS-innstillinger</string>
     <string name="ui_empty_3">Rask tilgang til ofte brukte apper</string>
     <string name="ui_empty_3_sub">KISS Launcher lærer seg vanene dine</string>
 
-    <string name="toggles_desc">Aktiver hurtiginnstillinger (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">Hurtiginnstillinger</string>
 
-    <string name="aliases_desc">Aktiver aliaser (praktiske snarveier)</string>
     <string name="aliases_name">Aliaser</string>
 
-    <string name="contacts_desc">Søk i kontaktene dine</string>
     <string name="contacts_name">Kontakter</string>
 
-    <string name="search_desc">Aktiver Google Nettsøk</string>
     <string name="search_name">Google-søk</string>
 
-    <string name="settings_desc">Search i enhetsinnstillingene dine</string>
     <string name="settings_name">Innstillinger</string>
 
     <string name="phone_name">Telefon</string>
@@ -43,17 +37,13 @@
     <string name="main_menu">Meny</string>
     <string name="main_clear">Tøm søkefeltet</string>
     <string name="main_kiss_back">Vis logg</string>
-    <string name="reset_desc">Tøm KISS-loggen din</string>
     <string name="reset_name">Tøm logg</string>
-    <string name="keyboard_desc">Vis alltid tastaturet ved oppstart</string>
     <string name="keyboard_name">Vis tastatur</string>
     <string name="spellcheck_name">Aktiver stavekontroll</string>
-    <string name="spellcheck_desc">Gi forslag mens du skriver</string>
     <string name="history_hide_desc">Skjul logg og startskjerm</string>
     <string name="history_hide_name">Minimalistisk grensesnitt</string>
     <string name="history_onclick_name">Vis logg ved trykk</string>
     <string name="portrait_title">Tving stående modus</string>
-    <string name="portrait_summary">Roter alltid skjermen til stående modus når KISS Launcher vises</string>
     <string name="icons_hide_main">Skjul appikoner</string>
     <string name="icons_hide_desc">Forbedrer ytelsen på trege enheter</string>
     <string name="root_mode_desc">Aktiver root-funksjoner hvis tilgjengelige (for å sende apper i hvilemodus)</string>
@@ -86,13 +76,10 @@
     <string name="toast_hibernate_error">Klarte ikke sende % i hvilemodus.</string>
     <string name="menu_contact_copy_phone">Kopier telefonnummer</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Velg KISS-tema</string>
     <string name="menu_phone_create">Opprett kontakt</string>
 
     <string name="order_apps_name">Sortering for appliste</string>
-    <string name="order_apps_desc">A til Å eller Å til A</string>
 
-<string name="phone_desc">Ring telefonnummere direkte</string>
     <string name="alias_contacts">kontakter,folk,relasjoner</string>
     <string name="alias_web">internett,web,browser</string>
     <string name="alias_mail">email,e-post,epåst</string>
@@ -107,7 +94,6 @@
     <string name="stub_toggle">Innstilling å slå av eller på</string>
     <string name="stub_contact_phone">+330 12 34 56 78</string>
     <string name="stub_phone">Ring +330 12 34 56 78</string>
-    <string name="shortcuts_desc">Søk i installerte snarveier</string>
     <string name="shortcuts_name">Snarveier</string>    
 
     <string name="reset_warn">Vil du tømme loggen?</string>    

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_history">Geschiedenis</string>
     <string name="title_providers">Providerkeuze</string>
     <string name="menu_settings">Apparaat instellingen</string>
-    <string name="menu_preferences">KISS instellingen</string>
     <string name="no_favorites">Nog geen favorieten. Gebruik de app, en favorieten zullen verschijnen.</string>
 
     <string name="ui_empty_1">Begin met zoeken</string>
@@ -23,22 +22,16 @@
     <string name="ui_empty_3">Snelle toegang tot je meestgebruikte apps</string>
     <string name="ui_empty_3_sub">KISS launcher leert van jouw gebruik</string>
 
-    <string name="toggles_desc">Schakel schakelaars in (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">Schakelaars</string>
 
-    <string name="aliases_desc">Schakel aliases in (handige verkortingen)</string>
     <string name="aliases_name">Aliases</string>
 
-    <string name="contacts_desc">Zoek in mijn contacten</string>
     <string name="contacts_name">Contacten</string>
 
-    <string name="search_desc">Gebruik Google zoeken</string>
     <string name="search_name">Google zoeken</string>
 
-    <string name="settings_desc">Zoek in mijn apparaat instellingen</string>
     <string name="settings_name">Instellingen</string>
 
-    <string name="phone_desc">Telefoonnummers direct bellen</string>
     <string name="phone_name">Telefoon</string>
 
     <string name="stub_application">Programmanaam</string>
@@ -51,9 +44,7 @@
     <string name="main_clear">Wis tekst</string>
     <string name="main_kiss">Toon favorieten en app lijst</string>
     <string name="main_kiss_back">Toon geschiedenis</string>
-    <string name="reset_desc">Wis je KISS geschiedenis</string>
     <string name="reset_name">Wis geschiedenis</string>
-    <string name="keyboard_desc">Toon toetsenbord altijd bij opstarten</string>
     <string name="keyboard_name">Toetsenbord tonen</string>
 
     <string name="alias_phone">bel,schrijf,telefoon</string>
@@ -84,7 +75,6 @@
     <string name="menu_app_uninstall">Verwijder</string>
 
 <string name="theme_name">Thema</string>
-    <string name="theme_desc">Wijzig KISS thema</string>
 
 <string name="title_advanced">Geavanceerde instellingen</string>
     <string name="spellcheck_name">Schakel spellingscontrole in</string>
@@ -93,7 +83,6 @@
 
     <string name="toggle_sync">Synchronisatie</string>
     <string name="menu_contact_copy_phone">Kopieer telefoonnummer</string>
-    <string name="spellcheck_desc">Toon suggesties tijdens het typen</string>
     <string name="root_mode_desc">Schakel root functionaliteit in indien beschikbaar (om applicaties te pauzeren)</string>
     <string name="toggle_torch">Zaklamp</string>
     <string name="menu_app_hibernate">Pauzeer</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_providers">Wybór Dostawcy</string>
     <string name="title_advanced">Ustawienia Zaawansowane</string>
     <string name="menu_settings">Ustawienia Urządzenia</string>
-    <string name="menu_preferences">Ustawienia KISS</string>
     <string name="no_favorites">Brak ulubionych. Naciśnij i przytrzymaj aby je dodać.</string>
 
     <string name="ui_empty_1">Zacznij szukać czegokolwiek</string>
@@ -23,22 +22,16 @@
     <string name="ui_empty_3">Szybki dostęp do najczęściej używanych aplikacji</string>
     <string name="ui_empty_3_sub">Launcher KISS poznaje twoje zwyczaje</string>
 
-    <string name="toggles_desc">Wyszukuj w przełącznikach (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_name">Przełączniki</string>
 
-    <string name="aliases_desc">Wyszukuj w aliasach</string>
     <string name="aliases_name">Aliasy</string>
 
-    <string name="contacts_desc">Wyszukuj w kontaktach</string>
     <string name="contacts_name">Kontakty</string>
 
-    <string name="search_desc">Włącz wyszukiwanie w Google Web</string>
     <string name="search_name">Wyszukiwanie Google</string>
 
-    <string name="settings_desc">Wyszukuj w ustawieniach urządzenia</string>
     <string name="settings_name">Ustawienia</string>
 
-    <string name="phone_desc">Bezpośredni dialer do numerów telefonicznych</string>
     <string name="phone_name">Telefon</string>
 
     <string name="stub_application">Nazwa aplikacji</string>
@@ -51,12 +44,9 @@
     <string name="main_clear">Wyczyść pole wyszukiwania</string>
     <string name="main_kiss">Wyświetl ulubione i listę aplikacji</string>
     <string name="main_kiss_back">Wyświetl historię</string>
-    <string name="reset_desc">Zresetuj historię KISS</string>
     <string name="reset_name">Zresetuj historię</string>
-    <string name="keyboard_desc">Zawsze wyświetlaj klawiaturę przy starcie</string>
     <string name="keyboard_name">Wyświetl klawiaturę</string>
     <string name="spellcheck_name">Włącz sprawdzanie pisowni</string>
-    <string name="spellcheck_desc">Wyświetl sugestie podczas pisania</string>
     <string name="root_mode_name">Tryb root</string>
     <string name="root_mode_error">Nie można uzyskać przywilejów root.</string>
 
@@ -93,7 +83,6 @@
     <string name="toast_hibernate_error">Nie udało się zahibernować %s.</string>
     <string name="menu_contact_copy_phone">Kopiuj numer telefonu</string>
     <string name="theme_name">Motyw</string>
-    <string name="theme_desc">Zaktualizuj motyw KISS</string>
 
     <string name="root_mode_desc">Włącz dodatki root jeśli dostępne (aby zahibernować aplikacje)</string>
 <string name="history_hide_desc">Ukryj historię i ekran wstępu</string>
@@ -102,19 +91,15 @@
     <string name="toggle_sync">Synchronizacja</string>
     <string name="menu_phone_create">Stwórz kontakt</string>
 
-    <string name="order_apps_desc">Od A do Z lub Z do A</string>
 
 <string name="toggles_on">%s aktywowany</string>
     <string name="toggles_off">%s dezaktywowany</string>
 
-    <string name="shortcuts_desc">Szukaj w zainstalowanych skrótach</string>
     <string name="shortcuts_name">Skróty</string>
 
     <string name="reset_excluded_apps_name">Zresetuj listę odrzuconych aplikacji</string>
     <string name="reset_warn">Na pewno chcesz wyczyścić swoją historię?</string>
-    <string name="reset_favorites_desc">Wyczyść listę ulubionych</string>
     <string name="reset_favorites_name">Wyczyść ulubione</string>
-    <string name="portrait_summary">Zawsze używaj trybu portretowego przy wyświetlaniu Launchera</string>
     <string name="icons_hide_main">Ukryj ikony aplikacji</string>
     <string name="icons_hide_desc">Włącz na wolnych urządzeniach</string>
     <string name="toggle_autorotate">Autoobrót</string>
@@ -127,14 +112,10 @@
     <string name="toast_favorites_added">%s został dodany do ulubionych</string>
 
     <string name="order_apps_name">Kolejność listy aplikacji</string>
-    <string name="enable_sms_desc">Dodaj przychodzące wiadomości do historii</string>
     <string name="enable_sms">Wypełnij historię wiadomościami tekstowymi</string>
-    <string name="enable_phone_desc">Dodaj przychodzące połączenia do historii</string>
     <string name="enable_phone">Wypełnij historię połączeniami telefonicznymi</string>
-    <string name="enable_app_desc">Dodaj nowe aplikację do historii</string>
     <string name="enable_app">Wypełnij historię z zainstalowanych aplikacji</string>
 
-<string name="reset_excluded_apps_desc">Zresetuj listę wykluczonych aplikacji z KISS</string>
     <string name="reset_excluded_apps_warn">Na pewno chcesz zresetować listę wykluczonych aplikacji?</string>
     <string name="reset_favorites_warn">Na pewno chcesz wyczyścić ulubione?</string>
     <string name="history_onclick_name">Minimalistyczne UI: Pokaż historię po dotknięciu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7,23 +7,18 @@
     <string name="title_history">Histórico</string>
     <string name="title_advanced">Configurações avançadas</string>
     <string name="menu_settings">Configurações do dispositivo</string>
-    <string name="menu_preferences">Configurações do Launcher</string>
     <string name="no_favorites">Ainda não há favoritos. Adicione-os com um clique longo.</string>
 
     <string name="ui_empty_1_sub">Aplicativos, contatos, configurações, …</string>
     <string name="ui_empty_2_sub">Acesso rápido</string>
     <string name="ui_empty_3_sub">O KISS aprende com os seus hábitos</string>
 
-    <string name="contacts_desc">Pesquisar em meus contatos</string>
     <string name="contacts_name">Contatos</string>
 
-    <string name="search_desc">Habilitar pesquisa no Google</string>
     <string name="search_name">Pesquisar no Google</string>
 
-    <string name="settings_desc">Procurar nas minhas configurações</string>
     <string name="settings_name">Configurações</string>
 
-    <string name="phone_desc">Discagem direta para números de telefone</string>
     <string name="phone_name">Telefone</string>
 
     <string name="stub_application">Nome do aplicativo</string>
@@ -33,10 +28,7 @@
     <string name="stub_phone">Ligar +330 12 34 56 78</string>
     <string name="main_menu">Menu</string>
     <string name="main_clear">Limpar campo de pesquisa</string>
-    <string name="reset_desc">Limpar seu histórico de pesquisa</string>
-    <string name="keyboard_desc">Sempre exibir o teclado ao iniciar</string>
     <string name="spellcheck_name">Habilitar verificação ortográfica</string>
-    <string name="spellcheck_desc">Fornecer sugestões ao digitar</string>
     <string name="history_hide_desc">Ocultar histórico na tela inicial</string>
     <string name="history_hide_name">Interface minimalista</string>
     <string name="history_onclick_name">Interface minimalista: Mostrar histórico ao clicar</string>
@@ -46,10 +38,8 @@
     <string name="ui_empty_2">Veja sempre seu histórico</string>
     <string name="ui_empty_3">Acesso rápido aos aplicativos mais usados</string>
     <string name="ui_empty_1">Comece pesquisando por algo</string>
-    <string name="aliases_desc">Habilitar apelidos (atalhos de conveniência)</string>
     <string name="aliases_name">Apelidos</string>
 
-    <string name="shortcuts_desc">Procurar em atalhos instalados</string>
     <string name="shortcuts_name">Atalhos</string>    
 
     <string name="main_kiss">Exibir favoritos e lista de apps</string>
@@ -57,7 +47,6 @@
     <string name="reset_name">Limpar histórico</string>
     <string name="reset_warn">Você realmente quer limpar histórico?</string>    
     <string name="keyboard_name">Exibir teclado</string>
-    <string name="portrait_summary">Sempre girar a tela para o modo retrato quando exibir o launcher</string>
     <string name="icons_hide_main">Ocultar ícones dos apps</string>
     <string name="icons_hide_desc">Habilitar em dispositivos lentos</string>
     <string name="root_mode_desc">Habilitar recursos de root, se disponível (para hibernar aplicações)</string>
@@ -92,11 +81,9 @@
     <string name="toast_hibernate_error">%s não hibernado com êxito.</string>
     <string name="menu_contact_copy_phone">Copiar o número de telefone</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">Trocar o tema do launcher</string>
     <string name="menu_phone_create">Criar contato</string>
 
     <string name="order_apps_name">Ordem da lista de apps</string>
-    <string name="order_apps_desc">De A à Z ou Z à A</string>
 
 <string name="activity_setting">Configurações do launcher</string>
     <string name="toggles_on">%s ativado</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -12,7 +12,6 @@
     <string name="title_history">История</string>
     <string name="title_providers">Выбор службы поиска</string>
     <string name="menu_settings">Настройки Устройства</string>
-    <string name="menu_preferences">Настройки KISS</string>
     <string name="no_favorites">Нет избранных. Добавить их можно долгим зажатием.</string>
 
     <string name="ui_empty_1">Начните поиск чего-либо</string>
@@ -22,22 +21,16 @@
     <string name="ui_empty_3">Быстрый доступ к часто используемым приложениям</string>
     <string name="ui_empty_3_sub">KISS launcher учится с помощью ваших привычек</string>
 
-    <string name="toggles_desc">Включить переключатели (Wi-Fi, Bluetooth, ...)</string>
     <string name="toggles_name">Переключатели</string>
 
-    <string name="aliases_desc">Включить привязки (быстрые сочетания)</string>
     <string name="aliases_name">Привязка</string>
 
-    <string name="contacts_desc">Поиск в моих контактах</string>
     <string name="contacts_name">Контакты</string>
 
-    <string name="search_desc">Включить поиск Google</string>
     <string name="search_name">Поиск Google</string>
 
-    <string name="settings_desc">Поиск в настройках моего устройства</string>
     <string name="settings_name">Настройки</string>
 
-    <string name="phone_desc">Прямой вызов по номеру телефона</string>
     <string name="phone_name">Телефон</string>
 
     <string name="stub_application">Название приложения</string>
@@ -50,9 +43,7 @@
     <string name="main_clear">Очистить поле ввода</string>
     <string name="main_kiss">Показывает список избранного и список приложений</string>
     <string name="main_kiss_back">Показать историю</string>
-    <string name="reset_desc">Сбростить историю KISS</string>
     <string name="reset_name">Сбросить историю</string>
-    <string name="keyboard_desc">Всегда показывать клавиатуру при запуске</string>
     <string name="keyboard_name">Отображать клавиатуру</string>
 
     <string name="alias_phone">набрать,позвонить,телефон</string>
@@ -82,7 +73,6 @@
     <string name="menu_app_details">Информация о приложении</string>
     <string name="menu_app_uninstall">Удаление</string>
     <string name="theme_name">Темы</string>
-    <string name="theme_desc">Выбрать тему KISS</string>
 
     <string name="menu_contact_copy_phone">Скопировать номер телефона</string>
     <string name="title_advanced">Продвинутые настройки</string>
@@ -96,33 +86,25 @@
     <string name="toast_hibernate_completed">%s гибернация успешна, перезапустите приложение для пробуждения.</string>
     <string name="toast_hibernate_error">%s гибернация не успешна.</string>
     <string name="spellcheck_name">Включить проверку орфографии</string>
-    <string name="spellcheck_desc">Показывать подсказки при вводе</string>
     <string name="toggle_sync">Синхронизация</string>
 <string name="portrait_title">Использовать портретный режим</string>
-    <string name="portrait_summary">Всегда переворачивать экран в портретный режим когда появляется лаунчер</string>
     <string name="menu_phone_create">Создать контакт</string>
 
     <string name="order_apps_name">Порядок сортировки приложений</string>
-    <string name="order_apps_desc">От A к Z или От Z к A</string>
 
 <string name="history_hide_desc">Скрыть историю и экран приветствия</string>
     <string name="history_hide_name">Минималистичный UI</string>
     <string name="history_onclick_name">Минималистичный UI: Показать историю по нажатию</string>
     <string name="icons_hide_main">Скрыть иконки приложений</string>
     <string name="icons_hide_desc">Включить на медленных устройствах</string>
-    <string name="shortcuts_desc">Поиск в установленных ярлыках</string>
     <string name="shortcuts_name">Ярлыки</string>    
 
     <string name="reset_warn">Вы действительно хотите сбросить историю?</string>    
     <string name="toggle_autorotate">Автопереворот</string>
-    <string name="enable_sms_desc">Добавить входящие сообщения отправителя в историю</string>
     <string name="enable_sms">Дополнить историю из текстовых сообщений</string>
-    <string name="enable_phone_desc">Добавить входящие звонки в историю</string>
     <string name="enable_phone">Пополнить историю из звонков</string>
-    <string name="enable_app_desc">Добавить новые приложения в историю</string>
     <string name="enable_app">Пополнить историю установленных приложений</string>
 
-<string name="reset_excluded_apps_desc">Сбросить список исключенных приложений из KISS</string>
     <string name="reset_excluded_apps_name">Сбросить список исключённых приложений</string>
     <string name="reset_excluded_apps_warn">Вы действительно хотите сбросить список исключённых приложений?</string>
     <string name="excluded_app_list_erased">Список исключённых приложений очищен.</string>
@@ -132,7 +114,6 @@
     <string name="toggles_on">%s активировано</string>
     <string name="toggles_off">%s деактивировано</string>
 
-    <string name="reset_favorites_desc">Сбросить список избранных</string>
     <string name="reset_favorites_name">Сбросить избранные</string>
     <string name="reset_favorites_warn">Вы действительно хотите сбросить свои избранные?</string>
     <string name="favorites_erased">Избранные сброшены.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -11,7 +11,6 @@
     <string name="title_history">História</string>
     <string name="title_advanced">Pokročilé nastavenia</string>
     <string name="menu_settings">Nastavenia zariadenia</string>
-    <string name="menu_preferences">KISS nastavenia</string>
     <string name="no_favorites">Žiadne obľúbené položky. Použí aplikáciu a objavia sa.</string>
 
     <string name="ui_empty_1">Začni hľadaním čohokoľvek</string>
@@ -21,23 +20,16 @@
     <string name="ui_empty_3">Rýchly prístup pre najpoužívanejšie aplikácie</string>
     <string name="ui_empty_3_sub">KISS launcher sa učí z Vaších zvykov</string>
 
-    <string name="toggles_desc"/>
     <string name="toggles_name"/>
 
-    <string name="aliases_desc"/>
     <string name="aliases_name"/>
 
-    <string name="contacts_desc">Vyhľadávať v kontaktoch</string>
     <string name="contacts_name">Kontakty</string>
 
-    <string name="search_desc">Zapnúť Google Web Search</string>
     <string name="search_name">Google vyhľadávanie</string>
 
-    <string name="settings_desc">Vyhľadávať v nastaveniach zariadenia</string>
     <string name="settings_name">Nastavenia</string>
 
-    <string name="phone_desc"/>
     <string name="phone_name">Telefón</string>
 
-    <string name="shortcuts_desc"></string>
     </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -13,7 +13,6 @@
     <string name="title_history">Поставке историјата</string>
     <string name="title_providers">Избор услуга</string>
     <string name="menu_settings">Поставке уређаја</string>
-    <string name="menu_preferences">Поставке покретача</string>
     <string name="no_favorites">Још нема омиљених. Користите апликацију и биће додата у омиљене.</string>
 
     <string name="ui_empty_1">Почните претрагом било чега</string>
@@ -23,22 +22,16 @@
     <string name="ui_empty_3">Брзи приступ најчешће коришћеним апликацијама</string>
     <string name="ui_empty_3_sub">КИС покретач учи ваше навике</string>
 
-    <string name="toggles_desc">Укључи прекидаче (бежични, блутут)</string>
     <string name="toggles_name">Прекидачи</string>
 
-    <string name="aliases_desc">Укључи псеудониме (брзе пречице)</string>
     <string name="aliases_name">Псеудоними</string>
 
-    <string name="contacts_desc">Тражи у мојим контактима</string>
     <string name="contacts_name">Контакти</string>
 
-    <string name="search_desc">Тражи на вебу помоћу Гугла</string>
     <string name="search_name">Гугл претрага</string>
 
-    <string name="settings_desc">Тражи у поставкама телефона</string>
     <string name="settings_name">Поставке</string>
 
-    <string name="phone_desc">Директно бирање телефонских бројева</string>
     <string name="phone_name">Телефон</string>
 
     <string name="stub_application">Име апликације</string>
@@ -51,12 +44,9 @@
     <string name="main_clear">Очисти текст</string>
     <string name="main_kiss">Приказуј списак апликација и омиљено</string>
     <string name="main_kiss_back">Приказуј историјат</string>
-    <string name="reset_desc">Чишћење историјат КИС покретача</string>
     <string name="reset_name">Ресетуј историјат</string>
-    <string name="keyboard_desc">Увек приказуј тастатуру по покретању</string>
     <string name="keyboard_name">Приказуј тастатуру</string>
     <string name="spellcheck_name">Омогући проверу правописа</string>
-    <string name="spellcheck_desc">Предложите корекције током претреса</string>
 
     <string name="alias_phone">dial,biraj,zovi,pozovi,šalji,poruka,telefon,бирај,зови,позови,шаљи,порука,телефон</string>
     <string name="alias_contacts">kontakt,ljudi,osobe,контакт,људи,особе</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -12,7 +12,6 @@
     <string name="title_history">Geçmiş</string>
     <string name="title_providers">Neler Gösterilsin</string>
     <string name="menu_settings">Aygıt ayarları</string>
-    <string name="menu_preferences">KISS ayarları</string>
     <string name="no_favorites">Henüz sık kullanılan uygulama yok. Bir ögeye uzunca dokunup ekleyebilirsiniz.</string>
 
     <string name="ui_empty_1">Bir şeyleri aramaya başlayın</string>
@@ -22,22 +21,16 @@
     <string name="ui_empty_3">En çok kullanılan uygulamalara hızlı erişim</string>
     <string name="ui_empty_3_sub">KISS başlatıcı alışkanlıklarınıza göre çalışır</string>
 
-    <string name="toggles_desc">Aç/Kapa düğmelerini etkinleştir (Wi-Fi, Bluetooth, ...)</string>
     <string name="toggles_name">Aç/Kapa düğmeleri</string>
 
-    <string name="aliases_desc">Armaları etkinleştir (kısayollar)</string>
     <string name="aliases_name">Armalar</string>
 
-    <string name="contacts_desc">Kişilerimde ara</string>
     <string name="contacts_name">Kişiler</string>
 
-    <string name="search_desc">Google Web aramasını etkinleştir</string>
     <string name="search_name">Google arama</string>
 
-    <string name="settings_desc">Aygıt ayarlarında ara</string>
     <string name="settings_name">Ayarlar</string>
 
-    <string name="phone_desc">Telefon numaraları için çevirici</string>
     <string name="phone_name">Telefon</string>
 
     <string name="stub_application">Uygulama adı</string>
@@ -50,9 +43,7 @@
     <string name="main_clear">Metni sil</string>
     <string name="main_kiss">Sık kullanılanları ve uygulama listesini göster</string>
     <string name="main_kiss_back">Geçmişi göster</string>
-    <string name="reset_desc">KISS geçmişini sil</string>
     <string name="reset_name">Geçmişi sil</string>
-    <string name="keyboard_desc">Başlangıçta klavyeyi hep göster</string>
     <string name="keyboard_name">Klavyeyi göster</string>
 
     <string name="alias_phone">çevir,ara,telefon</string>
@@ -83,7 +74,6 @@
     <string name="menu_app_uninstall">Yüklemeyi kaldır</string>
     <string name="menu_contact_copy_phone">Telefon numarasını kopyala</string>
     <string name="theme_name">Tema</string>
-    <string name="theme_desc">KISS temasını değiştir</string>
 
     <string name="title_advanced">Gelişmiş Ayarlar</string>
     <string name="root_mode_desc">Olanaklıysa süper kullanıcı özelliklerini etkinleştir (uygulamaları uyutmak için)</string>
@@ -96,21 +86,16 @@
     <string name="toast_hibernate_completed">%s uyku kipine alındı, uyandırmak için yeniden açın.</string>
     <string name="toast_hibernate_error">%s uyku kipine alınamadı.</string>
     <string name="spellcheck_name">Yazım denetimini etkinleştir</string>
-    <string name="spellcheck_desc">Yazarken önerileri göster</string>
 <string name="toggle_sync">Eşitleme</string>
     <string name="portrait_title">Dikey kipi zorla</string>
-    <string name="portrait_summary">Başlatıcıyı gösterirken ekranı her zaman dikey kipe döndür</string>
     <string name="menu_phone_create">Kişi oluştur</string>
 
     <string name="order_apps_name">Uygulama liste sırası</string>
-    <string name="order_apps_desc">A\'dan Z\'ye veya Z\'den A\'ya</string>
 
 <string name="history_hide_desc">Geçmiş ve giriş ekranını gizle</string>
     <string name="history_hide_name">Minimalistik arayüz</string>
-    <string name="shortcuts_desc">Yüklenmiş kısayollarda ara</string>
     <string name="shortcuts_name">Kısayollar</string>
 
-    <string name="reset_excluded_apps_desc">KISS uygulamalarına dahil edilmeyenler listesini sıfırla</string>
     <string name="reset_excluded_apps_name">Dahil edilmeyen uygulamalar listesini sıfırla</string>
     <string name="reset_excluded_apps_warn">Gerçekten dahil edilmeyen uygulamalar listenizi sıfırlamak istiyor musunuz?</string>
     <string name="reset_warn">Geçmişinizi gerçekten sıfırlamak istiyor musunuz?</string>
@@ -122,17 +107,13 @@
     <string name="excluded_app_list_added">Uygulama KISS\'e dahil edilmedi. Dilerseniz ayarlardan sıfırlayabilirsiniz.</string>
 
     <string name="menu_exclude">Uygulamayı KISS\'e dahil etme</string>
-    <string name="enable_sms_desc">Gönderenin mesajlarını geçmişe ekle</string>
     <string name="enable_sms">Geçmişte mesajları da göster</string>
-    <string name="enable_phone_desc">Geçmişe gelen çağrıları ekle</string>
     <string name="enable_phone">Geçmişi çağrılar ile doldur</string>
-    <string name="enable_app_desc">Yeni uygulamaları geçmişe ekle</string>
     <string name="enable_app">Geçmişi uygulama yüklemeleri ile doldur</string>
 
 <string name="toggles_on">% etkinleştirildi</string>
     <string name="toggles_off">% durduruldu</string>
 
-    <string name="reset_favorites_desc">Sık kullanılanlar listesini sıfırla</string>
     <string name="reset_favorites_name">Sık kullanılanları sıfırla</string>
     <string name="reset_favorites_warn">Sık kullanılanları gerçekten sıfırlamak istiyor musunuz?</string>
     <string name="favorites_erased">Sık kullanılanlar sıfırlandı.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,4 +121,6 @@
     <string name="enable_app">Show newly installed apps in history</string>
     <string name="shortcut_added">Shortcut added to KISS.</string>
 
+    <string name="items_title">items</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
-<?xml version='1.0' encoding='utf-8'?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 
     <string name="app_name">KISS launcher</string>
@@ -14,7 +13,6 @@
     <string name="title_providers">Providers Selection</string>
     <string name="title_advanced">Advanced Settings</string>
     <string name="menu_settings">Device Settings</string>
-    <string name="menu_preferences">KISS settings</string>
     <string name="no_favorites">No favorites yet. Add them through long click.</string>
 
     <string name="ui_empty_1">Start searching for anything</string>
@@ -24,27 +22,20 @@
     <string name="ui_empty_3">Quick access to most used apps</string>
     <string name="ui_empty_3_sub">KISS launcher learns from your habits</string>
 
-    <string name="toggles_desc">Enable toggles (Wi-Fi, Bluetooth, …)</string>
-    <string name="toggles_name">Toggles</string>
+    <string name="toggles_name">Toggles (Wi-Fi, Bluetooth, …)</string>
     <string name="toggles_on">%s activated</string>
     <string name="toggles_off">%s deactivated</string>
 
-    <string name="aliases_desc">Enable aliases (convenience shortcuts)</string>
     <string name="aliases_name">Aliases</string>
 
-    <string name="contacts_desc">Search in my contacts</string>
     <string name="contacts_name">Contacts</string>
 
-    <string name="search_desc">Enable Google Web Search</string>
     <string name="search_name">Google search</string>
 
-    <string name="settings_desc">Search in my device Settings</string>
-    <string name="settings_name">Settings</string>
+    <string name="settings_name">Device Settings</string>
 
-    <string name="phone_desc">Direct dialer for phone numbers</string>
-    <string name="phone_name">Phone</string>
+    <string name="phone_name">Phone numbers</string>
 
-    <string name="shortcuts_desc">Search in installed shortcuts</string>
     <string name="shortcuts_name">Shortcuts</string>
 
     <string name="stub_application">Application name</string>
@@ -57,33 +48,25 @@
     <string name="main_clear">Clear search field</string>
     <string name="main_kiss">Display favorites and app list</string>
     <string name="main_kiss_back">Display history</string>
-    <string name="reset_desc">Reset your KISS history</string>
-    <string name="reset_name">Reset history</string>
-    <string name="reset_excluded_apps_desc">Reset the list of excluded from KISS apps</string>
+    <string name="reset_name">Reset your KISS history</string>
     <string name="reset_excluded_apps_name">Reset excluded app list</string>
     <string name="reset_excluded_apps_warn">Do you really want to reset your excluded app list?</string>
     <string name="reset_warn">Do you really want to reset your history?</string>
-    <string name="reset_favorites_desc">Reset your list of favorites</string>
-    <string name="reset_favorites_name">Reset favorites</string>
+    <string name="reset_favorites_name">Reset your list of favorites</string>
     <string name="reset_favorites_warn">Do you really want to reset your favorites?</string>
-    <string name="keyboard_desc">Always display keyboard at startup</string>
-    <string name="keyboard_name">Display keyboard</string>
+    <string name="keyboard_name">Display keyboard on start</string>
     <string name="spellcheck_name">Enable spellcheck</string>
-    <string name="spellcheck_desc">Provide suggestions when typing</string>
     <string name="history_hide_desc">Hide history and intro screen</string>
     <string name="history_hide_name">Minimalistic UI</string>
-    <string name="history_onclick_desc">Touch anywhere to show history</string>
     <string name="history_onclick_name">Minimalistic UI: Show history on touch</string>
     <string name="portrait_title">Force portrait mode</string>
-    <string name="portrait_summary">Always rotate screen to portrait mode when showing the launcher</string>
     <string name="icons_hide_main">Hide application icons</string>
-    <string name="icons_hide_desc">Enable on slow devices</string>
-    <string name="root_mode_desc">Enable root features if available (to hibernate applications)</string>
+    <string name="icons_hide_desc">Useful on slow devices</string>
+    <string name="root_mode_desc">If available use it to hibernate applications</string>
     <string name="root_mode_name">Root mode</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>
     
-    <string name="icons_pack_desc">Choose an icon theme (ADW.Launcher theme)</string>
-    <string name="icons_pack_name">Icons Themes</string>    
+    <string name="icons_pack_name">Theme icons (ADW.Launcher theme)</string>
     <string name="icons_pack_default_name">System icons</string>
 
     <string name="alias_phone">dial,call,phone</string>
@@ -127,20 +110,15 @@
     <string name="toast_hibernate_completed">%s hibernated successfully, relaunch to awake.</string>
     <string name="toast_hibernate_error">%s not hibernated successfully.</string>
     <string name="menu_contact_copy_phone">Copy phone number</string>
-    <string name="theme_name">Theme</string>
-    <string name="theme_desc">Update KISS theme</string>
+    <string name="theme_name">Theme interface</string>
     <string name="menu_phone_create">Create contact</string>
 
     <string name="toast_favorites_added">%s was added to favorites</string>
 
-    <string name="order_apps_name">App list order</string>
-    <string name="order_apps_desc">A to Z or Z to A</string>
-    <string name="enable_sms_desc">Add sender\'s incoming messages to history</string>
-    <string name="enable_sms">Populate history from text messages</string>
-    <string name="enable_phone_desc">Add incoming calls to history</string>
-    <string name="enable_phone">Populate history from phone calls</string>
-    <string name="enable_app_desc">Add new apps to history</string>
-    <string name="enable_app">Populate history from app install</string>
+    <string name="order_apps_name">App list sort order</string>
+    <string name="enable_sms">Show incoming SMS in history</string>
+    <string name="enable_phone">Show incoming calls in history</string>
+    <string name="enable_app">Show newly installed apps in history</string>
     <string name="shortcut_added">Shortcut added to KISS.</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -5,32 +5,26 @@
         <fr.neamar.kiss.preference.ResetPreference
             android:dialogMessage="@string/reset_warn"
             android:key="reset"
-            android:summary="@string/reset_desc"
             android:title="@string/reset_name" />
         <fr.neamar.kiss.preference.ResetFavoritesPreference
             android:dialogMessage="@string/reset_favorites_warn"
             android:key="reset"
-            android:summary="@string/reset_favorites_desc"
             android:title="@string/reset_favorites_name" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="enable-sms-history"
-            android:summary="@string/enable_sms_desc"
             android:title="@string/enable_sms" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="enable-phone-history"
-            android:summary="@string/enable_phone_desc"
             android:title="@string/enable_phone" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-app-history"
-            android:summary="@string/enable_app_desc"
             android:title="@string/enable_app" />
         <fr.neamar.kiss.preference.ResetExcludedAppsPreference
             android:dialogMessage="@string/reset_excluded_apps_warn"
             android:key="reset-excluded-apps"
-            android:summary="@string/reset_excluded_apps_desc"
             android:title="@string/reset_excluded_apps_name" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/title_ui">
@@ -39,29 +33,24 @@
             android:entries="@array/themesEntries"
             android:entryValues="@array/themesValues"
             android:key="theme"
-            android:summary="@string/theme_desc"
             android:title="@string/theme_name" />
         <ListPreference
             android:defaultValue="default"
             android:key="icons-pack"
-            android:summary="@string/icons_pack_desc"
             android:title="@string/icons_pack_name"/>
         <ListPreference
             android:defaultValue="invertedAlphabetical"
             android:entries="@array/sortAppListEntries"
             android:entryValues="@array/sortAppListValues"
             android:key="sort-apps"
-            android:summary="@string/order_apps_desc"
             android:title="@string/order_apps_name" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="display-keyboard"
-            android:summary="@string/keyboard_desc"
             android:title="@string/keyboard_name" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="enable-spellcheck"
-            android:summary="@string/spellcheck_desc"
             android:title="@string/spellcheck_name" />
         <CheckBoxPreference
             android:defaultValue="false"
@@ -72,12 +61,10 @@
             android:defaultValue="false"
             android:key="history-onclick"
             android:dependency="history-hide"
-            android:summary="@string/history_onclick_desc"
             android:title="@string/history_onclick_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="force-portrait"
-            android:summary="@string/portrait_summary"
             android:title="@string/portrait_title" />
         <CheckBoxPreference
             android:defaultValue="false"
@@ -89,37 +76,30 @@
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-contacts"
-            android:summary="@string/contacts_desc"
             android:title="@string/contacts_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-settings"
-            android:summary="@string/settings_desc"
             android:title="@string/settings_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-toggles"
-            android:summary="@string/toggles_desc"
             android:title="@string/toggles_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-alias"
-            android:summary="@string/aliases_desc"
             android:title="@string/aliases_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-search"
-            android:summary="@string/search_desc"
             android:title="@string/search_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-phone"
-            android:summary="@string/phone_desc"
             android:title="@string/phone_name" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="enable-shortcuts"
-            android:summary="@string/shortcuts_desc"
             android:title="@string/shortcuts_name" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/title_advanced">


### PR DESCRIPTION
It depends/includes https://github.com/Neamar/KISS/pull/411

First thing, I apologize to the translators for the cuts.

I was translating KISS and at about 50% I saw that most of the text keeps repeating stuff just a bit different, basically the summaries where not really adding anything, just space on screen.

I removed the `_desc` strings that I felt were not helping and expanded upon the descriptions a bit.

While I did remove the strings in the translations, I'm not sure if the Weblate thing triggers a strings change (for those strings that I modified) all by itself or that I need to do something.