### PR TITLE
Add "KISS restart" to options menu

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/preference/RestartPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RestartPreference.java
@@ -1,0 +1,23 @@
+package fr.neamar.kiss.preference;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+
+public class RestartPreference extends DialogPreference {
+
+    public RestartPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        super.onClick(dialog, which);
+        if (which == DialogInterface.BUTTON_POSITIVE) {
+            System.exit(0);
+        }
+
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,4 +143,8 @@
     <string name="enable_app">Populate history from app install</string>
     <string name="shortcut_added">Shortcut added to KISS.</string>
 
+    <string name="restart_desc">Restart KISS launcher</string>
+    <string name="restart_name">Restart KISS</string>
+    <string name="restart_warn">Do you really want to restart KISS? If KISS is not your default launcher the app will simply quit.</string>
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -128,5 +128,10 @@
             android:key="root-mode"
             android:summary="@string/root_mode_desc"
             android:title="@string/root_mode_name" />
+        <fr.neamar.kiss.preference.RestartPreference
+            android:dialogMessage="@string/restart_warn"
+            android:key="restart"
+            android:summary="@string/restart_desc"
+            android:title="@string/restart_name" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This commit for issue #380 is adding a simple `KISS restart` to the options menu. If pressed it does a `System.exit(0);` which kills the application. On my 5.0.1 device the app is automatically restarted with new `PID` because of `default launcher` setting.

Do we have to care about KISS not being default launcher ?

Edit: No translations made so far. I'm not familiar with WebLate.