### PR TITLE
Smart history2

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -288,13 +288,14 @@ public class DataHandler extends BroadcastReceiver
      *
      * @param context   android context
      * @param itemCount max number of items to retrieve, total number may be less (search or calls are not returned for instance)
+     * @param smartHistory Recency vs Frecency
      * @return pojos in recent history
      */
-    public ArrayList<Pojo> getHistory(Context context, int itemCount) {
+    public ArrayList<Pojo> getHistory(Context context, int itemCount, boolean smartHistory) {
         ArrayList<Pojo> history = new ArrayList<>(itemCount);
 
         // Read history
-        ArrayList<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount);
+        ArrayList<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount, smartHistory);
 
         // Find associated items
         for (int i = 0; i < ids.size(); i++) {

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -693,6 +693,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
     @Override
     public void hideKeyboard() {
+
         // Check if no view has focus:
         View view = this.getCurrentFocus();
         if (view != null) {

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -55,6 +55,15 @@ public class DBHelper {
         db.close();
     }
 
+    private static Cursor getSmartHistoryCursor(SQLiteDatabase db, int limit) {
+        return db.query(false, "history", new String[]{"record", "count(*)", "max(_id)", "count(*) "}, null, null,
+                "record", null, "count(*) * 1.0 / (select count(*) from history) + 1.5 / ((select max(_id) from history) - max(_id) + 1)/((select max(_id) from history) - max(_id) + 1) DESC", Integer.toString(limit));
+    }
+
+    private static Cursor getHistoryCursor(SQLiteDatabase db, int limit) {
+        return db.query(true, "history", new String[]{"record", "1"}, null, null,
+                null, null, "_id DESC", Integer.toString(limit));
+    }
     /**
      * Retrieve previous query history
      *
@@ -62,7 +71,7 @@ public class DBHelper {
      * @param limit   max number of items to retrieve
      * @return records with number of use
      */
-    public static ArrayList<ValuedHistoryRecord> getHistory(Context context, int limit) {
+    public static ArrayList<ValuedHistoryRecord> getHistory(Context context, int limit, boolean smartHistory) {
         ArrayList<ValuedHistoryRecord> records;
 
         SQLiteDatabase db = getDatabase(context);
@@ -70,8 +79,9 @@ public class DBHelper {
         // Cursor query (boolean distinct, String table, String[] columns,
         // String selection, String[] selectionArgs, String groupBy, String
         // having, String orderBy, String limit)
-        Cursor cursor = db.query(true, "history", new String[]{"record", "1"}, null, null,
-                null, null, "_id DESC", Integer.toString(limit));
+        Cursor cursor = (smartHistory)?getSmartHistoryCursor(db, limit):getHistoryCursor(db, limit);
+        //db.query(true, "history", new String[]{"record", "1"}, null, null,
+        //        null, null, "_id DESC", Integer.toString(limit));
 
         records = readCursor(cursor);
         cursor.close();
@@ -196,5 +206,5 @@ public class DBHelper {
         
         db.close();        
     }
-    
+
 }

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -57,7 +57,7 @@ public class DBHelper {
 
     private static Cursor getSmartHistoryCursor(SQLiteDatabase db, int limit) {
         return db.query(false, "history", new String[]{"record", "count(*)", "max(_id)", "count(*) "}, null, null,
-                "record", null, "count(*) * 1.0 / (select count(*) from history) + 1.5 / ((select max(_id) from history) - max(_id) + 1)/((select max(_id) from history) - max(_id) + 1) DESC", Integer.toString(limit));
+                "record", null, "count(*) * 1.0 / (select count(*) from history) * 1.0 / ((select max(_id) from history) - max(_id) + 0.01) DESC", Integer.toString(limit));
     }
 
     private static Cursor getHistoryCursor(SQLiteDatabase db, int limit) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -1,5 +1,8 @@
 package fr.neamar.kiss.searcher;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
 import java.util.List;
 
 import fr.neamar.kiss.KissApplication;
@@ -11,15 +14,17 @@ import fr.neamar.kiss.pojo.Pojo;
  */
 public class HistorySearcher extends Searcher {
     private static final int MAX_RECORDS = 25;
+    private SharedPreferences prefs;
 
     public HistorySearcher(MainActivity activity) {
         super(activity);
+        prefs = PreferenceManager.getDefaultSharedPreferences(activity);
     }
 
     @Override
     protected List<Pojo> doInBackground(Void... voids) {
         // Ask for records
-
-        return KissApplication.getDataHandler(activity).getHistory(activity, MAX_RECORDS);
+        boolean smartHistory = !prefs.getString("history-mode", "recency").equals("recency");
+        return KissApplication.getDataHandler(activity).getHistory(activity, MAX_RECORDS, smartHistory);
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -24,4 +24,13 @@
         <item>alphabetical</item>
         <item>invertedAlphabetical</item>
     </string-array>
+    <string-array name="historyModeEntries">
+        <item>Most recent first</item>
+        <item>Frecency</item>
+    </string-array>
+    <string-array name="historyModeValues">
+        <item>recency</item>
+        <item>frecency</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="portrait_title">Force portrait mode</string>
     <string name="icons_hide_main">Hide application icons</string>
     <string name="icons_hide_desc">Useful on slow devices</string>
+    <string name="history_mode_name">History mode</string>
+    <string name="history_mode_desc">Select the way that the history is populated</string>
     <string name="root_mode_desc">If available use it to hibernate applications</string>
     <string name="root_mode_name">Root mode</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -107,6 +107,13 @@
             android:defaultValue="false"
             android:key="freeze-history"
             android:title="@string/freeze_history_name" />
+        <ListPreference
+            android:defaultValue="recency"
+            android:entries="@array/historyModeEntries"
+            android:entryValues="@array/historyModeValues"
+            android:key="history-mode"
+            android:summary="@string/history_mode_desc"
+            android:title="@string/history_mode_name" />
         <fr.neamar.kiss.preference.RootModePreference
             android:defaultValue="false"
             android:key="root-mode"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -103,10 +103,6 @@
             android:title="@string/shortcuts_name" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/title_advanced">
-        <fr.neamar.kiss.preference.FreezeHistoryPreference
-            android:defaultValue="false"
-            android:key="freeze-history"
-            android:title="@string/freeze_history_name" />
         <ListPreference
             android:defaultValue="recency"
             android:entries="@array/historyModeEntries"
@@ -114,6 +110,10 @@
             android:key="history-mode"
             android:summary="@string/history_mode_desc"
             android:title="@string/history_mode_name" />
+        <fr.neamar.kiss.preference.FreezeHistoryPreference
+            android:defaultValue="false"
+            android:key="freeze-history"
+            android:title="@string/freeze_history_name" />
         <fr.neamar.kiss.preference.RootModePreference
             android:defaultValue="false"
             android:key="root-mode"


### PR DESCRIPTION
#419 
Ordering of apps based on `frecency = frequency * recency`
`Frequency = number_of_launches_for_app / total_number_of_launches`
`Recency = 1 / position in normal history = 1/ (max(id) in history - max(app_id))`

The ordering is computed inside the sql query. Group by is needed. To avoid group by on all hisotry results i first limit to the 750 latest history entries. My initial tests indicate that smart history is ~2x slower than the normal history (which I think is still fine).
- Could someone test? First enable smart history on settings > advanced > history mode
- Any ideas about the titles in the settings? 