### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -13,6 +13,7 @@ import android.preference.PreferenceManager;
 import android.widget.Toast;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -250,7 +251,7 @@ public class DataHandler extends BroadcastReceiver
         currentQuery = query;
 
         // Have we ever made the same query and selected something ?
-        ArrayList<ValuedHistoryRecord> lastIdsForQuery = DBHelper.getPreviousResultsForQuery(
+        List<ValuedHistoryRecord> lastIdsForQuery = DBHelper.getPreviousResultsForQuery(
                 context, query);
         HashMap<String, Integer> knownIds = new HashMap<>();
         for (ValuedHistoryRecord id : lastIdsForQuery) {
@@ -262,7 +263,7 @@ public class DataHandler extends BroadcastReceiver
 
         for (ProviderEntry entry : this.providers.values()) {
             // Retrieve results for query:
-            ArrayList<Pojo> pojos = entry.provider.getResults(query);
+            List<Pojo> pojos = entry.provider.getResults(query);
 
             // Add results to list
             for (Pojo pojo : pojos) {
@@ -294,7 +295,7 @@ public class DataHandler extends BroadcastReceiver
         ArrayList<Pojo> history = new ArrayList<>(itemCount);
 
         // Read history
-        ArrayList<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount);
+        List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount);
 
         // Find associated items
         for (int i = 0; i < ids.size(); i++) {

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -26,6 +26,7 @@ import org.xmlpull.v1.XmlPullParser;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,7 +43,7 @@ public class IconsHandler {
     // map with available icons packs
     private HashMap<String, String> iconsPacks = new HashMap<>();
     // map with available drawable for an icons pack
-    private HashMap<String, String> packagesDrawables = new HashMap<>();
+    private Map<String, String> packagesDrawables = new HashMap<>();
     // instance of a resource object of an icon pack
     private Resources iconPackres;
     // package name of the icons pack

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -17,6 +17,8 @@ import android.widget.Toast;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import fr.neamar.kiss.broadcast.IncomingCallHandler;
 import fr.neamar.kiss.broadcast.IncomingSmsHandler;
@@ -87,7 +89,7 @@ public class SettingsActivity extends PreferenceActivity implements
             multiPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    HashSet<String> appListToBeExcluded = (HashSet<String>) newValue;
+                    Set<String> appListToBeExcluded = (HashSet<String>) newValue;
 
                     StringBuilder builder = new StringBuilder();
                     for (String s : appListToBeExcluded) {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
@@ -7,6 +7,7 @@ import android.os.IBinder;
 import android.util.Log;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.loader.LoadPojos;
@@ -16,7 +17,7 @@ public abstract class Provider<T extends Pojo> extends Service implements IProvi
     /**
      * Storage for search items used by this provider
      */
-    protected ArrayList<T> pojos = new ArrayList<>();
+    protected List<T> pojos = new ArrayList<>();
     private boolean loaded = false;
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/SearchProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/SearchProvider.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceManager;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -16,7 +17,7 @@ import fr.neamar.kiss.pojo.SearchPojo;
 
 public class SearchProvider extends Provider<SearchPojo> {
     private SharedPreferences prefs;
-    private static final LinkedHashMap<String,String> searchProviderUrls = new LinkedHashMap<>();
+    private static final HashMap<String,String> searchProviderUrls = new LinkedHashMap<>();
 
     static {
         searchProviderUrls.put("Bing", "https://www.bing.com/search?q=");

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAliasPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAliasPojos.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
 
+import java.util.List;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,7 +75,7 @@ public class LoadAliasPojos extends LoadPojos<AliasPojo> {
 
     }
 
-    private void addAliasesPojo(ArrayList<AliasPojo> alias, String[] aliases, String appInfo) {
+    private void addAliasesPojo(List<AliasPojo> alias, String[] aliases, String appInfo) {
         for (String a : aliases) {
             alias.add(makeAliasPojo(a, appInfo));
         }

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
@@ -6,6 +6,8 @@ import android.database.Cursor;
 import android.provider.ContactsContract;
 import android.util.Log;
 
+import java.util.List;
+import java.util.Map;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.regex.Pattern;
@@ -40,7 +42,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
         // Prevent duplicates by keeping in memory encountered phones.
         // The string key is "phone" + "|" + "name" (so if two contacts
         // with distinct name share same number, they both get displayed)
-        HashMap<String, ArrayList<ContactsPojo>> mapContacts = new HashMap<>();
+        Map<String, ArrayList<ContactsPojo>> mapContacts = new HashMap<>();
 
         if (cur != null) {
             if (cur.getCount() > 0) {
@@ -95,7 +97,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
         ArrayList<ContactsPojo> contacts = new ArrayList<>();
 
         Pattern phoneFormatter = Pattern.compile("[ \\.\\(\\)]");
-        for (ArrayList<ContactsPojo> phones : mapContacts.values()) {
+        for (List<ContactsPojo> phones : mapContacts.values()) {
             // Find primary phone and add this one.
             Boolean hasPrimary = false;
             for (ContactsPojo contact : phones) {
@@ -108,7 +110,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
 
             // If not available, add all (excluding duplicates).
             if (!hasPrimary) {
-                HashMap<String, Boolean> added = new HashMap<>();
+                Map<String, Boolean> added = new HashMap<>();
                 for (ContactsPojo contact : phones) {
                     String uniqueKey = phoneFormatter.matcher(contact.phone).replaceAll("");
                     uniqueKey = uniqueKey.replaceAll("^\\+33", "0");

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.BitmapFactory;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.db.ShortcutRecord;
@@ -17,7 +18,7 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutsPojo> {
 
     @Override
     protected ArrayList<ShortcutsPojo> doInBackground(Void... arg0) {
-        ArrayList<ShortcutRecord> records = DBHelper.getShortcuts(context);
+        List<ShortcutRecord> records = DBHelper.getShortcuts(context);
         ArrayList<ShortcutsPojo> pojos = new ArrayList<>();
         for (ShortcutRecord shortcutRecord : records) {
             ShortcutsPojo pojo = createPojo(shortcutRecord.name);

--- a/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss.pojo;
 
 import android.util.Pair;
 import java.util.ArrayList;
+import java.util.List;
 
 import fr.neamar.kiss.normalizer.StringNormalizer;
 
@@ -90,7 +91,7 @@ public abstract class Pojo {
                 + this.name.substring(positionEnd);
     }
 
-    public void setDisplayNameHighlightRegion(ArrayList<Pair<Integer, Integer>> positions) {
+    public void setDisplayNameHighlightRegion(List<Pair<Integer, Integer>> positions) {
         this.displayName = "";
         int lastPositionEnd = 0;
         for (Pair<Integer, Integer> position : positions) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -26,7 +26,7 @@ public class QuerySearcher extends Searcher {
     @Override
     protected List<Pojo> doInBackground(Void... voids) {
         // Ask for records
-        final ArrayList<Pojo> pojos = KissApplication.getDataHandler(activity).getResults(
+        final List<Pojo> pojos = KissApplication.getDataHandler(activity).getResults(
                 activity, query);
 
         // Trim items


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.