### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -13,6 +13,9 @@ public class KissApplication {
     private static RootHandler rootHandler;
     private static IconsHandler iconsPackHandler;
 
+    private KissApplication() {
+    }
+
     public static DataHandler getDataHandler(Context ctx) {
         if (dataHandler == null) {
             dataHandler = new DataHandler(ctx);

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -9,6 +9,9 @@ import fr.neamar.kiss.pojo.ShortcutsPojo;
 import java.util.ArrayList;
 
 public class DBHelper {
+    private DBHelper() {
+    }
+
     private static SQLiteDatabase getDatabase(Context context) {
         DB db = new DB(context);
         return db.getReadableDatabase();

--- a/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
@@ -6,6 +6,9 @@ import android.telephony.PhoneNumberUtils;
 import java.util.Locale;
 
 public class PhoneNormalizer {
+    private PhoneNormalizer() {
+    }
+
     public static String normalizePhone(String phoneNumber) {
         if(phoneNumber == null) {
             return "";

--- a/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
@@ -8,6 +8,9 @@ import java.text.Normalizer;
  * String utils to handle accented characters for search and highlighting
  */
 public class StringNormalizer {
+    private StringNormalizer() {
+    }
+
     /**
      * Make the given string easier to compare by performing a number of simplifications on it
      * <p/>


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.