### PR TITLE
Update gradle build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 


### PR DESCRIPTION
Gradle 2.1.10-beta1 was giving me errors on both my machine and circleci tests. Updating to 2.1.10 seems to fix the issue for me, let's see if it does on circleci too.