### PR TITLE
Fix for issue 459 - Cancelling uninstall app issue.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,7 +105,7 @@
             android:theme="@style/SettingTheme" />
 
         <!-- On new app installed or sdcard mount / unmount refresh the list -->
-        <receiver android:name=".broadcast.NewAppInstalledHandler">
+        <receiver android:name=".broadcast.PackageAddedRemovedHandler">
             <intent-filter>
                 <action android:name="android.intent.action.PACKAGE_ADDED" />
                 <action android:name="android.intent.action.PACKAGE_REMOVED" />

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -16,12 +16,12 @@ import fr.neamar.kiss.dataprovider.AppProvider;
  *
  * @author dorvaryn
  */
-public class NewAppInstalledHandler extends BroadcastReceiver {
+public class PackageAddedRemovedHandler extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context ctx, Intent intent) {
 
-        if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true))
+        if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
             // Insert into history new packages (not updated ones)
             if ("android.intent.action.PACKAGE_ADDED".equals(intent.getAction()) && !intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
                 // Add new package to history
@@ -38,18 +38,20 @@ public class NewAppInstalledHandler extends BroadcastReceiver {
                             .addToHistory("app://" + packageName + "/" + className);
                 }
             }
+        }
 
         if ("android.intent.action.PACKAGE_REMOVED".equals(intent.getAction())) {
             // Removed all installed shortcuts
             String packageName = intent.getData().getSchemeSpecificPart();
+
             KissApplication.getDataHandler(ctx).removeShortcuts(packageName);
         }
-        
+
         KissApplication.resetIconsHandler(ctx);
-        
+
         // Reload application list
         final AppProvider provider = KissApplication.getDataHandler(ctx).getAppProvider();
-        if(provider != null) {
+        if (provider != null) {
             provider.reload();
         }
 

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -104,8 +104,6 @@ public class AppResult extends Result {
                 return true;
             case R.id.item_app_uninstall:
                 launchUninstall(context, appPojo);
-                // Also remove item, since it will be uninstalled
-                parent.removeResult(this);
                 return true;
             case R.id.item_app_hibernate:
                 hibernate(context, appPojo);


### PR DESCRIPTION
Don't remove app result in "Uninstall" menu handler. The entry will be removed once the uninstall succeeds (see the appropiate BroadcastReceiver). #459 

I also renamed the "NewAppInstalledHandler" to "PackageAddedRemovedHandler" (since it listens for package add and remove events).