### PR TITLE
Dinamically reload contacts

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
@@ -2,6 +2,8 @@ package fr.neamar.kiss.dataprovider;
 
 import java.util.ArrayList;
 
+import android.database.ContentObserver;
+import android.provider.ContactsContract;
 import fr.neamar.kiss.loader.LoadContactsPojos;
 import fr.neamar.kiss.normalizer.PhoneNormalizer;
 import fr.neamar.kiss.normalizer.StringNormalizer;
@@ -9,10 +11,34 @@ import fr.neamar.kiss.pojo.ContactsPojo;
 import fr.neamar.kiss.pojo.Pojo;
 
 public class ContactsProvider extends Provider<ContactsPojo> {
+    
+    private ContentObserver cObserver = new ContentObserver(null) {
+
+        @Override
+        public void onChange(boolean selfChange) {
+            //reload contacts
+            reload();
+        }        
+        
+    };
 
     @Override
     public void reload() {
         this.initialize(new LoadContactsPojos(this));
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        //register content observer
+        getContentResolver().registerContentObserver(ContactsContract.Contacts.CONTENT_URI, false, cObserver);
+    }    
+
+    @Override
+    public void onDestroy() {        
+        super.onDestroy();
+        //deregister content observer
+        getContentResolver().unregisterContentObserver(cObserver);
     }
 
     public ArrayList<Pojo> getResults(String query) {


### PR DESCRIPTION
Hi,

this is my attempt to fix annoying bug that prevent ContactProvider to refresh itself when user add/delete/update a phone contact.
I've used a custom ContentObserver that is activated when something is changed on the internal database of contacts.

Unfortunately this mean that also when someone call (android refresh contact with timestamp of the last call) all contacts are reloaded.
For me this is more reasonable than restart kiss or deactivate/reactivate contact provider when I add someone to my phone book :)

Cheers.