### PR TITLE
Add App Switch Mode to resolve #471

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,9 @@
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <!-- To autorotation toggle -->
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <!-- To allow app switching - for apps that do not resume properly -->
+    <uses-permission android:name="android.permission.GET_TASKS" />
+    <uses-permission android:name="android.permission.REORDER_TASKS" />
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/app/src/main/java/fr/neamar/kiss/preference/AppSwitcherModePreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/AppSwitcherModePreference.java
@@ -1,0 +1,15 @@
+package fr.neamar.kiss.preference;
+
+import android.content.Context;
+import android.preference.CheckBoxPreference;
+import android.util.AttributeSet;
+
+import fr.neamar.kiss.R;
+
+
+public class AppSwitcherModePreference extends CheckBoxPreference {
+
+    public AppSwitcherModePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+}

--- a/app/src/main/java/fr/neamar/kiss/preference/AppSwitcherModeSwitch.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/AppSwitcherModeSwitch.java
@@ -1,0 +1,23 @@
+package fr.neamar.kiss.preference;
+
+import android.content.Context;
+import android.preference.SwitchPreference;
+import android.util.AttributeSet;
+
+import fr.neamar.kiss.R;
+
+
+public class AppSwitcherModeSwitch extends SwitchPreference {
+
+    public AppSwitcherModeSwitch(Context context) {
+        this(context, null);
+    }
+
+    public AppSwitcherModeSwitch(Context context, AttributeSet attrs) {
+        this(context, attrs, android.R.attr.switchPreferenceStyle);
+    }
+
+    public AppSwitcherModeSwitch(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
     <string name="search_providers_title">Select web search providers</string>
     <string name="history_mode_name">History mode</string>
     <string name="history_mode_desc">Select the way that the history is populated</string>
+    <string name="app_switcher_mode_desc">Useful for apps that do not resume properly</string>
+    <string name="app_switcher_mode_name">App Switcher mode</string>
     <string name="root_mode_desc">If available use it to hibernate applications</string>
     <string name="root_mode_name">Root mode</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -114,6 +114,11 @@
             android:defaultValue="false"
             android:key="freeze-history"
             android:title="@string/freeze_history_name" />
+        <fr.neamar.kiss.preference.AppSwitcherModePreference
+            android:defaultValue="false"
+            android:key="app-switcher-mode"
+            android:summary="@string/app_switcher_mode_desc"
+            android:title="@string/app_switcher_mode_name" />
         <fr.neamar.kiss.preference.RootModePreference
             android:defaultValue="false"
             android:key="root-mode"

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -114,6 +114,11 @@
             android:defaultValue="false"
             android:key="freeze-history"
             android:title="@string/freeze_history_name" />
+        <fr.neamar.kiss.preference.AppSwitcherModeSwitch
+            android:defaultValue="false"
+            android:key="app-switcher-mode"
+            android:summary="@string/app_switcher_mode_desc"
+            android:title="@string/app_switcher_mode_name" />
         <fr.neamar.kiss.preference.RootModeSwitch
             android:defaultValue="false"
             android:key="root-mode"


### PR DESCRIPTION
Adds ability to re-order tasks to bring running apps to the front. Useful for some apps that do not resume correctly and just go back to main activity when switched to using the normal intent way that most launchers use.
