### PR TITLE
Integration of Developer Settings, Accessibility and Memory

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/loader/LoadSettingsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadSettingsPojos.java
@@ -30,6 +30,10 @@ public class LoadSettingsPojos extends LoadPojos<SettingsPojo> {
                 Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS, R.drawable.setting_apps));
         settings.add(createPojo(context.getString(R.string.settings_connectivity),
                 Settings.ACTION_WIRELESS_SETTINGS, R.drawable.toggle_wifi));
+		        settings.add(createPojo(context.getString(R.string.settings_storage),
+		                Settings.ACTION_INTERNAL_STORAGE_SETTINGS, R.drawable.setting_info));
+        		settings.add(createPojo(context.getString(R.string.settings_accessibility),
+		                Settings.ACTION_ACCESSIBILITY_SETTINGS, R.drawable.setting_info));
         settings.add(createPojo(context.getString(R.string.settings_battery),
                 Intent.ACTION_POWER_USAGE_SUMMARY, R.drawable.setting_battery));
         settings.add(createPojo(context.getString(R.string.settings_tethering), "com.android.settings",
@@ -40,6 +44,10 @@ public class LoadSettingsPojos extends LoadPojos<SettingsPojo> {
                         Settings.ACTION_NFC_SETTINGS, R.drawable.setting_nfc));
             }
         }
+        		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+			            settings.add(createPojo(context.getString(R.string.settings_dev),
+			                    Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS, R.drawable.setting_info));
+		        }
         return settings;
     }
 

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -24,5 +24,13 @@
         <item>alphabetical</item>
         <item>invertedAlphabetical</item>
     </string-array>
+ <string-array name="historyModeEntries">
+		  <item>Più recente per primo</item>
+		  <item>Più utilizzato per primo</item>
+	 </string-array>
+	 <string-array name="historyModeValues">
+		  <item>recency</item>
+  		<item>frecency</item>
+ 	</string-array>
 </resources>
 

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -24,13 +24,13 @@
         <item>alphabetical</item>
         <item>invertedAlphabetical</item>
     </string-array>
- <string-array name="historyModeEntries">
-		  <item>Più recente per primo</item>
-		  <item>Più utilizzato per primo</item>
-	 </string-array>
-	 <string-array name="historyModeValues">
-		  <item>recency</item>
-  		<item>frecency</item>
- 	</string-array>
+    <string-array name="historyModeEntries">
+		        <item>Più recente per primo</item>
+		        <item>Più utilizzato per primo</item>
+	    </string-array>
+   	 <string-array name="historyModeValues">
+		        <item>recency</item>
+        		<item>frecency</item>
+    	</string-array>
 </resources>
 

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -25,12 +25,11 @@
         <item>invertedAlphabetical</item>
     </string-array>
     <string-array name="historyModeEntries">
-		        <item>Più recente per primo</item>
-		        <item>Più utilizzato per primo</item>
-	    </string-array>
-   	 <string-array name="historyModeValues">
-		        <item>recency</item>
-        		<item>frecency</item>
-    	</string-array>
+    	<item>Più recente per primo</item>
+    	<item>Più utilizzato per primo</item>
+    </string-array>
+    <string-array name="historyModeValues">
+    	<item>recency</item>
+    	<item>frecency</item>
+    </string-array>
 </resources>
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,9 @@
     <string name="settings_battery">Battery</string>
     <string name="settings_nfc">NFC</string>
     <string name="settings_tethering">Tethering</string>
+    <string name="settings_storage">Storage</string>
+	    <string name="settings_dev">Developer settings</string>
+	    <string name="settings_accessibility">Accessibility</string>
     <string name="toggle_wifi">Wifi</string>
     <string name="toggle_bluetooth">Bluetooth</string>
     <string name="toggle_silent">Silent</string>


### PR DESCRIPTION
I saw somewhat practical to integrate those three settings into the results that can be displayed when searching for settings.

The only thing I don't have, are appropriate drawables, so, for now, I used the simple settings_info. Sorry for the weird indentation, but this is my first time fiddling with GitHub.