### PR TITLE
Added missing translations

### DIFF
--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -24,5 +24,12 @@
         <item>alphabetical</item>
         <item>invertedAlphabetical</item>
     </string-array>
+    <string-array name="historyModeEntries">
+    	<item>Più recente per primo</item>
+    	<item>Più utilizzato per primo</item>
+    </string-array>
+    <string-array name="historyModeValues">
+    	<item>recency</item>
+    	<item>frecency</item>
+    </string-array>
 </resources>
-


### PR DESCRIPTION
This version of the arrays.xml covers some missing translations which concerned the History popularization setting of KISS.

Any weird indentation is due to GitHub's magistral disinterest in the existence of devs working from mobile. If anyone can fix that, I'll deeply appreciate.