### PR TITLE
fixing KISS listed as app

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -369,7 +369,7 @@ public class DataHandler extends BroadcastReceiver
 
     public void removeFromExcluded(String packageName) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this.context);
-        String excluded = prefs.getString("excluded-apps-list", "");
+        String excluded = prefs.getString("excluded-apps-list", context.getPackageName() + ";");
         prefs.edit().putString("excluded-apps-list", excluded.replaceAll(packageName + ";", "")).apply();
     }
 


### PR DESCRIPTION
I am fixing a bug in my commit [here](https://github.com/Neamar/KISS/pull/492/files#diff-6b03b81542bb53162d59723d31286d9cR360), 

As mentioned in #501 , Kiss could be visible in the application list but under the following assumptions:
- Your excluded list app is not set (new KISS installation)
- You have uninstalled an app (any app)

Edit:
Let me explain one more time how this bug works.
If a user has never excluded any app through KISS and used the 2.24.1 version, then the moment that he uninstalls an app (any app) then KISS will be visible in the application list.
To fix that he would have to manually exclude KISS from the application list. 
That would insert KISS package back in the excluded app list setting
