### PR TITLE
Make KISS Launcher properly disable soft-keyboard suggestions by default

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -65,15 +65,23 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     public static final String LOAD_OVER = "fr.neamar.summon.LOAD_OVER";
     public static final String FULL_LOAD_OVER = "fr.neamar.summon.FULL_LOAD_OVER";
     /**
-     * InputType with spellcheck and swiping
+     * InputType that behaves as if the consuming IME is a standard-obeying
+     * soft-keyboard
+     *
+     * *Auto Complete* means "we're handling auto-completion ourselves". Then
+     * we ignore whatever the IME thinks we should display.
      */
-    private final static int SPELLCHECK_ENABLED_INPUT_TYPE = InputType.TYPE_CLASS_TEXT |
-            InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
+    private final static int INPUT_TYPE_STANDARD = InputType.TYPE_CLASS_TEXT
+            | InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE
+            | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
     /**
-     * default InputType
+     * InputType that behaves as if the consuming IME is SwiftKey
+     *
+     * *Visible Password* fields will break many non-Latin IMEs and may show
+     * unexpected behaviour in numerous ways. (#454, #517)
      */
-    private final static int DEFAULT_INPUT_TYPE = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD |
-            InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+    private final static int INPUT_TYPE_WORKAROUND = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+            | InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
     /**
      * IDs for the favorites buttons
      */
@@ -106,7 +114,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     /**
      * Whether or not Search text should be spell checked (affects inputType)
      */
-    private boolean searchEditTextSpellcheck;
+    private boolean searchEditTextWorkaround;
     /**
      * Main list view
      */
@@ -287,7 +295,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.hider.start();
 
         // Check whether user enabled spell check and adjust input type accordingly
-        searchEditTextSpellcheck = prefs.getBoolean("enable-spellcheck", false);
+        searchEditTextWorkaround = prefs.getBoolean("enable-keyboard-workaround", false);
         adjustInputType(null);
 
         //enable/disable phone/sms broadcast receiver
@@ -307,10 +315,10 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
         if (currentText != null && Pattern.matches("[+]\\d+", currentText)) {
             requiredInputType = InputType.TYPE_CLASS_PHONE;
-        } else if (searchEditTextSpellcheck) {
-            requiredInputType = SPELLCHECK_ENABLED_INPUT_TYPE;
+        } else if (searchEditTextWorkaround) {
+            requiredInputType = INPUT_TYPE_WORKAROUND;
         } else {
-            requiredInputType = DEFAULT_INPUT_TYPE;
+            requiredInputType = INPUT_TYPE_STANDARD;
         }
         if (currentInputType != requiredInputType) {
             searchEditText.setInputType(requiredInputType);

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -27,7 +27,7 @@ public class SettingsActivity extends PreferenceActivity implements
         SharedPreferences.OnSharedPreferenceChangeListener {
 
     // Those settings require the app to restart
-    final static private String requireRestartSettings = "theme enable-spellcheck force-portrait";
+    final static private String requireRestartSettings = "theme enable-keyboard-workaround force-portrait";
 
     private SharedPreferences prefs;
 

--- a/app/src/main/res/values-ar-rAR/strings.xml
+++ b/app/src/main/res/values-ar-rAR/strings.xml
@@ -56,7 +56,6 @@
     <string name="reset_favorites_name">المفضلة إعادة تعيين</string>
     <string name="reset_favorites_warn">هل تريد حقا أن إعادة المفضلة لديك؟</string>
     <string name="keyboard_name">لوحة المفاتيح عرض</string>
-    <string name="spellcheck_name">تمكين التدقيق الإملائي</string>
     <string name="history_hide_desc">إخفاء التاريخ وشاشة مقدمات</string>
     <string name="history_hide_name">واجهة أضيق الحدود</string>
     <string name="history_onclick_name">واجهة أضيق الحدود: عرض التاريخ على اتصال</string>

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -71,7 +71,6 @@
 
     <string name="reset_name">Reanicia la to historia de KISS</string>
     <string name="keyboard_name">Amosar tecláu nel aniciu</string>
-    <string name="spellcheck_name">Habilitar comprobación ortográfica</string>
     <string name="portrait_title">Forciar mou vertical</string>
     <string name="root_mode_desc">Si ta disponible, úsalu pa hibernar aplicaciones</string>
     <string name="alias_phone">marcar,llamar,llamada,teléfonu,marcáu,telefonazu,telefonada</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -85,7 +85,6 @@
 
     <string name="toast_hibernate_completed">%s yuxu rejimine alındı, oyandırmaq üçün yenidən açın.</string>
     <string name="toast_hibernate_error">%s yuxu rejimine alınamadı.</string>
-    <string name="spellcheck_name">İmla yoxlamasını aktivləşdir</string>
     <string name="portrait_title">Dikey rejimi zorla</string>
     <string name="toggle_sync">Sinxronizasiya</string>
     <string name="menu_phone_create">Kontakt yarat</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -86,7 +86,8 @@
     <string name="menu_contact_copy_phone">Telefonnummer kopieren</string>
     <string name="menu_app_hibernate">Schlafenlegen</string>
 
-    <string name="spellcheck_name">Rechtschreibprüfung aktivieren</string>
+    <string name="keyboard_workaround_name">Abhilfe gegen Tastatur-Vorschläge</string>
+    <string name="keyboard_workaround_desc">Kaputte Soft-Tastaturen (wie SwiftKey™) zwingen keine Vorschläge anzuzeigen</string>
 
     <string name="portrait_title">Hochformat erzwingen</string>
 
@@ -148,8 +149,7 @@
     <string name="ui_excluded_apps_dialog_title">Apps abwählen, die nicht mehr ausgeblendet werden sollen</string>
     <string name="freeze_history_warn">Sind Sich sicher, dass Sie den Verlauf einfrieren und keine zukünftigen Änderungen zulassen wollen? Der Verlauf wird sich nicht mehr ändern.</string>
 
-<string name="history_mode_name">Sortiermodus</string>
+    <string name="history_mode_name">Sortiermodus</string>
     <string name="history_mode_desc">Festlegen wie Einträge im Verlauf sortiert werden</string>
     <string name="menu_shortcut_remove">Verknüpfung entfernen</string>
-
-    </resources>
+</resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -88,7 +88,6 @@
     <string name="reset_warn">Θέλετε πραγματικά να διαγραψετε το ιστορικό σας;</string>
     <string name="reset_favorites_name">Διαγραφή τη λίστας αγαπημένων</string>
     <string name="reset_favorites_warn">Θέλετε πραγματικά να διαγράψετε τα αγαπημένα σας;</string>
-    <string name="spellcheck_name">Ενεργοποίηση ορθογραφικού ελέγχου</string>
     <string name="history_hide_desc">Απόκρυψη ιστορικού και αρχικής οθόνης</string>
     <string name="history_hide_name">Μινιμαλιστική διεπαφή</string>
     <string name="history_onclick_name">Μινιμαλιστική διεπαφή: Εμφάνιση ιστορικού μέσω αφής</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,7 +55,6 @@
     <string name="reset_favorites_name">Restablecer la lista de favoritos</string>
     <string name="reset_favorites_warn">¿Seguro que quieres resetear tus favoritos?</string>
     <string name="keyboard_name">Mostrar teclado al iniciar</string>
-    <string name="spellcheck_name">Activar corrector</string>
     <string name="history_hide_desc">Ocultar historial y la pantalla de inicio</string>
     <string name="history_hide_name">Interfaz minimalista</string>
     <string name="history_onclick_name">Interfaz minimalista: Mostrar historial al tocar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -46,7 +46,6 @@
     <string name="main_kiss_back">Afficher l\'historique</string>
     <string name="reset_name">Vider l\'historique de KISS</string>
     <string name="keyboard_name">Afficher le clavier au démarrage</string>
-    <string name="spellcheck_name">Activer la vérification orthographique</string>
 
     <string name="alias_phone">téléphone,numéroteur,composeur,appeler</string>
     <string name="alias_contacts">contacts,personnes,relations</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -46,7 +46,6 @@
     <string name="main_kiss_back">Amosa o historial</string>
     <string name="reset_name">Restablece o historial</string>
     <string name="keyboard_name">Amosar teclado</string>
-    <string name="spellcheck_name">Activar corrector</string>
     <string name="history_hide_desc">Ocultar historial e pantalla de inicio</string>
     <string name="history_hide_name">Interface minimalista</string>
     <string name="portrait_title">Forcar modo vertical</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -47,7 +47,6 @@
     <string name="main_kiss_back">Pokaži povjest</string>
     <string name="reset_name">Resetiraj povjest</string>
     <string name="keyboard_name">Pokaži tipkovnicu</string>
-    <string name="spellcheck_name">Omogući provjeru pravopisa</string>
     <string name="root_mode_desc">Omogući root značajke ako su moguće (hiberniranje aplikacija)</string>
     <string name="root_mode_name">Root način rada</string>
     <string name="root_mode_error">Nemoguće dobiti root privilegije.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -75,7 +75,6 @@
     <string name="aliases_name">Álnevek</string>
 
     <string name="title_advanced">Haladó beállítások</string>
-    <string name="spellcheck_name">Helyesírás-ellenőrző engedélyezése</string>
     <string name="root_mode_desc">Ha elérhető, használja az app-ok hibernálásához</string>
     <string name="root_mode_name">Root mód</string>
     <string name="root_mode_error">Nem sikerült root jogot szerezni.</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -50,7 +50,6 @@
     <string name="reset_favorites_name">Hapus daftar favorit anda</string>
     <string name="reset_favorites_warn">Anda benar-benar ingin menghapus favorit anda?</string>
     <string name="keyboard_name">Tampilkan papan ketik ketika memulai</string>
-    <string name="spellcheck_name">Aktifkan pemeriksa ejaan</string>
     <string name="history_hide_desc">Sembunyikan riwayat dan layar pengantar</string>
     <string name="history_hide_name">UI Minimalistik</string>
     <string name="history_onclick_name">UI Minimalistik: Tampilkan riwayat saat menyentuh</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -92,7 +92,6 @@
     <string name="theme_name">Tema</string>
     <string name="menu_phone_create">Crea contatto</string>
 
-    <string name="spellcheck_name">Abilita correttore ortografico</string>
     <string name="history_hide_desc">Nascondi la cronologia e la schermata introduttiva</string>
     <string name="history_hide_name">Interfaccia minimale</string>
     <string name="history_onclick_name">Interfaccia minimale: mostra la cronologia al tocco</string>
@@ -132,7 +131,7 @@
 
     <string name="items_title">%d elementi</string>
 
-    <string name="search_desc">Abilita la ricerca tramite Google, DuckDuckGo, Bing, etc.</string>
+    <string name="search_desc">Abilita la ricerca tramite Google, DuckDuckGo, Bing, …</string>
     <string name="ui_excluded_apps">Elenca o modifica le app escluse</string>
     <string name="ui_excluded_apps_dialog_title">Deseleziona le app che intendi includere</string>
     <string name="ui_excluded_apps_not_found">Nessuna app è stata esclusa</string>
@@ -147,7 +146,4 @@
     <string name="enable_favorites_bar">Mostra i preferiti sopra la barra di ricerca</string>
     <string name="exclude_favorites">Escludi i preferiti dalla cronologia</string>
     <string name="favorites_hide">Interfaccia minimale: nascondi preferiti</string>
-<string name="settings_accessibility">Accessibilità</string>
-    <string name="settings_storage">Archiviazione</string>
-    <string name="settings_dev">Opzioni sviluppatore</string>
-    </resources>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -84,7 +84,6 @@
     <string name="menu_contact_copy_phone">電話番号をコピー</string>
     <string name="theme_name">テーマインターフェイス</string>
 
-    <string name="spellcheck_name">スペルチェックを有効にする</string>
     <string name="toggle_sync">同期</string>
     <string name="portrait_title">強制的に縦向き</string>
     <string name="menu_phone_create">連絡先を作成</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -40,7 +40,6 @@
     <string name="main_kiss_back">Vis historikk</string>
     <string name="reset_name">Tøm din KISS-historikk</string>
     <string name="keyboard_name">Vis tastatur ved oppstart</string>
-    <string name="spellcheck_name">Aktiver stavekontroll</string>
     <string name="history_hide_desc">Skjul historikk og startskjerm</string>
     <string name="history_hide_name">Minimalistisk grensesnitt</string>
     <string name="history_onclick_name">Minimalistisk grensesnitt: Vis historikk ved trykk</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -77,7 +77,6 @@
     <string name="theme_name">Thema</string>
 
     <string name="title_advanced">Geavanceerde instellingen</string>
-    <string name="spellcheck_name">Schakel spellingscontrole in</string>
     <string name="root_mode_name">Root modus</string>
     <string name="root_mode_error">Het lukte niet om root toegang te krijgen.</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -46,7 +46,6 @@
     <string name="main_kiss_back">Wyświetl historię</string>
     <string name="reset_name">Zresetuj historię</string>
     <string name="keyboard_name">Wyświetl klawiaturę</string>
-    <string name="spellcheck_name">Włącz sprawdzanie pisowni</string>
     <string name="root_mode_name">Tryb root</string>
     <string name="root_mode_error">Nie można uzyskać przywilejów root.</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -29,7 +29,6 @@
     <string name="stub_phone">Ligar +330 12 34 56 78</string>
     <string name="main_menu">Menu</string>
     <string name="main_clear">Limpar campo de pesquisa</string>
-    <string name="spellcheck_name">Habilitar verificação ortográfica</string>
     <string name="history_hide_desc">Ocultar histórico na tela inicial</string>
     <string name="history_hide_name">Interface minimalista</string>
     <string name="history_onclick_name">Interface minimalista: Mostrar histórico ao clicar</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -55,7 +55,6 @@
     <string name="reset_favorites_name">Curata lista de favorite</string>
     <string name="reset_favorites_warn">Chiar doriti curatarea favoritelor?</string>
     <string name="keyboard_name">Arata tastatura la deschidere</string>
-    <string name="spellcheck_name">Activeaza verificarea ortografica</string>
     <string name="history_hide_desc">Ascunde istoricul si ecranul initial</string>
     <string name="history_hide_name">Interfata minima</string>
     <string name="history_onclick_name">Interfata minima: Arata istoric la atingere</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -85,7 +85,6 @@
 
     <string name="toast_hibernate_completed">%s гибернация успешна, перезапустите приложение для пробуждения.</string>
     <string name="toast_hibernate_error">%s гибернация не успешна.</string>
-    <string name="spellcheck_name">Включить проверку орфографии</string>
     <string name="toggle_sync">Синхронизация</string>
     <string name="portrait_title">Использовать портретный режим</string>
     <string name="menu_phone_create">Создать контакт</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -46,7 +46,6 @@
     <string name="main_kiss_back">Приказуј историјат</string>
     <string name="reset_name">Ресетуј историјат</string>
     <string name="keyboard_name">Приказуј тастатуру по покретању</string>
-    <string name="spellcheck_name">Омогући проверу правописа</string>
 
     <string name="alias_phone">dial,biraj,zovi,pozovi,šalji,poruka,telefon,бирај,зови,позови,шаљи,порука,телефон</string>
     <string name="alias_contacts">kontakt,ljudi,osobe,контакт,људи,особе</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -85,7 +85,6 @@
 
     <string name="toast_hibernate_completed">%s uyku kipine alındı, uyandırmak için yeniden açın.</string>
     <string name="toast_hibernate_error">%s uyku kipine alınamadı.</string>
-    <string name="spellcheck_name">Yazım denetimini etkinleştir</string>
     <string name="toggle_sync">Eşitleme</string>
     <string name="portrait_title">Dikey kipi zorla</string>
     <string name="menu_phone_create">Kişi oluştur</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -56,7 +56,6 @@
     <string name="reset_favorites_name">重置您的收藏列表</string>
     <string name="reset_favorites_warn">您确定要重置您的收藏？</string>
     <string name="keyboard_name">启动时显示键盘</string>
-    <string name="spellcheck_name">启用拼写检查</string>
     <string name="history_hide_desc">隐藏历史记录和介绍画面</string>
     <string name="history_hide_name">简约界面</string>
     <string name="history_onclick_name">简约界面：触摸时显示历史记录</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,8 @@
     <string name="reset_favorites_name">Reset your list of favorites</string>
     <string name="reset_favorites_warn">Do you really want to reset your favorites?</string>
     <string name="keyboard_name">Display keyboard on start</string>
-    <string name="spellcheck_name">Enable spellcheck</string>
+    <string name="keyboard_workaround_name">Keyboard suggestions workaround</string>
+    <string name="keyboard_workaround_desc">Prevent broken soft-keyboards (like SwiftKey™) from showing suggestions</string>
     <string name="history_hide_desc">Hide history and intro screen</string>
     <string name="history_hide_name">Minimalistic UI</string>
     <string name="history_onclick_name">Minimalistic UI: Show history on touch</string>

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -62,8 +62,9 @@
             android:title="@string/keyboard_name" />
         <fr.neamar.kiss.SwitchPreference
             android:defaultValue="false"
-            android:key="enable-spellcheck"
-            android:title="@string/spellcheck_name" />
+            android:key="enable-keyboard-workaround"
+            android:summary="@string/keyboard_workaround_desc"
+            android:title="@string/keyboard_workaround_name" />
         <fr.neamar.kiss.SwitchPreference
             android:defaultValue="false"
             android:key="history-hide"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -62,8 +62,9 @@
             android:title="@string/keyboard_name" />
         <CheckBoxPreference
             android:defaultValue="false"
-            android:key="enable-spellcheck"
-            android:title="@string/spellcheck_name" />
+            android:key="enable-keyboard-workaround"
+            android:summary="@string/keyboard_workaround_desc"
+            android:title="@string/keyboard_workaround_name" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="history-hide"


### PR DESCRIPTION
There is also a (new) workaround mode in settings, that will use a "visible password" field to get the old (SwiftKey-compatible) behavior back.

See issues #454 and #517.