### PR TITLE
Issue #540 - Landline detection isn't working.

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
@@ -89,7 +89,7 @@ public class PhoneNormalizer {
                 String simCountryIso = manager.getSimCountryIso();
                 //Log.d("COUNTRY", "SIM: " + simCountryIso);
                 if (!TextUtils.isEmpty(simCountryIso))
-                    return simCountryIso;
+                    return simCountryIso.toUpperCase();
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
@@ -97,7 +97,7 @@ public class PhoneNormalizer {
                 String networkCountryIso = manager.getNetworkCountryIso();
                 //Log.d("COUNTRY", "NET: " + networkCountryIso);
                 if (!TextUtils.isEmpty(networkCountryIso))
-                    return networkCountryIso;
+                    return networkCountryIso.toUpperCase();
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -92,12 +92,9 @@ public class ContactsResult extends Result {
                 }
             });
 
-            /*
-            Temporary disabled, see https://github.com/Neamar/KISS/issues/540
             if (contactPojo.homeNumber)
                 messageButton.setVisibility(View.INVISIBLE);
             else
-            */
                 messageButton.setVisibility(View.VISIBLE);
 
         } else {


### PR DESCRIPTION
Detection might not have been working due to the usage of a lowercase country iso code. Fixed by uppercasing sim country iso and network country iso value returned by telephonymanager.