### PR TITLE
Emulate the back btn when pressing the home btn

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -460,6 +460,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         // This is called when the user press Home again while already browsing MainActivity
         // onResume() will be called right after, hiding the kissbar if any.
         // http://developer.android.com/reference/android/app/Activity.html#onNewIntent(android.content.Intent)
+        onBackPressed();
+        hideKeyboard(); // Doesn't actually seem to work right now, but if it every does lets leave it ere
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -461,7 +461,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         // onResume() will be called right after, hiding the kissbar if any.
         // http://developer.android.com/reference/android/app/Activity.html#onNewIntent(android.content.Intent)
         onBackPressed();
-        hideKeyboard(); // Doesn't actually seem to work right now, but if it every does lets leave it ere
+        hideKeyboard(); // Hiding the keyboard depends on the value from the setting "display keyboard on app open"
     }
 
     @Override


### PR DESCRIPTION
The home button currently does nothing.

User expect the home button to be a system button that restores you to the launcher with all settings cleared ready to start again.

Currently the back button does this, so calling back from home works as intended.

ps: (ignore the other commit in here, i suspect it will be merged in the other PR - Sorry @Neamar)