### PR TITLE
Don't show history list when clicking favorites

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -566,19 +566,15 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     }
 
     public void onFavoriteButtonClicked(View favorite) {
-
+        // The bar is shown due to dispatchTouchEvent, hide it again to stop the bad ux.
+        displayKissBar(false);
+        
         // Favorites handling
         Pojo pojo = KissApplication.getDataHandler(MainActivity.this).getFavorites(tryToRetrieve)
                 .get(Integer.parseInt((String) favorite.getTag()));
         final Result result = Result.fromPojo(MainActivity.this, pojo);
 
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                result.fastLaunch(MainActivity.this);
-            }
-        }, KissApplication.TOUCH_DELAY);
+        result.fastLaunch(MainActivity.this);
     }
 
     private void displayClearOnInput() {


### PR DESCRIPTION
As the list is triggered before this function, we have to hide it again.
Originally we had a handler running instantly, this way we just load the app instantly instead.