### PR TITLE
Issue #550

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import fr.neamar.kiss.R;
 
@@ -48,9 +50,10 @@ public class PhoneNormalizer {
         if (input.startsWith("+")) return input;
 
         if (prefixEntry != null) {
-            if (prefixEntry.international_prefix_pattern.length() > 0 &&
-                    input.matches(prefixEntry.international_prefix_pattern)) {
-                return "+" + input.replaceFirst(prefixEntry.international_prefix_pattern, "");
+            if (prefixEntry.international_prefix_pattern.length() > 0) {
+                Matcher m = Pattern.compile(prefixEntry.international_prefix_pattern).matcher(input);
+                if (m.lookingAt())
+                    return "+" + m.replaceFirst("");
             }
             if (prefixEntry.national_prefix.length() > 0 && input.startsWith(prefixEntry.national_prefix)) {
                 return "+" + prefixEntry.ptsn_country_code + input.substring(prefixEntry.national_prefix.length());

--- a/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
@@ -18,13 +18,16 @@ import java.util.regex.Pattern;
 import fr.neamar.kiss.R;
 
 public class PhoneNormalizer {
-    static PhoneNormalizer instance;
-    private final PrefixEntry prefixEntry;
+    private static PhoneNormalizer instance;
     private final String countryIso;
+    private final Pattern internationalPrefixPattern;
+    private final PrefixEntry prefixEntry;
 
     private PhoneNormalizer(Context context) {
         countryIso = determineCountryIso(context);
         prefixEntry = loadPrefixEntry(context, countryIso);
+        internationalPrefixPattern = prefixEntry != null && !prefixEntry.international_prefix_pattern.isEmpty() ?
+                Pattern.compile(prefixEntry.international_prefix_pattern) : null;
     }
 
     public static void initialize(Context context) {
@@ -50,8 +53,8 @@ public class PhoneNormalizer {
         if (input.startsWith("+")) return input;
 
         if (prefixEntry != null) {
-            if (prefixEntry.international_prefix_pattern.length() > 0) {
-                Matcher m = Pattern.compile(prefixEntry.international_prefix_pattern).matcher(input);
+            if (internationalPrefixPattern != null) {
+                Matcher m = internationalPrefixPattern.matcher(input);
                 if (m.lookingAt())
                     return "+" + m.replaceFirst("");
             }
@@ -110,10 +113,10 @@ public class PhoneNormalizer {
     }
 
     private class PrefixEntry {
-        public String iso_country_code;
-        public String ptsn_country_code;
         public String international_prefix_pattern;
+        public String iso_country_code;
         public String national_prefix;
+        public String ptsn_country_code;
 
         public PrefixEntry(String iso_country_code, String ptsn_country_code,
                            String international_prefix_pattern, String national_prefix) {


### PR DESCRIPTION
This should fix issue #550.

Matching the international prefix was not working properly. Numbers starting with the international prefix were therefor handled as if they were starting with the national prefix.

The sample input number in the ticket was something like "00431234123412". The international prefix for austria is "00". The old implementation was trying to match this with "00431234123412".matches("00"). However this would return true if the whole string was matching (which is not the case). I changed this to using a [matcher](https://developer.android.com/reference/java/util/regex/Matcher.html) and its [lookingAt](https://developer.android.com/reference/java/util/regex/Matcher.html#lookingAt()) method, which returns true if the pattern matches parts of the input string.