### PR TITLE
Add a remove fav to results menu

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -422,6 +422,8 @@ public class DataHandler extends BroadcastReceiver
 
         String favApps = PreferenceManager.getDefaultSharedPreferences(context).
                 getString("favorite-apps-list", "");
+
+        // Check if we are already a fav icon
         if (favApps.contains(id + ";")) {
             //shouldn't happen
             return false;
@@ -433,6 +435,25 @@ public class DataHandler extends BroadcastReceiver
         }
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString("favorite-apps-list", favApps + id + ";").commit();
+
+        context.retrieveFavorites();
+
+        return true;
+    }
+
+    public boolean removeFromFavorites(MainActivity context, String id) {
+
+        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
+                getString("favorite-apps-list", "");
+
+        // Check if we are not already a fav icon
+        if (!favApps.contains(id + ";")) {
+            //shouldn't happen
+            return false;
+        }
+
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString("favorite-apps-list", favApps.replace(id + ";", "")).commit();
 
         context.retrieveFavorites();
 
@@ -462,20 +483,6 @@ public class DataHandler extends BroadcastReceiver
         }
 
         return null;
-    }
-
-    public void removeFromFavorites(Pojo pojo, Context context) {
-        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
-                getString("favorite-apps-list", "");
-        if (!favApps.contains(pojo.id + ";")) {
-            return;
-        }
-
-        PreferenceManager.getDefaultSharedPreferences(context).edit()
-                .putString("favorite-apps-list", favApps.replace(pojo.id + ";", "")).commit();
-
-        ((MainActivity) context).retrieveFavorites();
-
     }
 
     protected class ProviderEntry {

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -21,6 +21,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import fr.neamar.kiss.KissApplication;
+import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.AppPojo;
@@ -125,7 +126,7 @@ public class AppResult extends Result {
                 .putString("excluded-apps-list", excludedAppList + appPojo.packageName + ";").commit();
         //remove app pojo from appProvider results - no need to reset handler
         KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
-        KissApplication.getDataHandler(context).removeFromFavorites(appPojo, context);
+        KissApplication.getDataHandler(context).removeFromFavorites((MainActivity) context, appPojo.id);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
 
     }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -101,10 +101,13 @@ public abstract class Result {
         menu.getMenuInflater().inflate(menuId, menu.getMenu());
 
         // If app already pinned, do not display the "add to favorite" option
+        // otherwise don't show the "remove favorite button"
         String favApps = PreferenceManager.getDefaultSharedPreferences(context).
                 getString("favorite-apps-list", "");
         if (favApps.contains(this.pojo.id + ";")) {
             menu.getMenu().removeItem(R.id.item_favorites_add);
+        } else {
+            menu.getMenu().removeItem(R.id.item_favorites_remove);
         }
 
         return menu;
@@ -124,6 +127,9 @@ public abstract class Result {
             case R.id.item_favorites_add:
                 launchAddToFavorites(context, pojo);
                 break;
+            case R.id.item_favorites_remove:
+                launchRemoveFromFavorites(context, pojo);
+                break;
         }
 
         //Update Search to reflect favorite add, if the "exclude favorites" option is active
@@ -135,6 +141,12 @@ public abstract class Result {
     private void launchAddToFavorites(Context context, Pojo app) {
         String msg = context.getResources().getString(R.string.toast_favorites_added);
         KissApplication.getDataHandler(context).addToFavorites((MainActivity) context, app.id);
+        Toast.makeText(context, String.format(msg, app.name), Toast.LENGTH_SHORT).show();
+    }
+
+    private void launchRemoveFromFavorites(Context context, Pojo app) {
+        String msg = context.getResources().getString(R.string.toast_favorites_removed);
+        KissApplication.getDataHandler(context).removeFromFavorites((MainActivity) context, app.id);
         Toast.makeText(context, String.format(msg, app.name), Toast.LENGTH_SHORT).show();
     }
 

--- a/app/src/main/res/menu/menu_item_app.xml
+++ b/app/src/main/res/menu/menu_item_app.xml
@@ -13,6 +13,10 @@
         android:title="@string/menu_favorites_add" />
 
     <item
+        android:id="@+id/item_favorites_remove"
+        android:title="@string/menu_favorites_remove" />
+
+    <item
         android:id="@+id/item_app_details"
         android:title="@string/menu_app_details" />
 </menu>

--- a/app/src/main/res/menu/menu_item_contact.xml
+++ b/app/src/main/res/menu/menu_item_contact.xml
@@ -9,4 +9,7 @@
     <item
         android:id="@+id/item_favorites_add"
         android:title="@string/menu_favorites_add" />
+    <item
+        android:id="@+id/item_favorites_remove"
+        android:title="@string/menu_favorites_remove" />
 </menu>

--- a/app/src/main/res/menu/menu_item_default.xml
+++ b/app/src/main/res/menu/menu_item_default.xml
@@ -8,4 +8,8 @@
         android:id="@+id/item_favorites_add"
         android:title="@string/menu_favorites_add" />
 
+    <item
+        android:id="@+id/item_favorites_remove"
+        android:title="@string/menu_favorites_remove" />
+
 </menu>

--- a/app/src/main/res/menu/menu_item_phone.xml
+++ b/app/src/main/res/menu/menu_item_phone.xml
@@ -9,6 +9,10 @@
         android:title="@string/menu_favorites_add" />
 
     <item
+        android:id="@+id/item_favorites_remove"
+        android:title="@string/menu_favorites_remove" />
+
+    <item
         android:id="@+id/item_phone_createcontact"
         android:title="@string/menu_phone_create" />
 

--- a/app/src/main/res/menu/menu_item_shortcut.xml
+++ b/app/src/main/res/menu/menu_item_shortcut.xml
@@ -4,6 +4,9 @@
         android:id="@+id/item_favorites_add"
         android:title="@string/menu_favorites_add" />
     <item
+        android:id="@+id/item_favorites_remove"
+        android:title="@string/menu_favorites_remove" />
+    <item
         android:id="@+id/item_app_uninstall"
         android:title="@string/menu_shortcut_remove" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,5 +151,7 @@
     <string name="alternate_history_inputs">Alternate history inputs</string>
     <string name="keyboard_options">Keyboard options</string>
     <string name="misc">Misc</string>
+    <string name="toast_favorites_removed">%s was removed from favorites</string>
+    <string name="menu_favorites_remove">Remove favorite</string>
 
 </resources>


### PR DESCRIPTION
When long pressing on an item, you can just optionally remove that item instead of having to add a new set of favorites to reorder.

**Examples**
![image](https://cloud.githubusercontent.com/assets/1134201/21032007/8a350b32-bd9e-11e6-871d-b7bb02606ad5.png)

----

![image](https://cloud.githubusercontent.com/assets/1134201/21032008/909b65ac-bd9e-11e6-8680-80ae88912293.png)
