### PR TITLE
`LauncherApps` API and foreign-profile application support

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -31,6 +31,7 @@ import fr.neamar.kiss.db.ValuedHistoryRecord;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoComparator;
 import fr.neamar.kiss.pojo.ShortcutsPojo;
+import fr.neamar.kiss.utils.UserHandle;
 
 public class DataHandler extends BroadcastReceiver
         implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -357,14 +358,18 @@ public class DataHandler extends BroadcastReceiver
     }
 
 
-    public void addToExcluded(String packageName) {
+    public void addToExcluded(String packageName, UserHandle user) {
+		packageName = user.addUserSuffixToString(packageName, '#');
+		
         String excludedAppList = PreferenceManager.getDefaultSharedPreferences(context).
                 getString("excluded-apps-list", context.getPackageName() + ";");
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString("excluded-apps-list", excludedAppList + packageName + ";").apply();
     }
 
-    public void removeFromExcluded(String packageName) {
+    public void removeFromExcluded(String packageName, UserHandle user) {
+		packageName = user.addUserSuffixToString(packageName, '#');
+		
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this.context);
         String excluded = prefs.getString("excluded-apps-list", context.getPackageName() + ";");
         prefs.edit().putString("excluded-apps-list", excluded.replaceAll(packageName + ";", "")).apply();

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -375,6 +375,25 @@ public class DataHandler extends BroadcastReceiver
         prefs.edit().putString("excluded-apps-list", excluded.replaceAll(packageName + ";", "")).apply();
     }
 
+	public void removeFromExcluded(UserHandle user) {
+		// This is only intended for apps from foreign-profiles
+		if(user.isCurrentUser()) {
+			return;
+		}
+		
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this.context);
+		String[] excludedList = prefs.getString("excluded-apps-list", context.getPackageName() + ";").split(";");
+		
+		StringBuilder excluded = new StringBuilder();
+		for(String excludedItem : excludedList) {
+			if(!user.hasStringUserSuffix(excludedItem, '#')) {
+				excluded.append(excludedItem + ";");
+			}
+		}
+		
+		prefs.edit().putString("excluded-apps-list", excluded.toString()).apply();
+	}
+
     /**
      * Return all applications
      *
@@ -469,6 +488,26 @@ public class DataHandler extends BroadcastReceiver
 
         return true;
     }
+    
+	public void removeFromFavorites(UserHandle user) {
+		// This is only intended for apps from foreign-profiles
+		if(user.isCurrentUser()) {
+			return;
+		}
+		
+		String[] favAppList = PreferenceManager.getDefaultSharedPreferences(this.context)
+		                                       .getString("favorite-apps-list", "").split(";");
+		
+		StringBuilder favApps = new StringBuilder();
+		for(String favAppID : favAppList) {
+			if(!favAppID.startsWith("app://") || !user.hasStringUserSuffix(favAppID, '/')) {
+				favApps.append(favAppID + ";");
+			}
+		}
+		
+		PreferenceManager.getDefaultSharedPreferences(this.context).edit()
+		                 .putString("favorite-apps-list", favApps.toString()).apply();
+	}
 
     /**
      * Insert specified ID (probably a pojo.id) into history

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -281,7 +281,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 RecordAdapter adapter = ((RecordAdapter) list.getAdapter());
 
-                adapter.onClick(adapter.getCount() - 1, null);
+                adapter.onClick(adapter.getCount() - 1, v);
 
                 return true;
             }
@@ -573,7 +573,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         Pojo pojo = favorites.get(favNumber);
         final Result result = Result.fromPojo(MainActivity.this, pojo);
 
-        result.fastLaunch(MainActivity.this);
+        result.fastLaunch(MainActivity.this, favorite);
     }
 
     private void displayClearOnInput() {

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -37,7 +37,7 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
             }
         }
 
-        if ("android.intent.action.PACKAGE_REMOVED".equals(action)) {
+        if ("android.intent.action.PACKAGE_REMOVED".equals(action) && !replacing) {
             // Removed all installed shortcuts
             KissApplication.getDataHandler(ctx).removeShortcuts(packageName);
             KissApplication.getDataHandler(ctx).removeFromExcluded(packageName, user);

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -7,6 +7,7 @@ import android.preference.PreferenceManager;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.dataprovider.AppProvider;
+import fr.neamar.kiss.utils.UserHandle;
 
 /**
  * This class gets called when an application is created or removed on the
@@ -18,35 +19,28 @@ import fr.neamar.kiss.dataprovider.AppProvider;
  */
 public class PackageAddedRemovedHandler extends BroadcastReceiver {
 
-    @Override
-    public void onReceive(Context ctx, Intent intent) {
-
-        if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
+	public static void handleEvent(Context ctx, String action, String packageName, UserHandle user, boolean replacing) {
+		if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
             // Insert into history new packages (not updated ones)
-            if ("android.intent.action.PACKAGE_ADDED".equals(intent.getAction()) && !intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
+            if ("android.intent.action.PACKAGE_ADDED".equals(action) && !replacing) {
                 // Add new package to history
-                String packageName = intent.getData().getSchemeSpecificPart();
-
                 Intent launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(packageName);
                 if (launchIntent == null) {//for some plugin app
                     return;
                 }
 
-                String className = launchIntent.getComponent().getClassName();
-                if (className != null) {
-                    KissApplication.getDataHandler(ctx)
-                            .addToHistory("app://" + packageName + "/" + className);
+				String className = launchIntent.getComponent().getClassName();
+				if (className != null) {
+					String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
+                    KissApplication.getDataHandler(ctx).addToHistory(pojoID);
                 }
             }
         }
 
-        if ("android.intent.action.PACKAGE_REMOVED".equals(intent.getAction())) {
+        if ("android.intent.action.PACKAGE_REMOVED".equals(action)) {
             // Removed all installed shortcuts
-            String packageName = intent.getData().getSchemeSpecificPart();
-
             KissApplication.getDataHandler(ctx).removeShortcuts(packageName);
-
-            KissApplication.getDataHandler(ctx).removeFromExcluded(packageName);
+            KissApplication.getDataHandler(ctx).removeFromExcluded(packageName, user);
         }
 
         KissApplication.resetIconsHandler(ctx);
@@ -56,6 +50,15 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
         if (provider != null) {
             provider.reload();
         }
+	}
+
+    @Override
+    public void onReceive(Context ctx, Intent intent) {
+		handleEvent(ctx,
+				intent.getAction(),
+				intent.getData().getSchemeSpecificPart(), new UserHandle(),
+				intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)
+		);
 
     }
 

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.preference.PreferenceManager;
 import android.os.Build;
+import android.os.Process;
 import android.os.UserManager;
 import android.util.Log;
 
@@ -50,13 +51,17 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 			// Handle multi-profile support introduced in Android 5 (#542)
 			for (android.os.UserHandle profile : manager.getUserProfiles()) {
 				android.util.Log.w("KISS Apps", "Found profile: " + profile);
+				UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
 				for (LauncherActivityInfo activityInfo : launcher.getActivityList(null, profile)) {
 					ApplicationInfo appInfo = activityInfo.getApplicationInfo();
 					android.util.Log.w("KISS Apps", "Found app: " + appInfo);
-					if (!excludedApps.contains(appInfo.packageName)) {
+					
+					String fullPackageName = user.addUserSuffixToString(appInfo.packageName, '#');
+					if(!excludedApps.contains(fullPackageName)) {
 						AppPojo app = new AppPojo();
 						
-						app.id = pojoScheme + appInfo.packageName + "/" + activityInfo.getName();
+						app.id = user.addUserSuffixToString(pojoScheme + appInfo.packageName + "/" + activityInfo.getName(), '/');
+						
 						app.setName(activityInfo.getLabel().toString());
 						
 						app.packageName  = appInfo.packageName;
@@ -64,7 +69,7 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 						
 						// Wrap Android user handle in opaque container that will work across
 						// all Android versions
-						app.userHandle = new UserHandle(profile);
+						app.userHandle = user;
 						
 						app.setTags(tagsHandler.getTags(app.id));
 						apps.add(app);

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -50,11 +50,9 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 			
 			// Handle multi-profile support introduced in Android 5 (#542)
 			for (android.os.UserHandle profile : manager.getUserProfiles()) {
-				android.util.Log.w("KISS Apps", "Found profile: " + profile);
 				UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
 				for (LauncherActivityInfo activityInfo : launcher.getActivityList(null, profile)) {
 					ApplicationInfo appInfo = activityInfo.getApplicationInfo();
-					android.util.Log.w("KISS Apps", "Found app: " + appInfo);
 					
 					String fullPackageName = user.addUserSuffixToString(appInfo.packageName, '#');
 					if(!excludedApps.contains(fullPackageName)) {

--- a/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
@@ -1,4 +1,5 @@
 package fr.neamar.kiss.pojo;
+import fr.neamar.kiss.utils.UserHandle;
 
 import android.util.Pair;
 
@@ -7,6 +8,7 @@ import fr.neamar.kiss.normalizer.StringNormalizer;
 public class AppPojo extends Pojo {
     public String packageName;
     public String activityName;
+    public UserHandle userHandle;
 
     // Tags assigned to this pojo
     public String tags;

--- a/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
@@ -1,6 +1,9 @@
 package fr.neamar.kiss.pojo;
 
 import android.util.Pair;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import fr.neamar.kiss.normalizer.StringNormalizer;
@@ -25,6 +28,10 @@ public abstract class Pojo {
     // Array that contains the non-normalized positions for every normalized
     // character entry
     private int[] namePositionMap = null;
+    // Tags assigned to this pojo
+    public String tags;
+    // Variable to store the formated (user selection in bold) tag
+    public String displayTags = "";
 
     /**
      * Map a position in the normalized name to a position in the standard name string
@@ -104,4 +111,27 @@ public abstract class Pojo {
         this.displayName += this.name.substring(lastPositionEnd);
     }
 
+    public void setTagHighlight(int positionStart, int positionEnd) {
+        this.displayTags = this.tags.substring(0, positionStart)
+                + '{' + this.tags.substring(positionStart, positionEnd) + '}'
+                + this.tags.substring(positionEnd);
+    }
+    
+    /**
+     * Item comparer for sorting Pojos based on their human-readable text
+     * description
+     */
+    public static class NameComparator implements Comparator<Pojo> {
+    	private final Collator collator = Collator.getInstance();
+    	
+    	
+        public final int compare(Pojo a, Pojo b) {
+            int result = this.collator.compare(a.name, b.name);
+            if(result == 0) {
+            	// Fall back to ID-based ordering if names match exactly
+            	result = this.collator.compare(a.id, b.id);
+            }
+            return result;
+        }
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -252,6 +252,10 @@ public class AppResult extends Result {
 				intent.setComponent(className);
 				intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
 				
+				if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+					intent.setSourceBounds(v.getClipBounds());
+				}
+				
 				context.startActivity(intent);
 			}
 		 } catch (ActivityNotFoundException e) {

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -8,6 +8,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.LauncherApps;
+import android.content.pm.LauncherActivityInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -104,7 +105,8 @@ public class AppResult extends Result {
 			ApplicationInfo ai;
 			if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 				LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
-				ai = launcher.getActivityList(this.appPojo.packageName, this.appPojo.userHandle.getRealHandle()).get(0).getApplicationInfo();
+				LauncherActivityInfo info = launcher.getActivityList(this.appPojo.packageName, this.appPojo.userHandle.getRealHandle()).get(0);
+				ai = info.getApplicationInfo();
 			} else {
 				ai = context.getPackageManager().getApplicationInfo(this.appPojo.packageName, 0);
 			}
@@ -231,13 +233,13 @@ public class AppResult extends Result {
 
     @Override
     public Drawable getDrawable(Context context) {
-
+        
         if (icon == null) {
-             icon = KissApplication.getIconsHandler(context).getDrawableIconForPackage(className);
+             icon = KissApplication.getIconsHandler(context).getDrawableIconForPackage(className, this.appPojo.userHandle);
         }
-
+                
         return icon;
-
+        
     }
 
 	@Override

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Process;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.view.LayoutInflater;
@@ -102,17 +103,20 @@ public class AppResult extends Result {
         }
         try {
             // app installed under /system can't be uninstalled
+			boolean isSameProfile = true;
 			ApplicationInfo ai;
 			if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 				LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
 				LauncherActivityInfo info = launcher.getActivityList(this.appPojo.packageName, this.appPojo.userHandle.getRealHandle()).get(0);
 				ai = info.getApplicationInfo();
+				
+				isSameProfile = this.appPojo.userHandle.isCurrentUser();
 			} else {
 				ai = context.getPackageManager().getApplicationInfo(this.appPojo.packageName, 0);
 			}
             
             // Need to AND the flags with SYSTEM:
-            if ((ai.flags & ApplicationInfo.FLAG_SYSTEM) == 0) {
+            if ((ai.flags & ApplicationInfo.FLAG_SYSTEM) == 0 && isSameProfile) {
                 menu.getMenuInflater().inflate(R.menu.menu_item_app_uninstall, menu.getMenu());
             }
         } catch (NameNotFoundException | IndexOutOfBoundsException e) {

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -227,18 +228,23 @@ public class AppResult extends Result {
 
     }
 
-    @Override
-    public void doLaunch(Context context, View v) {
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        intent.addCategory(Intent.CATEGORY_LAUNCHER);
-        intent.setComponent(className);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-
-        try {
-            context.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
-            // Application was just removed?
-            Toast.makeText(context, R.string.application_not_found, Toast.LENGTH_LONG).show();
-        }
-    }
+	@Override
+	public void doLaunch(Context context, View v) {
+		try {
+			if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+				launcher.startMainActivity(className, appPojo.userHandle.getRealHandle(), v.getClipBounds(), null);
+			} else {
+				Intent intent = new Intent(Intent.ACTION_MAIN);
+				intent.addCategory(Intent.CATEGORY_LAUNCHER);
+				intent.setComponent(className);
+				intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+				
+				context.startActivity(intent);
+			}
+		 } catch (ActivityNotFoundException e) {
+			// Application was just removed?
+			Toast.makeText(context, R.string.application_not_found, Toast.LENGTH_LONG).show();
+		}
+	}
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -156,7 +156,7 @@ public class AppResult extends Result {
     }
 
     private void excludeFromAppList(Context context, AppPojo appPojo) {
-        KissApplication.getDataHandler(context).addToExcluded(appPojo.packageName);
+        KissApplication.getDataHandler(context).addToExcluded(appPojo.packageName, appPojo.userHandle);
         //remove app pojo from appProvider results - no need to reset handler
         KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
         KissApplication.getDataHandler(context).removeFromFavorites((MainActivity) context, appPojo.id);

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.provider.ContactsContract;
 import android.view.MenuItem;
@@ -158,6 +159,10 @@ public class ContactsResult extends Result {
 
         viewContact.setData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI,
                 String.valueOf(contactPojo.lookupKey)));
+        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            viewContact.setSourceBounds(v.getClipBounds());
+        }
+
         viewContact.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         viewContact.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
         context.startActivity(viewContact);

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.ContactsContract;
 import android.view.MenuItem;
 import android.view.View;
@@ -69,6 +70,9 @@ public class PhoneResult extends Result {
     public void doLaunch(Context context, View v) {
         Intent phone = new Intent(Intent.ACTION_CALL);
         phone.setData(Uri.parse("tel:" + Uri.encode(phonePojo.phone)));
+        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            phone.setSourceBounds(v.getClipBounds());
+        }
 
         phone.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -179,8 +179,8 @@ public abstract class Result {
      *
      * @param context android context
      */
-    public void fastLaunch(Context context) {
-        this.launch(context, null);
+    public void fastLaunch(Context context, View v) {
+        this.launch(context, v);
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.net.Uri;
+import android.os.Build;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
@@ -48,6 +49,9 @@ public class SearchResult extends Result {
     public void doLaunch(Context context, View v) {
         boolean exceptionThrown = false;
         Intent search = new Intent(Intent.ACTION_WEB_SEARCH);
+        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            search.setSourceBounds(v.getClipBounds());
+        }
         search.putExtra(SearchManager.QUERY, searchPojo.query);
         if (pojo.name.equals("Google")) {
             // In the latest Google Now version, ACTION_WEB_SEARCH is broken when used with FLAG_ACTIVITY_NEW_TASK.

--- a/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
@@ -53,6 +54,10 @@ public class SettingsResult extends Result {
         if (!settingPojo.packageName.isEmpty()) {
             intent.setClassName(settingPojo.packageName, settingPojo.settingName);
         }
+        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            intent.setSourceBounds(v.getClipBounds());
+        }
+
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
     }

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
@@ -87,6 +88,10 @@ public class ShortcutsResult extends Result {
 
         try {
             Intent intent = Intent.parseUri(shortcutPojo.intentUri, 0);
+            if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                intent.setSourceBounds(v.getClipBounds());
+            }
+
             context.startActivity(intent);
         } catch (Exception e) {
             // Application was just removed?

--- a/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
@@ -39,4 +39,9 @@ public class UserHandle {
 			return Process.myUserHandle();
 		}
 	}
+	
+	
+	public boolean isCurrentUser() {
+		return (this.handle == null);
+	}
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
@@ -60,4 +60,18 @@ public class UserHandle {
 			return result.toString();
 		}
 	}
+	
+	public boolean hasStringUserSuffix(String string, char separator) {
+		long serial = 0;
+		
+		int index = string.lastIndexOf((int) separator);
+		if(index > -1) {
+			String serialText = string.substring(index);
+			try {
+				serial = Long.parseLong(serialText);
+			} catch(NumberFormatException e) {}
+		}
+		
+		return (serial == this.serial);
+	}
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss.utils;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.os.Build;
 import android.os.Process;
 
@@ -9,24 +10,27 @@ import android.os.Process;
  * Wrapper class for `android.os.UserHandle` that works with all Android versions
  */
 public class UserHandle {
+	private long   serial;
 	private Object handle; // android.os.UserHandle on Android 4.2 and newer
 	
 	public UserHandle() {
-		this(null);
+		this(0, null);
 	}
 	
 	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-	public UserHandle(Object user) {
+	public UserHandle(long serial, android.os.UserHandle user) {
 		if(android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
 			// OS does not provide any APIs for multi-user support
+			this.serial = 0;
 			this.handle = null;
 		} else if(user != null && Process.myUserHandle().equals(user)) {
 			// For easier processing the current user is also stored as `null`, even
 			// if there is multi-user support
+			this.serial = 0;
 			this.handle = null;
 		} else {
 			// Store the given user handle
-			assert (user instanceof android.os.UserHandle);
+			this.serial = serial;
 			this.handle = user;
 		}
 	}
@@ -43,5 +47,17 @@ public class UserHandle {
 	
 	public boolean isCurrentUser() {
 		return (this.handle == null);
+	}
+	
+	
+	public String addUserSuffixToString(String base, char separator) {
+		if(this.handle == null) {
+			return base;
+		} else {
+			StringBuilder result = new StringBuilder(base);
+			result.append(separator);
+			result.append(this.serial);
+			return result.toString();
+		}
 	}
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
@@ -1,0 +1,42 @@
+package fr.neamar.kiss.utils;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Process;
+
+
+/**
+ * Wrapper class for `android.os.UserHandle` that works with all Android versions
+ */
+public class UserHandle {
+	private Object handle; // android.os.UserHandle on Android 4.2 and newer
+	
+	public UserHandle() {
+		this(null);
+	}
+	
+	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+	public UserHandle(Object user) {
+		if(android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
+			// OS does not provide any APIs for multi-user support
+			this.handle = null;
+		} else if(user != null && Process.myUserHandle().equals(user)) {
+			// For easier processing the current user is also stored as `null`, even
+			// if there is multi-user support
+			this.handle = null;
+		} else {
+			// Store the given user handle
+			assert (user instanceof android.os.UserHandle);
+			this.handle = user;
+		}
+	}
+	
+	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+	public android.os.UserHandle getRealHandle() {
+		if(this.handle != null) {
+			return (android.os.UserHandle) this.handle;
+		} else {
+			return Process.myUserHandle();
+		}
+	}
+}


### PR DESCRIPTION
Android 5 had introduced a new API for interacting with apps specifically for launchers. Usage of this API is not optional anymore however, as new system app management features (such as launching protected apps and apps from work-mode profiles) can only be correctly accessed using this API and because such features were actually (attempted to be) used by our users (#597, #542).

Issue #542 also has most of the development history of this change recorded.