### PR TITLE
Add a share intent for plain text queries

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.net.Uri;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.PopupMenu;
@@ -70,9 +71,23 @@ public class SearchResult extends Result {
     }
 
     @Override
-    protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
+    protected Boolean popupMenuClickHandler(Context context, RecordAdapter parent, MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.item_share:
+                Intent shareIntent = new Intent();
+                shareIntent.setAction(Intent.ACTION_SEND);
+                shareIntent.putExtra(Intent.EXTRA_TEXT, searchPojo.query);
+                shareIntent.setType("text/plain");
+                shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(shareIntent);
+                return true;
+        }
 
-        // Empty menu so that you don't add on favorites
-        return new PopupMenu(context, parentView);
+        return super.popupMenuClickHandler(context, parent, item);
+    }
+
+    @Override
+    protected PopupMenu buildPopupMenu(Context context, final RecordAdapter parent, View parentView) {
+        return inflatePopupMenu(R.menu.menu_item_search, context, parentView);
     }
 }

--- a/app/src/main/res/menu/menu_item_search.xml
+++ b/app/src/main/res/menu/menu_item_search.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/item_share"
+        android:title="@string/share" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,5 +159,6 @@
     <string name="misc">Misc</string>
     <string name="toast_favorites_removed">%s was removed from favorites</string>
     <string name="menu_favorites_remove">Remove favorite</string>
+    <string name="share">Share to...</string>
 
 </resources>


### PR DESCRIPTION
Added an option to "Share" a plain search query:

Possible improvement: return the list of apps able to handle the intent directly in the menu instead of adding one more step.
Menu would then include "Add to Dropbox", "Translate", "Copy to clipboard", "Android Beam", etc.

![2017-02-15 22 28 19](https://cloud.githubusercontent.com/assets/536844/22998330/18ea8cea-f38b-11e6-94c9-033c0409f896.png)
![2017-02-15 22 28 24](https://cloud.githubusercontent.com/assets/536844/22998329/18e99dd0-f38b-11e6-9e6f-09479c22f245.png)