### PR TITLE
Should be String

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -156,7 +156,7 @@
     <string name="alternate_history_inputs">Alternatieve geschiedenisinvoer</string>
     <string name="keyboard_options">Toetsenbordopties</string>
     <string name="misc">Overig</string>
-    <string name="toast_favorites_removed">%d verwijderd van favorieten</string>
+    <string name="toast_favorites_removed">%s verwijderd van favorieten</string>
     <string name="menu_favorites_remove">Verwijder favoriet</string>
 
 <string name="default_launcher_warn">Je wordt naar het startscherm gestuurd na het selecteren van de standaardlauncher. Weet je zeker dat je door wilt gaan?


### PR DESCRIPTION
`toast_favorites_removed` uses `%s` for all other languages. Thus, the linter barfed when it found it using `%d`.