### PR TITLE
Ui tweaker

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -382,14 +382,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             Log.i(TAG, "Restarting app after setting changes");
             // Restart current activity to refresh view, since some preferences
             // may require using a new UI
-            prefs.edit().putBoolean("require-layout-update", false).commit();
-            Intent i = new Intent(this, getClass());
-            i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK
-                    | Intent.FLAG_ACTIVITY_NO_ANIMATION);
-            finish();
-            overridePendingTransition(0, 0);
-            startActivity(i);
-            overridePendingTransition(0, 0);
+            prefs.edit().putBoolean("require-layout-update", false).apply();
+            this.recreate();
             return;
         }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -320,6 +320,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         displayClearOnInput();
 
         UiTweaks.updateThemePrimaryColor(this);
+        UiTweaks.tintResources(this);
     }
 
     private void adjustInputType(String currentText) {
@@ -377,6 +378,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         Log.i(TAG, "Resuming KISS");
 
         if (prefs.getBoolean("require-layout-update", false)) {
+            super.onResume();
             Log.i(TAG, "Restarting app after setting changes");
             // Restart current activity to refresh view, since some preferences
             // may require using a new UI
@@ -388,7 +390,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             overridePendingTransition(0, 0);
             startActivity(i);
             overridePendingTransition(0, 0);
-            super.onResume();
             return;
         }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -318,6 +318,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
         // Hide the "X" after the text field, instead displaying the menu button
         displayClearOnInput();
+
+        UiTweaks.updateThemePrimaryColor(this);
     }
 
     private void adjustInputType(String currentText) {

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -66,6 +66,8 @@ public class SettingsActivity extends PreferenceActivity implements
         addExcludedAppSettings(prefs);
 
         addSearchProvidersSelector(prefs);
+
+        UiTweaks.updateThemePrimaryColor(this);
     }
 
     private void loadExcludedAppsToPreference(MultiSelectListPreference multiSelectList) {
@@ -152,6 +154,10 @@ public class SettingsActivity extends PreferenceActivity implements
             if (provider != null) {
                 provider.reload();
             }
+        }
+
+        if(key.equalsIgnoreCase("primary-color")) {
+            UiTweaks.updateThemePrimaryColor(this);
         }
 
         if (requireRestartSettings.contains(key)) {

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -11,6 +11,7 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
+import android.preference.PreferenceScreen;
 import android.widget.Toast;
 
 import java.util.Arrays;
@@ -69,6 +70,13 @@ public class SettingsActivity extends PreferenceActivity implements
         addSearchProvidersSelector(prefs);
 
         UiTweaks.updateThemePrimaryColor(this);
+
+        // Notification color can't be updated before Lollipop
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            PreferenceScreen screen = (PreferenceScreen) findPreference("ui-holder");
+            Preference pref = findPreference("notification-bar-color");
+            screen.removePreference(pref);
+        }
     }
 
     private void loadExcludedAppsToPreference(MultiSelectListPreference multiSelectList) {

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -29,8 +29,8 @@ public class SettingsActivity extends PreferenceActivity implements
         SharedPreferences.OnSharedPreferenceChangeListener {
 
     // Those settings require the app to restart
-    final static private String requireRestartSettings = "enable-keyboard-workaround force-portrait";
-    final static private String requireInstantRestart = "theme primary-color";
+    final static private String requireRestartSettings = "enable-keyboard-workaround force-portrait primary-color";
+    final static private String requireInstantRestart = "theme notification-bar-color";
 
     private boolean requireFullRestart = false;
 

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -28,7 +28,8 @@ public class SettingsActivity extends PreferenceActivity implements
         SharedPreferences.OnSharedPreferenceChangeListener {
 
     // Those settings require the app to restart
-    final static private String requireRestartSettings = "enable-keyboard-workaround force-portrait theme";
+    final static private String requireRestartSettings = "enable-keyboard-workaround force-portrait";
+    final static private String requireInstantRestart = "theme primary-color";
 
     private boolean requireFullRestart = false;
 
@@ -156,17 +157,14 @@ public class SettingsActivity extends PreferenceActivity implements
             }
         }
 
-        if(key.equalsIgnoreCase("primary-color")) {
-            UiTweaks.updateThemePrimaryColor(this);
-        }
-
         if (requireRestartSettings.contains(key)) {
             requireFullRestart = true;
+        }
 
-            if (key.equalsIgnoreCase("theme")) {
-                finish();
-                return;
-            }
+        if (requireInstantRestart.contains(key)) {
+            requireFullRestart = true;
+            finish();
+            return;
         }
 
         if ("enable-sms-history".equals(key) || "enable-phone-history".equals(key)) {
@@ -184,7 +182,7 @@ public class SettingsActivity extends PreferenceActivity implements
         prefs.unregisterOnSharedPreferenceChangeListener(this);
 
         if (requireFullRestart) {
-            Toast.makeText(this, R.string.app_wil_restart, Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.app_will_restart, Toast.LENGTH_SHORT).show();
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
             prefs.edit().putBoolean("require-layout-update", true).apply();
 

--- a/app/src/main/java/fr/neamar/kiss/UiTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/UiTweaks.java
@@ -15,15 +15,14 @@ public class UiTweaks {
     static String DEFAULT_GREEN = "#4caf50";
 
     static void updateThemePrimaryColor(Activity activity) {
-        String primaryColorOverride = getPrimaryColor(activity);
+        String notificationBarColorOverride = getNotificationBarColor(activity);
 
         // Circuit breaker, keep default behavior.
-        if (primaryColorOverride.equals(DEFAULT_GREEN)) {
+        if (notificationBarColorOverride.equals(DEFAULT_GREEN)) {
             return;
         }
 
-        int primaryColor = Color.parseColor(primaryColorOverride);
-
+        int notificationBarColor = Color.parseColor(notificationBarColorOverride);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = activity.getWindow();
@@ -31,17 +30,17 @@ public class UiTweaks {
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
 
             // Update status bar color
-            window.setStatusBarColor(primaryColor);
+            window.setStatusBarColor(notificationBarColor);
         }
 
         ActionBar actionBar = activity.getActionBar();
         if (actionBar != null) {
-            actionBar.setBackgroundDrawable(new ColorDrawable(primaryColor));
+            actionBar.setBackgroundDrawable(new ColorDrawable(notificationBarColor));
         }
     }
 
     static void tintResources(MainActivity mainActivity) {
-        String primaryColorOverride = getPrimaryColorForDisplay(mainActivity);
+        String primaryColorOverride = getPrimaryColor(mainActivity);
 
         // Circuit breaker, keep default behavior.
         if (primaryColorOverride.equals(DEFAULT_GREEN)) {
@@ -58,15 +57,15 @@ public class UiTweaks {
         mainActivity.findViewById(R.id.main_kissbar).setBackgroundColor(primaryColor);
     }
 
-    public static String getPrimaryColor(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getString("primary-color", DEFAULT_GREEN);
+    private static String getNotificationBarColor(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getString("notification-bar-color", DEFAULT_GREEN);
     }
 
-    public static String getPrimaryColorForDisplay(Context context) {
-        String primaryColor = getPrimaryColor(context);
+    public static String getPrimaryColor(Context context) {
+        String primaryColor = PreferenceManager.getDefaultSharedPreferences(context).getString("primary-color", DEFAULT_GREEN);
 
         // Transparent can't be displayed for text color, replace with light gray.
-        if(primaryColor.equals("#00000000")) {
+        if(primaryColor.equals("#00000000") || primaryColor.equals(("#AAFFFFFF"))) {
             return "#BDBDBD";
         }
 

--- a/app/src/main/java/fr/neamar/kiss/UiTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/UiTweaks.java
@@ -1,0 +1,36 @@
+package fr.neamar.kiss;
+
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.view.Window;
+import android.view.WindowManager;
+
+/**
+ * Created by neamar on 19/03/17.
+ */
+
+public class UiTweaks {
+    static void updateThemePrimaryColor(Activity activity) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        String primaryColorOverride = prefs.getString("primary-color", "");
+
+        // Circuit breaker, keep default behavior.
+        if (primaryColorOverride.isEmpty()) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            int mainColor = Color.parseColor(primaryColorOverride);
+            Window window = activity.getWindow();
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+
+            // Update status bar color
+            window.setStatusBarColor(mainColor);
+
+        }
+    }
+}

--- a/app/src/main/java/fr/neamar/kiss/UiTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/UiTweaks.java
@@ -2,7 +2,7 @@ package fr.neamar.kiss;
 
 import android.app.ActionBar;
 import android.app.Activity;
-import android.content.SharedPreferences;
+import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
@@ -16,11 +16,10 @@ import android.view.WindowManager;
 
 public class UiTweaks {
     static void updateThemePrimaryColor(Activity activity) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
-        String primaryColorOverride = prefs.getString("primary-color", "");
+        String primaryColorOverride = getPrimaryColor(activity);
 
         // Circuit breaker, keep default behavior.
-        if (primaryColorOverride.isEmpty()) {
+        if (primaryColorOverride.equals("#4caf50")) {
             return;
         }
 
@@ -40,5 +39,9 @@ public class UiTweaks {
         if(actionBar != null) {
             actionBar.setBackgroundDrawable(new ColorDrawable(primaryColor));
         }
+    }
+
+    public static String getPrimaryColor(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context).getString("primary-color", "#4caf50");
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/UiTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/UiTweaks.java
@@ -1,8 +1,10 @@
 package fr.neamar.kiss;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.view.Window;
@@ -22,15 +24,21 @@ public class UiTweaks {
             return;
         }
 
+        int primaryColor = Color.parseColor(primaryColorOverride);
+
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            int mainColor = Color.parseColor(primaryColorOverride);
             Window window = activity.getWindow();
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
 
             // Update status bar color
-            window.setStatusBarColor(mainColor);
+            window.setStatusBarColor(primaryColor);
+        }
 
+        ActionBar actionBar = activity.getActionBar();
+        if(actionBar != null) {
+            actionBar.setBackgroundDrawable(new ColorDrawable(primaryColor));
         }
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/UiTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/UiTweaks.java
@@ -9,10 +9,7 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 import android.view.Window;
 import android.view.WindowManager;
-
-/**
- * Created by neamar on 19/03/17.
- */
+import android.widget.ImageView;
 
 public class UiTweaks {
     static void updateThemePrimaryColor(Activity activity) {
@@ -36,12 +33,39 @@ public class UiTweaks {
         }
 
         ActionBar actionBar = activity.getActionBar();
-        if(actionBar != null) {
+        if (actionBar != null) {
             actionBar.setBackgroundDrawable(new ColorDrawable(primaryColor));
         }
     }
 
+    static void tintResources(MainActivity mainActivity) {
+        String primaryColorOverride = getPrimaryColorForDisplay(mainActivity);
+
+        // Circuit breaker, keep default behavior.
+        if (primaryColorOverride.equals("#4caf50")) {
+            return;
+        }
+
+        int primaryColor = Color.parseColor(primaryColorOverride);
+
+        // Launcher button should have the main color
+        ImageView launcherButton = (ImageView) mainActivity.findViewById(R.id.launcherButton);
+        launcherButton.setColorFilter(primaryColor);
+
+        // Kissbar background
+        mainActivity.findViewById(R.id.main_kissbar).setBackgroundColor(primaryColor);
+    }
+
     public static String getPrimaryColor(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context).getString("primary-color", "#4caf50");
+    }
+
+    public static String getPrimaryColorForDisplay(Context context) {
+        String primaryColor = getPrimaryColor(context);
+        if(primaryColor.equals("#00000000")) {
+            return "#BDBDBD";
+        }
+
+        return primaryColor;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/UiTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/UiTweaks.java
@@ -12,11 +12,13 @@ import android.view.WindowManager;
 import android.widget.ImageView;
 
 public class UiTweaks {
+    static String DEFAULT_GREEN = "#4caf50";
+
     static void updateThemePrimaryColor(Activity activity) {
         String primaryColorOverride = getPrimaryColor(activity);
 
         // Circuit breaker, keep default behavior.
-        if (primaryColorOverride.equals("#4caf50")) {
+        if (primaryColorOverride.equals(DEFAULT_GREEN)) {
             return;
         }
 
@@ -42,7 +44,7 @@ public class UiTweaks {
         String primaryColorOverride = getPrimaryColorForDisplay(mainActivity);
 
         // Circuit breaker, keep default behavior.
-        if (primaryColorOverride.equals("#4caf50")) {
+        if (primaryColorOverride.equals(DEFAULT_GREEN)) {
             return;
         }
 
@@ -57,11 +59,13 @@ public class UiTweaks {
     }
 
     public static String getPrimaryColor(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getString("primary-color", "#4caf50");
+        return PreferenceManager.getDefaultSharedPreferences(context).getString("primary-color", DEFAULT_GREEN);
     }
 
     public static String getPrimaryColorForDisplay(Context context) {
         String primaryColor = getPrimaryColor(context);
+
+        // Transparent can't be displayed for text color, replace with light gray.
         if(primaryColor.equals("#00000000")) {
             return "#BDBDBD";
         }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -7,14 +7,13 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
-import android.content.pm.LauncherApps;
 import android.content.pm.LauncherActivityInfo;
+import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
-import android.os.Process;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.view.LayoutInflater;
@@ -32,7 +31,6 @@ import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.AppPojo;
-import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.utils.SpaceTokenizer;
 
 public class AppResult extends Result {
@@ -56,7 +54,7 @@ public class AppResult extends Result {
         }
 
         TextView appName = (TextView) v.findViewById(R.id.item_app_name);
-        appName.setText(enrichText(appPojo.displayName));
+        appName.setText(enrichText(appPojo.displayName, context));
 
         TextView tagsView = (TextView) v.findViewById(R.id.item_app_tag);
         //Hide tags view if tags are empty or if user has selected to hide them and the query doesnt match tags
@@ -66,7 +64,7 @@ public class AppResult extends Result {
         }
         else {
             tagsView.setVisibility(View.VISIBLE);
-            tagsView.setText(enrichText(appPojo.displayTags));
+            tagsView.setText(enrichText(appPojo.displayTags, context));
         }
 
         final ImageView appIcon = (ImageView) v.findViewById(R.id.item_app_icon);

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -3,6 +3,7 @@ package fr.neamar.kiss.result;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
@@ -21,6 +22,7 @@ import java.io.InputStream;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
+import fr.neamar.kiss.UiTweaks;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.ContactsPojo;
 import fr.neamar.kiss.searcher.QueryInterface;
@@ -66,10 +68,13 @@ public class ContactsResult extends Result {
             }
         });
 
+        int primaryColor = Color.parseColor(UiTweaks.getPrimaryColorForDisplay(context));
         // Phone action
         ImageButton phoneButton = (ImageButton) v.findViewById(R.id.item_contact_action_phone);
+        phoneButton.setColorFilter(primaryColor);
         // Message action
         ImageButton messageButton = (ImageButton) v.findViewById(R.id.item_contact_action_message);
+        messageButton.setColorFilter(primaryColor);
 
         PackageManager pm = context.getPackageManager();
 

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -68,7 +68,7 @@ public class ContactsResult extends Result {
             }
         });
 
-        int primaryColor = Color.parseColor(UiTweaks.getPrimaryColorForDisplay(context));
+        int primaryColor = Color.parseColor(UiTweaks.getPrimaryColor(context));
         // Phone action
         ImageButton phoneButton = (ImageButton) v.findViewById(R.id.item_contact_action_phone);
         phoneButton.setColorFilter(primaryColor);

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -43,7 +43,7 @@ public class ContactsResult extends Result {
 
         // Contact name
         TextView contactName = (TextView) v.findViewById(R.id.item_contact_name);
-        contactName.setText(enrichText(contactPojo.displayName));
+        contactName.setText(enrichText(contactPojo.displayName, context));
 
         // Contact phone
         TextView contactPhone = (TextView) v.findViewById(R.id.item_contact_phone);

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -32,7 +32,7 @@ public class PhoneResult extends Result {
 
         TextView appName = (TextView) v.findViewById(R.id.item_phone_text);
         String text = context.getString(R.string.ui_item_phone);
-        appName.setText(enrichText(String.format(text, "{" + phonePojo.phone + "}")));
+        appName.setText(enrichText(String.format(text, "{" + phonePojo.phone + "}"), context));
 
         ((ImageView) v.findViewById(R.id.item_phone_icon)).setColorFilter(getThemeFillColor(context), PorterDuff.Mode.SRC_IN);
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -213,7 +213,7 @@ public abstract class Result {
      * @return text displayable on a textview
      */
     Spanned enrichText(String text, Context context) {
-        return Html.fromHtml(text.replaceAll("\\{", "<font color=" + UiTweaks.getPrimaryColor(context) + ">").replaceAll("\\}", "</font>"));
+        return Html.fromHtml(text.replaceAll("\\{", "<font color=" + UiTweaks.getPrimaryColorForDisplay(context) + ">").replaceAll("\\}", "</font>"));
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -213,7 +213,7 @@ public abstract class Result {
      * @return text displayable on a textview
      */
     Spanned enrichText(String text, Context context) {
-        return Html.fromHtml(text.replaceAll("\\{", "<font color=" + UiTweaks.getPrimaryColorForDisplay(context) + ">").replaceAll("\\}", "</font>"));
+        return Html.fromHtml(text.replaceAll("\\{", "<font color=" + UiTweaks.getPrimaryColor(context) + ">").replaceAll("\\}", "</font>"));
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
+import fr.neamar.kiss.UiTweaks;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.pojo.AppPojo;
@@ -211,8 +212,8 @@ public abstract class Result {
      * @param text to highlight
      * @return text displayable on a textview
      */
-    Spanned enrichText(String text) {
-        return Html.fromHtml(text.replaceAll("\\{", "<font color=#4caf50>").replaceAll("\\}", "</font>"));
+    Spanned enrichText(String text, Context context) {
+        return Html.fromHtml(text.replaceAll("\\{", "<font color=" + UiTweaks.getPrimaryColor(context) + ">").replaceAll("\\}", "</font>"));
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -34,11 +34,11 @@ public class SearchResult extends Result {
         ImageView image = (ImageView) v.findViewById(R.id.item_search_icon);
         if (searchPojo.direct) {
             String text = context.getString(R.string.ui_item_visit);
-            appName.setText(enrichText(String.format(text, "{" + this.pojo.name + "}")));
+            appName.setText(enrichText(String.format(text, "{" + this.pojo.name + "}"), context));
             image.setImageResource(R.drawable.ic_public);
         } else {
             String text = context.getString(R.string.ui_item_search);
-            appName.setText(enrichText(String.format(text, this.pojo.name, "{" + searchPojo.query + "}")));
+            appName.setText(enrichText(String.format(text, this.pojo.name, "{" + searchPojo.query + "}"), context));
             image.setImageResource(R.drawable.search);
         }
         image.setColorFilter(getThemeFillColor(context), PorterDuff.Mode.SRC_IN);

--- a/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
@@ -29,7 +29,7 @@ public class SettingsResult extends Result {
 
         String settingPrefix = "<small><small>" + context.getString(R.string.settings_prefix) + "</small></small>";
         TextView settingName = (TextView) v.findViewById(R.id.item_setting_name);
-        settingName.setText(TextUtils.concat(Html.fromHtml(settingPrefix), enrichText(settingPojo.displayName)));
+        settingName.setText(TextUtils.concat(Html.fromHtml(settingPrefix), enrichText(settingPojo.displayName, context)));
 
         ImageView settingIcon = (ImageView) v.findViewById(R.id.item_setting_icon);
         settingIcon.setImageDrawable(getDrawable(context));

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -39,7 +39,7 @@ public class ShortcutsResult extends Result {
             v = inflateFromId(context, R.layout.item_shortcut);
 
         TextView appName = (TextView) v.findViewById(R.id.item_app_name);
-        appName.setText(enrichText(shortcutPojo.displayName));
+        appName.setText(enrichText(shortcutPojo.displayName, context));
 
         final ImageView shortcutIcon = (ImageView) v.findViewById(R.id.item_shortcut_icon);
         final ImageView appIcon = (ImageView) v.findViewById(R.id.item_app_icon);

--- a/app/src/main/java/fr/neamar/kiss/result/TogglesResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TogglesResult.java
@@ -43,7 +43,7 @@ public class TogglesResult extends Result {
         String togglePrefix = "<small><small>" + context.getString(R.string.toggles_prefix) + "</small></small>";
 
         TextView toggleName = (TextView) v.findViewById(R.id.item_toggle_name);
-        toggleName.setText(TextUtils.concat(Html.fromHtml(togglePrefix), enrichText(togglePojo.displayName)));
+        toggleName.setText(TextUtils.concat(Html.fromHtml(togglePrefix), enrichText(togglePojo.displayName, context)));
 
         ImageView toggleIcon = (ImageView) v.findViewById(R.id.item_toggle_icon);
         toggleIcon.setImageDrawable(context.getResources().getDrawable(togglePojo.icon));

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -111,7 +111,7 @@
     <string name="restart_warn">Наистина ли искате да рестартирате KISS? Ако KISS не е launcher-ът ви по подразбиране, приложението просто ще се затвори.</string>
 
     <string name="items_title">%d елемента</string>
-    <string name="app_wil_restart">Вие сте променили някои важни настройки, приложението ще се рестартира.</string>
+    <string name="app_will_restart">Вие сте променили някои важни настройки, приложението ще се рестартира.</string>
     <string name="keyboard_options">Настройки за клавиатурата</string>
     <string name="misc">Разни</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -149,7 +149,7 @@
     <string name="keyboard_options">Tastatureinstellungen</string>
     <string name="misc">Verschiedenes</string>
 
-<string name="app_wil_restart">Wichtige Einstellungen wurden verändert; App wird neu gestartet.</string>
+<string name="app_will_restart">Wichtige Einstellungen wurden verändert; App wird neu gestartet.</string>
     <string name="alternate_history_inputs">Zusätzliche Quellen für Verlaufseinträge</string>
     <string name="settings_accessibility">Bedienungshilfen</string>
     <string name="title_settings">Einstellungen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_accessibility">Προσβασιμότητα</string>
     <string name="restart_desc">Διόρθωση θεμάτων / νέων επαφών που δεν εμφανίζονται</string>
     <string name="items_title">%d στοιχεία</string>
-    <string name="app_wil_restart">Έχετε τροποποιήσει κάποιες σημαντικές ρυθμίσεις, η εφαρμογή θα επανεκκινήσει.</string>
+    <string name="app_will_restart">Έχετε τροποποιήσει κάποιες σημαντικές ρυθμίσεις, η εφαρμογή θα επανεκκινήσει.</string>
     <string name="alternate_history_inputs">Τροποποιήστε τις ροές του ιστορικού</string>
     <string name="keyboard_options">Επιλογές πληκτρολογίου</string>
     <string name="misc">Λοιπά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -154,7 +154,7 @@
 
 Nota: Si no ve la opción \'Siempre\', pulse el botón de inicio después de elegir el selector deseado.</string>
 
-    <string name="app_wil_restart">Has modificado algunos ajustes importantes, la aplicación se reiniciará.</string>
+    <string name="app_will_restart">Has modificado algunos ajustes importantes, la aplicación se reiniciará.</string>
     <string name="alternate_history_inputs">Alternar entradas del historial</string>
     <string name="keyboard_options">Opciones de teclado</string>
     <string name="misc">Miscelánea</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -139,7 +139,7 @@
     <string name="restart_warn">Voulez-vous vraiment redémarrer KISS ? Si KISS n’est pas votre accueil par défaut, l’appli va juste quitter.</string>
 
     <string name="items_title">%d objets</string>
-    <string name="app_wil_restart">Vous avez changé des paramètres importants, l’appli va redémarrer.</string>
+    <string name="app_will_restart">Vous avez changé des paramètres importants, l’appli va redémarrer.</string>
     <string name="alternate_history_inputs">Autres entrées de l’historique</string>
     <string name="keyboard_options">Options du clavier</string>
     <string name="misc">Divers</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -143,6 +143,6 @@
     <string name="restart_warn">Želite li ponovo pokrenuti KISS? Ako KISS nije vaš glavni pokretač aplikacija će se zatvoriti.</string>
 
     <string name="items_title">%d stavke</string>
-    <string name="app_wil_restart">Promjenili ste neke bitne postavke, aplikacija će se ponovo pokrenuti.</string>
+    <string name="app_will_restart">Promjenili ste neke bitne postavke, aplikacija će se ponovo pokrenuti.</string>
     <string name="keyboard_options">Postavke tipkovnice</string>
     </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -134,7 +134,7 @@
     <string name="settings_accessibility">Aksesibilitas</string>
     <string name="keyboard_workaround_name">Solusi saran keyboard</string>
     <string name="keyboard_workaround_desc">Cegah soft-keyboards (seperti SwiftKey™) dari menampilkan sugesti</string>
-    <string name="app_wil_restart">Anda telah mengubah beberapa peraturan penting, apl akan memulai ulang.</string>
+    <string name="app_will_restart">Anda telah mengubah beberapa peraturan penting, apl akan memulai ulang.</string>
     <string name="alternate_history_inputs">Alternatif masukan riwayat</string>
     <string name="keyboard_options">Opsi keyboard</string>
     <string name="misc">Dll</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -137,7 +137,7 @@
     <string name="restart_warn">Sei sicuro di voler riavviare KISS? Se KISS non è il tuo launcher predefinito, verrà solamente terminato.</string>
 
     <string name="items_title">%d elementi</string>
-    <string name="app_wil_restart">Hai modificato delle impostazioni importanti, pertanto KISS verrà riavviato.</string>
+    <string name="app_will_restart">Hai modificato delle impostazioni importanti, pertanto KISS verrà riavviato.</string>
     <string name="alternate_history_inputs">Elementi aggiuntivi</string>
     <string name="keyboard_options">Tastiera e opzioni d\'immissione</string>
     <string name="misc">Altro</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -143,7 +143,7 @@
     <string name="settings_accessibility">アクセシビリティ</string>
     <string name="keyboard_workaround_name">キーボード入力候補の修正</string>
     <string name="keyboard_workaround_desc">(SwiftKey™ のような) 壊れたソフトキーボードが入力候補を表示するのを防止します</string>
-    <string name="app_wil_restart">いくつかの重要な設定を変更しました。アプリを再起動します。</string>
+    <string name="app_will_restart">いくつかの重要な設定を変更しました。アプリを再起動します。</string>
     <string name="alternate_history_inputs">代替の履歴入力</string>
     <string name="keyboard_options">キーボード オプション</string>
     <string name="misc">その他</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -148,7 +148,7 @@
     <string name="default_launcher_warn">Po to kai pasirinksite numatytąją paleidimo priemonę, Jūs atsidursite namų ekrane. Ar Jūs įsitikinęs, kad norite pradėti?\n\nPastaba: jei nematote pasirinkimo „Visada\", paspauskite namų mygtuką po to kai pasirinksite numatytąją paleidimo priemonę.</string>
 
     <string name="items_title">%d elementai</string>
-    <string name="app_wil_restart">Jūs pakeitėte svarbius nustatymus, programėlė persikraus.</string>
+    <string name="app_will_restart">Jūs pakeitėte svarbius nustatymus, programėlė persikraus.</string>
     <string name="alternate_history_inputs">Alternatyvūs istorijos įvedimai</string>
     <string name="keyboard_options">Klaviatūros nustatymai</string>
     <string name="misc">Įvairūs</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -147,7 +147,7 @@
     <string name="exclude_favorites">Utelat favoritter fra historikk</string>
     <string name="favorites_hide">Skjul favorittbjelke</string>
     <string name="default_launcher_title">Endre forvalgt oppstarter</string>
-    <string name="app_wil_restart">Du har endret noen viktige innstillinger, programmet vil starte på ny.</string>
+    <string name="app_will_restart">Du har endret noen viktige innstillinger, programmet vil starte på ny.</string>
     <string name="alternate_history_inputs">Alternative historikkinndatametoder</string>
     <string name="keyboard_options">Tastaturvalg</string>
     <string name="misc">Ymse</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -152,7 +152,7 @@
 
     <string name="default_launcher_title">Verander standaardlauncher</string>
     <string name="items_title">%d items</string>
-    <string name="app_wil_restart">Je hebt enkele belangrijke instellingen aangepast. De applicatie wordt daarom herstart.</string>
+    <string name="app_will_restart">Je hebt enkele belangrijke instellingen aangepast. De applicatie wordt daarom herstart.</string>
     <string name="alternate_history_inputs">Alternatieve geschiedenisinvoer</string>
     <string name="keyboard_options">Toetsenbordopties</string>
     <string name="misc">Overig</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -138,7 +138,7 @@
     <string name="settings_accessibility">Accesibilitate</string>
     <string name="keyboard_workaround_name">Rezolvare sugestii tastatura</string>
     <string name="keyboard_workaround_desc">Previne tastaturile problematice (precum SwiftKey™) sa mai arate sugestii</string>
-    <string name="app_wil_restart">S-au schimbat setari importante, aplicatia va reporni.</string>
+    <string name="app_will_restart">S-au schimbat setari importante, aplicatia va reporni.</string>
     <string name="alternate_history_inputs">Surse alternative istoric</string>
     <string name="keyboard_options">Optiuni tastatura</string>
     <string name="misc">Diverse</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -153,7 +153,7 @@
     <string name="tags_add_title">Добавить тэги, разделенные пробелом</string>
     <string name="tags_confirmation_added">Тэг был установлен</string>
     <string name="default_launcher_title">Изменить лаунчер по умолчанию</string>
-    <string name="app_wil_restart">Вы изменили ключевые настройки, лаунчер будет перезапущен.</string>
+    <string name="app_will_restart">Вы изменили ключевые настройки, лаунчер будет перезапущен.</string>
     <string name="alternate_history_inputs">Изменить историю ввода</string>
     <string name="keyboard_options">Настройки клавиатуры</string>
     <string name="misc">Разное</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -146,7 +146,7 @@
     <string name="default_launcher_warn">Efter du valt standardstartsida kommer du skickas till dess framsida. Vill du fortsätta? Om du inte ser valet "Alltid" som alltid trycker du på hemknappen på din mobil EFTER du valt startsida.</string>
 
     <string name="items_title">%d föremål</string>
-    <string name="app_wil_restart">Du har ändrat några viktiga inställningar, appen startar nu om.</string>
+    <string name="app_will_restart">Du har ändrat några viktiga inställningar, appen startar nu om.</string>
     <string name="alternate_history_inputs">Andra historiktillägg</string>
     <string name="keyboard_options">Tangentbordsalternativ</string>
     <string name="misc">Övrigt</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -142,7 +142,7 @@
     <string name="settings_accessibility">Приступачност</string>
     <string name="keyboard_workaround_name">Поправка за предлоге тастатуре</string>
     <string name="keyboard_workaround_desc">Спречава покварене софтверске тастатуре (нпр. SwiftKey™) да приказују предлоге</string>
-    <string name="app_wil_restart">Изменили сте неке битне поставке, апликације ће поново да се покрене.</string>
+    <string name="app_will_restart">Изменили сте неке битне поставке, апликације ће поново да се покрене.</string>
     <string name="alternate_history_inputs">Мењај улазе историјата наизменице</string>
     <string name="keyboard_options">Опције тастатуре</string>
     <string name="misc">Разно</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -144,7 +144,7 @@
     <string name="favorites_hide">Sık Kullanılanlar Çubuğunu Gizle</string>
     <string name="keyboard_workaround_desc">Bozuk yazılım-klavyeleri (SwiftKey™ gibi) öneri göstermekten alıkoy</string>
     <string name="keyboard_workaround_name">Klavye önerileri çözümü</string>
-    <string name="app_wil_restart">Bazı önemli ayarları değiştirdiniz, uygulama yeniden başlayacak.</string>
+    <string name="app_will_restart">Bazı önemli ayarları değiştirdiniz, uygulama yeniden başlayacak.</string>
     <string name="misc">Türlü</string>
 
 <string name="keyboard_options">Klavye seçenekleri</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -138,7 +138,7 @@
     <string name="settings_accessibility">无障碍功能</string>
     <string name="keyboard_workaround_name">键盘建议修正</string>
     <string name="keyboard_workaround_desc">显示建议时避免不能用的软键盘（如 SwiftKey™）</string>
-    <string name="app_wil_restart">您更改了某些重要设置，本应用需要重启。</string>
+    <string name="app_will_restart">您更改了某些重要设置，本应用需要重启。</string>
     <string name="alternate_history_inputs">备用历史记录输入</string>
     <string name="keyboard_options">键盘选项</string>
     <string name="misc">杂项</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -58,7 +58,7 @@
         <item>Transparent</item>
     </string-array>
     <string-array name="colorValues">
-        <item>#4caf50</item>
+        <item></item>
         <item>#D32F2F</item>
         <item>#C2185B</item>
         <item>#7B1FA2</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -33,7 +33,7 @@
         <item>frecency</item>
     </string-array>
     <string-array name="colorEntries">
-        <item>Default green</item>
+        <item>Default theme color</item>
         <item>Red</item>
         <item>Pink</item>
         <item>Purple</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -33,29 +33,29 @@
         <item>frecency</item>
     </string-array>
     <string-array name="colorEntries">
-        <item>Default theme color</item>
-        <item>Red</item>
-        <item>Pink</item>
-        <item>Purple</item>
-        <item>Deep purple</item>
-        <item>Indigo</item>
-        <item>Blue</item>
-        <item>Light blue</item>
-        <item>Cyan</item>
-        <item>Teal</item>
-        <item>Green</item>
-        <item>Light Green</item>
-        <item>Lime</item>
-        <item>Yellow</item>
-        <item>Amber</item>
-        <item>Orange</item>
-        <item>Deep orange</item>
-        <item>Brown</item>
-        <item>Grey</item>
-        <item>Blue Grey</item>
-        <item>Black</item>
-        <item>Semi-transparent black</item>
-        <item>Semi-transparent white</item>
+        <item><font bgcolor="#4caf50" fgcolor="#4caf50">□□□</font></item>
+        <item><font bgcolor="#D32F2F" fgcolor="#D32F2F">□□□</font></item>
+        <item><font bgcolor="#C2185B" fgcolor="#C2185B">□□□</font></item>
+        <item><font bgcolor="#7B1FA2" fgcolor="#7B1FA2">□□□</font></item>
+        <item><font bgcolor="#512DA8" fgcolor="#512DA8">□□□</font></item>
+        <item><font bgcolor="#303F9F" fgcolor="#303F9F">□□□</font></item>
+        <item><font bgcolor="#1976D2" fgcolor="#1976D2">□□□</font></item>
+        <item><font bgcolor="#0288D1" fgcolor="#0288D1">□□□</font></item>
+        <item><font bgcolor="#0097A7" fgcolor="#0097A7">□□□</font></item>
+        <item><font bgcolor="#00796B" fgcolor="#00796B">□□□</font></item>
+        <item><font bgcolor="#388E3C" fgcolor="#388E3C">□□□</font></item>
+        <item><font bgcolor="#689F38" fgcolor="#689F38">□□□</font></item>
+        <item><font bgcolor="#AFB42B" fgcolor="#AFB42B">□□□</font></item>
+        <item><font bgcolor="#FBC02D" fgcolor="#FBC02D">□□□</font></item>
+        <item><font bgcolor="#FFA000" fgcolor="#FFA000">□□□</font></item>
+        <item><font bgcolor="#F57C00" fgcolor="#F57C00">□□□</font></item>
+        <item><font bgcolor="#E64A19" fgcolor="#E64A19">□□□</font></item>
+        <item><font bgcolor="#5D4037" fgcolor="#5D4037">□□□</font></item>
+        <item><font bgcolor="#616161" fgcolor="#616161">□□□</font></item>
+        <item><font bgcolor="#455A64" fgcolor="#455A64">□□□</font></item>
+        <item><font bgcolor="#000000" fgcolor="#000000">□□□</font></item>
+        <item>Transparent dark</item>
+        <item>Transparent white</item>
         <item>Transparent</item>
     </string-array>
     <string-array name="colorValues">

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -32,5 +32,54 @@
         <item>recency</item>
         <item>frecency</item>
     </string-array>
-
+    <string-array name="colorEntries">
+        <item>Default green</item>
+        <item>Red</item>
+        <item>Pink</item>
+        <item>Purple</item>
+        <item>Deep purple</item>
+        <item>Indigo</item>
+        <item>Blue</item>
+        <item>Light blue</item>
+        <item>Cyan</item>
+        <item>Teal</item>
+        <item>Green</item>
+        <item>Light Green</item>
+        <item>Lime</item>
+        <item>Yellow</item>
+        <item>Amber</item>
+        <item>Orange</item>
+        <item>Deep orange</item>
+        <item>Brown</item>
+        <item>Grey</item>
+        <item>Blue Grey</item>
+        <item>Black</item>
+        <item>White</item>
+        <item>Transparent</item>
+    </string-array>
+    <string-array name="colorValues">
+        <item>#4caf50</item>
+        <item>#D32F2F</item>
+        <item>#C2185B</item>
+        <item>#7B1FA2</item>
+        <item>#512DA8</item>
+        <item>#303F9F</item>
+        <item>#1976D2</item>
+        <item>#0288D1</item>
+        <item>#0097A7</item>
+        <item>#00796B</item>
+        <item>#388E3C</item>
+        <item>#689F38</item>
+        <item>#AFB42B</item>
+        <item>#FBC02D</item>
+        <item>#FFA000</item>
+        <item>#F57C00</item>
+        <item>#E64A19</item>
+        <item>#5D4037</item>
+        <item>#616161</item>
+        <item>#455A64</item>
+        <item>#000000</item>
+        <item>#FFFFFF</item>
+        <item>#00000000</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -54,6 +54,8 @@
         <item>Grey</item>
         <item>Blue Grey</item>
         <item>Black</item>
+        <item>Semi-transparent black</item>
+        <item>Semi-transparent white</item>
         <item>Transparent</item>
     </string-array>
     <string-array name="colorValues">
@@ -78,6 +80,8 @@
         <item>#616161</item>
         <item>#455A64</item>
         <item>#000000</item>
+        <item>#AA000000</item>
+        <item>#AAFFFFFF</item>
         <item>#00000000</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -58,7 +58,7 @@
         <item>Transparent</item>
     </string-array>
     <string-array name="colorValues">
-        <item></item>
+        <item>#4caf50</item>
         <item>#D32F2F</item>
         <item>#C2185B</item>
         <item>#7B1FA2</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -54,7 +54,6 @@
         <item>Grey</item>
         <item>Blue Grey</item>
         <item>Black</item>
-        <item>White</item>
         <item>Transparent</item>
     </string-array>
     <string-array name="colorValues">
@@ -79,7 +78,6 @@
         <item>#616161</item>
         <item>#455A64</item>
         <item>#000000</item>
-        <item>#FFFFFF</item>
         <item>#00000000</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,7 +154,7 @@
     <string name="default_launcher_warn">After selecting the Default Launcher, you\'ll be sent to its Home Screen. Are you sure you\'d like to proceed?\n\nNote: If you don\'t see the \'Always\' option, press the Home Button after selecting your desired Launcher.</string>
 
     <string name="items_title">%d items</string>
-    <string name="app_wil_restart">You\'ve changed some important settings, the app will restart.</string>
+    <string name="app_will_restart">You\'ve changed some important settings, the app will restart.</string>
     <string name="alternate_history_inputs">Alternate history inputs</string>
     <string name="keyboard_options">Keyboard options</string>
     <string name="misc">Misc</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,5 +162,6 @@
     <string name="menu_favorites_remove">Remove favorite</string>
     <string name="share">Share to...</string>
     <string name="main_color">Primary color</string>
+    <string name="notification_bar_color">Notification bar color</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,5 +163,4 @@
     <string name="share">Share to...</string>
     <string name="main_color">Primary color</string>
     <string name="notification_bar_color">Notification bar color</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,5 +161,6 @@
     <string name="toast_favorites_removed">%s was removed from favorites</string>
     <string name="menu_favorites_remove">Remove favorite</string>
     <string name="share">Share to...</string>
+    <string name="main_color">Primary color</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -41,7 +41,7 @@
                 android:title="@string/exclude_favorites" />
         </PreferenceCategory>
     </PreferenceScreen>
-    <PreferenceScreen android:title="@string/title_ui">
+    <PreferenceScreen android:title="@string/title_ui" android:key="ui-holder">
         <ListPreference
             android:defaultValue="light"
             android:entries="@array/themesEntries"
@@ -52,6 +52,12 @@
             android:defaultValue="default"
             android:key="icons-pack"
             android:title="@string/icons_pack_name" />
+        <ListPreference
+            android:defaultValue="#4caf50"
+            android:entries="@array/colorEntries"
+            android:entryValues="@array/colorValues"
+            android:key="notification-bar-color"
+            android:title="@string/notification_bar_color" />
         <ListPreference
             android:defaultValue="#4caf50"
             android:entries="@array/colorEntries"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -53,7 +53,6 @@
             android:key="icons-pack"
             android:title="@string/icons_pack_name" />
         <ListPreference
-            android:defaultValue="#4caf50"
             android:entries="@array/colorEntries"
             android:entryValues="@array/colorValues"
             android:key="primary-color"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -52,6 +52,12 @@
             android:defaultValue="default"
             android:key="icons-pack"
             android:title="@string/icons_pack_name" />
+        <ListPreference
+            android:defaultValue="#4caf50"
+            android:entries="@array/colorEntries"
+            android:entryValues="@array/colorValues"
+            android:key="primary-color"
+            android:title="@string/main_color" />
         <PreferenceCategory android:title="@string/keyboard_options">
             <fr.neamar.kiss.SwitchPreference
                 android:defaultValue="false"
@@ -138,7 +144,7 @@
         <fr.neamar.kiss.preference.DefaultLauncherPreference
             android:dialogMessage="@string/default_launcher_warn"
             android:key="default-launcher"
-            android:title="@string/default_launcher_title"/>
+            android:title="@string/default_launcher_title" />
         <ListPreference
             android:defaultValue="recency"
             android:entries="@array/historyModeEntries"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -53,6 +53,7 @@
             android:key="icons-pack"
             android:title="@string/icons_pack_name" />
         <ListPreference
+            android:defaultValue="#4caf50"
             android:entries="@array/colorEntries"
             android:entryValues="@array/colorValues"
             android:key="primary-color"


### PR DESCRIPTION
Lets you change the main color.

This is the currently most complained about feature in the Play Store: a lot of people hate the green bar.

This PR builds on previous work I did on #630, but a lot has changed since then, especially with the dropped support of older SDKs.

Changing the main color will:

* change kiss logo color
* change standard favorite bar background color
* change phone and messaging icon on contacts
* change highlight color in search result
* change notification bar color (Android L and above only)
* Change action bar color in settings (but not in subscreens for some reason?)

The following won't change, because they're too complex to manage (or I'm too stupid [lazy?] to figure out how to do it):

* loading spinner indicator when opening app for the first time
* toggle color in Toggle search results (and in KISS settings)
* cursor color in search box

Needs to be tested on Android < L before merge.

Left to do:

* [x] Use defined color on MainActivity and Results
* [x] Let primary color and notification color be different if you want to (e.g. transparent notification bar while still using KISS green)
* [x] Add semi-transparent black in the color list
* [x] Hide notification bar color pre-L
* [x] Try to display the colors directly in the DialogPicker, instead of using their english names
* [x] No immediate restart