### PR TITLE
Fix crash when toggle button is invoked from KISS-Bar/Favorites

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/TogglesResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TogglesResult.java
@@ -108,7 +108,17 @@ public class TogglesResult extends Result {
 
     @Override
     public void doLaunch(Context context, View v) {
-        if (v == null) {
+        CompoundButton toggleButton = null;
+        if (v != null) {
+            toggleButton = (CompoundButton) v.findViewById(R.id.item_toggle_action_toggle);
+        }
+
+        if (toggleButton != null) {
+            // Use the handler to check or un-check button
+            if (toggleButton.isEnabled()) {
+                toggleButton.performClick();
+            }
+        } else {
             //in case it is pinned on kissbar
             if (togglesHandler == null) {
                 togglesHandler = new TogglesHandler(context);
@@ -123,14 +133,6 @@ public class TogglesResult extends Result {
             //show toast to inform user what the state is
             Toast.makeText(context, String.format(msg, " " + this.pojo.displayName), Toast.LENGTH_SHORT).show();
 
-        }
-        else {
-            // Use the handler to check or un-check button
-            final CompoundButton toggleButton = (CompoundButton) v
-                    .findViewById(R.id.item_toggle_action_toggle);
-            if (toggleButton.isEnabled()) {
-                toggleButton.performClick();
-            }
         }
     }
 


### PR DESCRIPTION
Fix for #635 

Partially my fault as this probably happened during the refactoring for the Android 5+ `LauncherApps` API.