### PR TITLE
Fix crashes when entering a number larger than `Integer.MAX_VALUE` as search result limit

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -287,7 +287,9 @@ public class DataHandler extends BroadcastReceiver
      * @return pojos in recent history
      */
     public ArrayList<Pojo> getHistory(Context context, int itemCount, boolean smartHistory, ArrayList<Pojo> itemsToExclude) {
-        ArrayList<Pojo> history = new ArrayList<>(itemCount);
+        // Pre-allocate array slots that are likely to be used based on the current maximum item
+        // count
+        ArrayList<Pojo> history = new ArrayList<>(Math.min(itemCount, 256));
 
         // Read history
         List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount, smartHistory);

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -26,7 +26,10 @@ public class HistorySearcher extends Searcher {
         // Ask for records
         boolean smartHistory = !prefs.getString("history-mode", "recency").equals("recency");
         boolean excludeFavorites = prefs.getBoolean("exclude-favorites", false);
-        int max_records = Integer.parseInt(prefs.getString("number-of-display-elements", String.valueOf(DEFAULT_MAX_RESULTS)));
+        
+        // Convert `"number-of-display-elements"` to double first before truncating to int to avoid
+        // `java.lang.NumberFormatException` crashes for values larger than `Integer.MAX_VALUE`
+        int maxRecords = (new Double(prefs.getString("number-of-display-elements", String.valueOf(DEFAULT_MAX_RESULTS)))).intValue();
 
         //Gather favorites
         ArrayList<Pojo> favoritesPojo = new ArrayList<Pojo>(0);
@@ -34,6 +37,6 @@ public class HistorySearcher extends Searcher {
             favoritesPojo = KissApplication.getDataHandler(activity).getFavorites(activity.tryToRetrieve);
         }
 
-        return KissApplication.getDataHandler(activity).getHistory(activity, max_records, smartHistory, favoritesPojo);
+        return KissApplication.getDataHandler(activity).getHistory(activity, maxRecords, smartHistory, favoritesPojo);
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -35,11 +35,13 @@ public class QuerySearcher extends Searcher {
         final List<Pojo> pojos = KissApplication.getDataHandler(activity).getResults(
                 activity, query);
 
-        // Trim items
-        int max_records = Integer.parseInt(prefs.getString("number-of-display-elements", String.valueOf(DEFAULT_MAX_RESULTS)));
+        // Convert `"number-of-display-elements"` to double first before truncating to int to avoid
+        // `java.lang.NumberFormatException` crashes for values larger than `Integer.MAX_VALUE`
+        int maxRecords = (new Double(prefs.getString("number-of-display-elements", String.valueOf(DEFAULT_MAX_RESULTS)))).intValue();
 
-        if (pojos.size() > max_records) {
-            return pojos.subList(0, max_records);
+        // Possibly limit number of results post-mortem
+        if (pojos.size() > maxRecords) {
+            return pojos.subList(0, maxRecords);
         }
 
         return pojos;


### PR DESCRIPTION
Fixes #653.