### PR TITLE
Don't updateThemePrimaryColor on SettingsActivity

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -70,8 +70,6 @@ public class SettingsActivity extends PreferenceActivity implements
 
         addSearchProvidersSelector(prefs);
 
-        UiTweaks.updateThemePrimaryColor(this);
-
         // Notification color can't be updated before Lollipop
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             PreferenceScreen screen = (PreferenceScreen) findPreference("ui-holder");


### PR DESCRIPTION
SettingsActivity shouldn't receive its actionbar (or statusbar) colour from
updateThemePrimaryColor. Using the method only changes the colour of the
first page of Settings, it doesn't apply anywhere else in the activity.
This means that other pages of Settings will have the default green
colour while the first page has the colour set from
updateThemePrimaryColor.