### PR TITLE
fixing deletion of tags on history reset

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -343,6 +343,11 @@ public class DataHandler extends BroadcastReceiver
         Toast.makeText(context, R.string.shortcut_added, Toast.LENGTH_SHORT).show();
     }
 
+    public void clearHistory()
+    {
+        DBHelper.clearHistory(this.context);
+    }
+
     public void removeShortcut(ShortcutsPojo shortcut) {
         DBHelper.removeShortcut(this.context, shortcut.name);
 

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -62,6 +62,12 @@ public class DBHelper {
         db.close();
     }
 
+    public static void clearHistory(Context context) {
+        SQLiteDatabase db = getDatabase(context);
+        db.delete("history", "", null);
+        db.close();
+    }
+
     private static Cursor getSmartHistoryCursor(SQLiteDatabase db, int limit) {
         //Since smart history sql uses a group by we don't use the whole history but a limit of recent apps
         int historyWindowSize =  limit *30;

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetPreference.java
@@ -21,11 +21,9 @@ public class ResetPreference extends DialogPreference {
     public void onClick(DialogInterface dialog, int which) {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
-            getContext().deleteDatabase(DB.DB_NAME);
-            KissApplication.getDataHandler(getContext()).reloadAll();
-            PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
-                    .putBoolean("layout-updated", true).apply();
-
+            KissApplication.getDataHandler(getContext()).clearHistory();
+//            PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
+//                    .putBoolean("layout-updated", true).apply();
             Toast.makeText(getContext(), R.string.history_erased, Toast.LENGTH_LONG).show();
         }
 


### PR DESCRIPTION
fixing #672
Current state:
- On history deletion, the whole kiss db is reset

Fix
- On history deletion, only the history table is cleared.

Question 1: Should shortcuts be deleted too? 
Question 2 : Should the layout be updated?