### PR TITLE
Use "search bar" (vs "search field") consistently in all strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="stub_phone" translatable="false">Call +330 12 34 56 78</string>
     <string name="stub_app_tag">Tag example</string>
     <string name="main_menu">Menu</string>
-    <string name="main_clear">Clear search field</string>
+    <string name="main_clear">Clear search bar</string>
     <string name="main_kiss">Display favorites and app list</string>
     <string name="main_kiss_back">Display history</string>
     <string name="reset_name">Reset your KISS history</string>
@@ -141,7 +141,7 @@
     <string name="enable_sms">Show incoming SMS in history</string>
     <string name="enable_phone">Show incoming calls in history</string>
     <string name="enable_app">Show newly installed apps in history</string>
-    <string name="enable_favorites_bar">Show favorites above search field</string>
+    <string name="enable_favorites_bar">Show favorites above search bar</string>
     <string name="exclude_favorites">Exclude favorites from history</string>
     <string name="favorites_hide">Hide Favorites Bar</string>
     <string name="shortcut_added">Shortcut added to KISS.</string>


### PR DESCRIPTION
Noticed this b/c of the recently introduced #685 