### PR TITLE
Favorites bar ON by default with default dialer, contacts and browser preselected

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -378,9 +378,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     }
 
     private void configureFirstRun() {
-        if (prefs.getBoolean("firstRun", true) || true) {
+        if (prefs.getBoolean("firstRun", true)) {
             // It is the first run. Make sure this is not an update by checking if history is empty
-            if (DBHelper.getHistoryLength(this) != -1) {
+            if (DBHelper.getHistoryLength(this) == 0) {
                 addDefaultAppsToFavs();
             }
             // set flag to false

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -102,7 +102,7 @@
                 android:key="sort-apps"
                 android:title="@string/order_apps_name" />
             <fr.neamar.kiss.SwitchPreference
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="enable-favorites-bar"
                 android:title="@string/enable_favorites_bar" />
             <fr.neamar.kiss.SwitchPreference


### PR DESCRIPTION
Hi all,
A few months ago, we had a short discussion (offline) regarding the favorites bar above search and default favorites after first installation of KISS.

In this PR, the favorites bar is set to ON by default (the user can of course disable it in settings).
Also, on first run (detected by a flag on shared preferences + history.size == 0) the default dialer, contact app and browser are set as favorites. 

A screenshot after installation of KISS:

![image](https://user-images.githubusercontent.com/7504889/30768881-40ab9b80-a00f-11e7-9606-d49af8d8a2e6.png)

I think it creates a better first time experience. Any opinions are welcome

PS: On the downside: I am adding some further chaos inside MainActivity.java... :-/