### PR TITLE
Do full substring search on contact names as fallback.

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
@@ -78,12 +78,17 @@ public class ContactsProvider extends Provider<ContactsPojo> {
                         + ")</small>";
                 relevance = 30;
             } else if (query.length() > 2) {
-                matchPositionStart = 0;
-                matchPositionEnd = 0;
-                if (contact.phoneSimplified.startsWith(query)) {
-                    relevance = 10;
-                } else if (contact.phoneSimplified.contains(query)) {
-                    relevance = 5;
+                if ((matchPositionStart = contactNameNormalized.indexOf(query)) > -1) {
+                    relevance = 15;
+                    matchPositionEnd = matchPositionStart + query.length();
+                } else {
+                    matchPositionStart = 0;
+                    matchPositionEnd = 0;
+                    if (contact.phoneSimplified.startsWith(query)) {
+                        relevance = 10;
+                    } else if (contact.phoneSimplified.contains(query)) {
+                        relevance = 5;
+                    }
                 }
             }
 


### PR DESCRIPTION
Don't miss contacts whose first and last name are glued together without any separator (or that have other unusual naming).

<!-- Better to fix KISS then rename all my contacts that were originally imported from a dumb phone's SIM card (and I keep on naming new contacts like this) -->