### PR TITLE
Strip redundant package prefix from SettingsActivity (fixes #733).

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -109,7 +109,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="fr.neamar.kiss.SettingsActivity"
+            android:name=".SettingsActivity"
             android:label="@string/activity_setting"
             android:theme="@style/SettingTheme" />
 


### PR DESCRIPTION
Just a minor cleanup.