### PR TITLE
fix add fav refresh

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -186,7 +186,7 @@ public class AppResult extends Result {
                 return true;
             case R.string.menu_tags_edit:
                 launchEditTagsDialog(context, appPojo);
-                break;
+                return true;
         }
 
         return super.popupMenuClickHandler(context, parent, stringId );


### PR DESCRIPTION
fix #790 "after setting a tag while showing all apps (a-z) it jumps back to history"
The list scroll still resets, I'll look into that at a later time.