### PR TITLE
Quick fix for app icon flicker

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -50,13 +50,6 @@ public class AppResult extends Result {
 		}
 
 		@Override
-		protected void onPreExecute()
-		{
-			super.onPreExecute();
-			image.setImageResource(android.R.color.transparent);
-		}
-
-		@Override
 		protected Drawable doInBackground( Void... voids )
 		{
 			if ( isCancelled() || view.getTag() != this )


### PR DESCRIPTION
The cached icon will remain visible until the new icon is loaded