### PR TITLE
Another attempt at fixing app flickering

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -59,6 +59,7 @@ public class AppResult extends Result {
             if (isCancelled() || drawable == null)
                 return;
             image.setImageDrawable(drawable);
+            image.setTag(appPojo.packageName);
             view.setTag(null);
         }
     }
@@ -101,8 +102,11 @@ public class AppResult extends Result {
                 view.setTag(null);
             }
 
-            view.setTag(new AsyncSetImage(view, appIcon).execute());
-            appIcon.setImageResource(android.R.color.transparent);
+            // Load new image if package is different from what we're currently displaying
+            if(!(appIcon.getTag() instanceof String) || !((appIcon.getTag()).equals(appPojo.packageName))) {
+                view.setTag(new AsyncSetImage(view, appIcon).execute());
+                appIcon.setImageResource(android.R.color.transparent);
+            }
         }
 
         return view;


### PR DESCRIPTION
Related to #801.

Looking at #801, I'm wondering if we're talking about the same thing, or if maybe my device behaves in a weird way.

I'll explain what I'm trying to fix *here*, and then we can decide if that was indeed the same issue or just me misunderstanding what "flicker" meant.

In my case, when searching for apps, for a couple ms (just enough for the eye to register) the app icon displayed will be the same as the app in the same position just before. For instance, if my history contains "Google Search" and I search for "Whatsapp", for the shortest amount of time I'll see the text "Whatsapp" with the "Google Search" image.

The same thing happens, for instance, when moving from the history to the app list (provided minimal history is disabled and open keyboard on start is off too, otherwise everything moves and it's hard to tell what's happening).

Another interesting thing is that, sometimes, for reasons probably related to the lazy loading of providers, the app will be refreshed with the exact same Results (let's say, for instance, I only have apps in my history, then the contact provider finishes to load and all the images are displayed again).

This fix will:

* Ensure no loading happens if the image currently displayed is already the one we'd load (for instance, when you launch an app, history is refreshed in the background which sometimes caused the app icon to disappear/reappear)
* Ensure the image currently used is cleared as soon as the record is displayed on screen
* Remove the current caching strategy