### PR TITLE
Freeze history

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,6 +215,6 @@
     <string name="user_experience_summary">Minimalistic UI, keyboard settings, …</string>
     <string name="title_favorites">Favorites settings</string>
     <string name="history_favorites_summary">Reset your favorites, remove favorites bar, …</string>
-    <string name="freeze_history_summary">Keep history as-is forever</string>
+    <string name="freeze_history_summary">Keep history as-is until unchecked</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,5 +215,6 @@
     <string name="user_experience_summary">Minimalistic UI, keyboard settings, …</string>
     <string name="title_favorites">Favorites settings</string>
     <string name="history_favorites_summary">Reset your favorites, remove favorites bar, …</string>
+    <string name="freeze_history_summary">Keep history as-is forever</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,6 +22,20 @@
             android:order="45"
             android:textColor="?attr/searchColor"
             android:title="@string/number_of_display_items" />
+        <ListPreference
+            android:defaultValue="recency"
+            android:entries="@array/historyModeEntries"
+            android:entryValues="@array/historyModeValues"
+            android:order="46"
+            android:key="history-mode"
+            android:summary="@string/history_mode_desc"
+            android:title="@string/history_mode_name" />
+        <fr.neamar.kiss.preference.FreezeHistorySwitch
+            android:defaultValue="false"
+            android:key="freeze-history"
+            android:order="47"
+            android:summary="@string/freeze_history_summary"
+            android:title="@string/freeze_history_name" />
         <PreferenceCategory
             android:order="50"
             android:title="@string/alternate_history_inputs">
@@ -215,17 +229,6 @@
             android:dialogMessage="@string/default_launcher_warn"
             android:key="default-launcher"
             android:title="@string/default_launcher_title" />
-        <ListPreference
-            android:defaultValue="recency"
-            android:entries="@array/historyModeEntries"
-            android:entryValues="@array/historyModeValues"
-            android:key="history-mode"
-            android:summary="@string/history_mode_desc"
-            android:title="@string/history_mode_name" />
-        <fr.neamar.kiss.preference.FreezeHistorySwitch
-            android:defaultValue="false"
-            android:key="freeze-history"
-            android:title="@string/freeze_history_name" />
         <fr.neamar.kiss.preference.RootModeSwitch
             android:defaultValue="false"
             android:key="root-mode"

--- a/docs/_posts/2018-02-24-freeze-history.md
+++ b/docs/_posts/2018-02-24-freeze-history.md
@@ -2,7 +2,7 @@
 title: Freeze history feature
 categories:
   - Favorites
-description: "How to freeze history to display more favorites"
+description: "How to freeze history in order to display more favorites"
 type: Document
 ---
 

--- a/docs/_posts/2018-02-24-freeze-history.md
+++ b/docs/_posts/2018-02-24-freeze-history.md
@@ -1,0 +1,19 @@
+---
+title: Freeze history feature
+categories:
+  - Favorites
+description: "How to freeze history to display more favorites"
+type: Document
+---
+
+KISS can display up to 5 favorites. If this is not enough for you, there is a way to freeze the history to always display the same results when you open KISS.
+
+The best way to use this feature is to reset all your history to start from a clean slate (`⋮, KISS Settings, History settings, Reset history`).
+
+> Make sure Minimalistic UI is turned off (`⋮, KISS Settings, User Experience, Minimalistic UI`).
+
+Then, search for everything that you want to see in your history.
+
+When you're ready, go back to the settings and Freeze history (`⋮, KISS Settings, History Settings, Freeze history`).
+
+From now on, the history list will always look the same as what it is *now*.


### PR DESCRIPTION
The freeze history option was still under "Advanced settings".

This will move "Freeze history" and "History mode" to history settings, where they logically belong.

Also added some documentation for the freeze history feature.