### PR TITLE
Stop storing Android context in static fields

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
         android:required="false" />
 
     <application
+        android:name=".KissApplication"
         android:allowBackup="true"
         android:hardwareAccelerated="true"
         android:icon="@drawable/ic_launcher"

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -46,7 +46,7 @@ public class DataHandler extends BroadcastReceiver
     final static private List<String> PROVIDER_NAMES = Arrays.asList(
             "app", "contacts", "phone", "search", "settings", "shortcuts", "toggles"
     );
-    private static TagsHandler tagsHandler;
+    private TagsHandler tagsHandler;
     final private Context context;
     private String currentQuery;
     private Map<String, ProviderEntry> providers = new HashMap<>();

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -50,7 +50,7 @@ public class DataHandler extends BroadcastReceiver
     final private Context context;
     private String currentQuery;
     private Map<String, ProviderEntry> providers = new HashMap<>();
-    private boolean providersReady = false;
+    public boolean allProvidersHaveLoaded = false;
 
     /**
      * Initialize all providers
@@ -192,7 +192,7 @@ public class DataHandler extends BroadcastReceiver
      * might be ready now
      */
     private void handleProviderLoaded() {
-        if (this.providersReady) {
+        if (this.allProvidersHaveLoaded) {
             return;
         }
 
@@ -212,7 +212,7 @@ public class DataHandler extends BroadcastReceiver
             // Nothing
         }
 
-        this.providersReady = true;
+        this.allProvidersHaveLoaded = true;
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -19,9 +19,9 @@ public class KissApplication extends Application {
         return (KissApplication) context.getApplicationContext();
     }
 
-    public DataHandler getDataHandler(Context ctx) {
+    public DataHandler getDataHandler() {
         if (dataHandler == null) {
-            dataHandler = new DataHandler(ctx);
+            dataHandler = new DataHandler(this);
         }
         return dataHandler;
     }
@@ -37,9 +37,9 @@ public class KissApplication extends Application {
         return cameraHandler;
     }
 
-    public RootHandler getRootHandler(Context ctx) {
+    public RootHandler getRootHandler() {
         if (rootHandler == null) {
-            rootHandler = new RootHandler(ctx);
+            rootHandler = new RootHandler(this);
         }
         return rootHandler;
     }
@@ -48,14 +48,14 @@ public class KissApplication extends Application {
         rootHandler.resetRootHandler(ctx);
     }
 
-    public void initDataHandler(Context ctx) {
+    public void initDataHandler() {
         if (dataHandler == null) {
-            dataHandler = new DataHandler(ctx);
+            dataHandler = new DataHandler(this);
         }
         else {
             // Already loaded! We still need to fire the FULL_LOAD event
             Intent i = new Intent(MainActivity.FULL_LOAD_OVER);
-            ctx.sendBroadcast(i);
+            sendBroadcast(i);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -1,52 +1,54 @@
 package fr.neamar.kiss;
 
+import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 
-public class KissApplication {
+public class KissApplication extends Application {
     /**
      * Number of ms to wait, after a click occurred, to record a launch
      * Setting this value to 0 removes all animations
      */
     public static final int TOUCH_DELAY = 120;
-    private static DataHandler dataHandler;
-    private static CameraHandler cameraHandler;
-    private static RootHandler rootHandler;
+    private DataHandler dataHandler;
+    private CameraHandler cameraHandler;
+    private RootHandler rootHandler;
     private IconsHandler iconsPackHandler;
 
-    private KissApplication() {
+    public static KissApplication getApplication(Context context) {
+        return (KissApplication) context.getApplicationContext();
     }
 
-    public static DataHandler getDataHandler(Context ctx) {
+    public DataHandler getDataHandler(Context ctx) {
         if (dataHandler == null) {
             dataHandler = new DataHandler(ctx);
         }
         return dataHandler;
     }
 
-    public static void setDataHandler(DataHandler newDataHandler) {
+    public void setDataHandler(DataHandler newDataHandler) {
         dataHandler = newDataHandler;
     }
 
-    public static CameraHandler getCameraHandler() {
+    public CameraHandler getCameraHandler() {
         if (cameraHandler == null) {
             cameraHandler = new CameraHandler();
         }
         return cameraHandler;
     }
 
-    public static RootHandler getRootHandler(Context ctx) {
+    public RootHandler getRootHandler(Context ctx) {
         if (rootHandler == null) {
             rootHandler = new RootHandler(ctx);
         }
         return rootHandler;
     }
 
-    public static void resetRootHandler(Context ctx) {
+    public void resetRootHandler(Context ctx) {
         rootHandler.resetRootHandler(ctx);
     }
 
-    public static void initDataHandler(Context ctx) {
+    public void initDataHandler(Context ctx) {
         if (dataHandler == null) {
             dataHandler = new DataHandler(ctx);
         }
@@ -57,16 +59,16 @@ public class KissApplication {
         }
     }
 
-    public static IconsHandler getIconsHandler(Context ctx) {
+    public IconsHandler getIconsHandler() {
         if (iconsPackHandler == null) {
-            iconsPackHandler = new IconsHandler(ctx);
+            iconsPackHandler = new IconsHandler(this);
         }
 
         return iconsPackHandler;
     }
 
-    public static void resetIconsHandler(Context ctx) {
-        iconsPackHandler = new IconsHandler(ctx);
+    public void resetIconsHandler() {
+        iconsPackHandler = new IconsHandler(this);
     }
 
 }

--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -19,6 +19,13 @@ public class KissApplication extends Application {
         return (KissApplication) context.getApplicationContext();
     }
 
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // When opening the app for any reason, start loading the data handler
+        initDataHandler();
+    }
+
     public DataHandler getDataHandler() {
         if (dataHandler == null) {
             dataHandler = new DataHandler(this);
@@ -52,7 +59,7 @@ public class KissApplication extends Application {
         if (dataHandler == null) {
             dataHandler = new DataHandler(this);
         }
-        else {
+        else if(dataHandler.allProvidersHaveLoaded) {
             // Already loaded! We still need to fire the FULL_LOAD event
             Intent i = new Intent(MainActivity.FULL_LOAD_OVER);
             sendBroadcast(i);

--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -12,7 +12,7 @@ public class KissApplication {
     private static DataHandler dataHandler;
     private static CameraHandler cameraHandler;
     private static RootHandler rootHandler;
-    private static IconsHandler iconsPackHandler;
+    private IconsHandler iconsPackHandler;
 
     private KissApplication() {
     }

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -180,7 +180,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.registerReceiver(mReceiver, intentFilterLoad);
         this.registerReceiver(mReceiver, intentFilterLoadOver);
         this.registerReceiver(mReceiver, intentFilterFullLoadOver);
-        KissApplication.getApplication(this).initDataHandler();
 
         /*
          * Set the view and store all useful components

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -180,7 +180,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.registerReceiver(mReceiver, intentFilterLoad);
         this.registerReceiver(mReceiver, intentFilterLoadOver);
         this.registerReceiver(mReceiver, intentFilterFullLoadOver);
-        KissApplication.initDataHandler(this);
+        KissApplication.getApplication(this).initDataHandler(this);
 
         /*
          * Set the view and store all useful components
@@ -388,13 +388,13 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         super.onDestroy();
         // unregister our receiver
         this.unregisterReceiver(this.mReceiver);
-        KissApplication.getCameraHandler().releaseCamera();
+        KissApplication.getApplication(this).getCameraHandler().releaseCamera();
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        KissApplication.getCameraHandler().releaseCamera();
+        KissApplication.getApplication(this).getCameraHandler().releaseCamera();
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -180,7 +180,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.registerReceiver(mReceiver, intentFilterLoad);
         this.registerReceiver(mReceiver, intentFilterLoadOver);
         this.registerReceiver(mReceiver, intentFilterFullLoadOver);
-        KissApplication.getApplication(this).initDataHandler(this);
+        KissApplication.getApplication(this).initDataHandler();
 
         /*
          * Set the view and store all useful components

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -111,7 +111,7 @@ public class SettingsActivity extends PreferenceActivity implements
                     multiPreference.setDialogMessage(R.string.ui_excluded_apps_not_found);
                 }
 
-                final AppProvider provider = KissApplication.getDataHandler(SettingsActivity.this).getAppProvider();
+                final AppProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler(SettingsActivity.this).getAppProvider();
                 if (provider != null) {
                     provider.reload();
                 }
@@ -168,7 +168,7 @@ public class SettingsActivity extends PreferenceActivity implements
             @SuppressWarnings("unchecked")
             public boolean onPreferenceChange(Preference preference, Object newValue) {
 
-                final SearchProvider provider = KissApplication.getDataHandler(SettingsActivity.this).getSearchProvider();
+                final SearchProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler(SettingsActivity.this).getSearchProvider();
                 if (provider != null) {
                     provider.reload();
                 }
@@ -224,7 +224,7 @@ public class SettingsActivity extends PreferenceActivity implements
                 }
 
                 // Reload search list
-                final SearchProvider provider = KissApplication.getDataHandler(SettingsActivity.this).getSearchProvider();
+                final SearchProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler(SettingsActivity.this).getSearchProvider();
                 if (provider != null) {
                     provider.reload();
                 }
@@ -246,10 +246,10 @@ public class SettingsActivity extends PreferenceActivity implements
         if (key.equalsIgnoreCase("available-search-providers")) {
             addCustomSearchProvidersPreferences(prefs);
         } else if (key.equalsIgnoreCase("icons-pack")) {
-            KissApplication.getIconsHandler(this).loadIconsPack(sharedPreferences.getString(key, "default"));
+            KissApplication.getApplication(this).getIconsHandler().loadIconsPack(sharedPreferences.getString(key, "default"));
         } else if (key.equalsIgnoreCase("sort-apps")) {
             // Reload application list
-            final AppProvider provider = KissApplication.getDataHandler(this).getAppProvider();
+            final AppProvider provider = KissApplication.getApplication(this).getDataHandler(this).getAppProvider();
             if (provider != null) {
                 provider.reload();
             }
@@ -279,7 +279,7 @@ public class SettingsActivity extends PreferenceActivity implements
 
     @SuppressWarnings("deprecation")
     private void fixSummaries() {
-        int historyLength = KissApplication.getDataHandler(this).getHistoryLength();
+        int historyLength = KissApplication.getApplication(this).getDataHandler(this).getHistoryLength();
         if (historyLength > 5) {
             findPreference("reset").setSummary(String.format(getString(R.string.items_title), historyLength));
         }
@@ -303,7 +303,7 @@ public class SettingsActivity extends PreferenceActivity implements
     }
 
     protected void setListPreferenceIconsPacksData(ListPreference lp) {
-        IconsHandler iph = KissApplication.getIconsHandler(this);
+        IconsHandler iph = KissApplication.getApplication(this).getIconsHandler();
 
         CharSequence[] entries = new CharSequence[iph.getIconsPacks().size() + 1];
         CharSequence[] entryValues = new CharSequence[iph.getIconsPacks().size() + 1];

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -111,7 +111,7 @@ public class SettingsActivity extends PreferenceActivity implements
                     multiPreference.setDialogMessage(R.string.ui_excluded_apps_not_found);
                 }
 
-                final AppProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler(SettingsActivity.this).getAppProvider();
+                final AppProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler().getAppProvider();
                 if (provider != null) {
                     provider.reload();
                 }
@@ -168,7 +168,7 @@ public class SettingsActivity extends PreferenceActivity implements
             @SuppressWarnings("unchecked")
             public boolean onPreferenceChange(Preference preference, Object newValue) {
 
-                final SearchProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler(SettingsActivity.this).getSearchProvider();
+                final SearchProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler().getSearchProvider();
                 if (provider != null) {
                     provider.reload();
                 }
@@ -224,7 +224,7 @@ public class SettingsActivity extends PreferenceActivity implements
                 }
 
                 // Reload search list
-                final SearchProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler(SettingsActivity.this).getSearchProvider();
+                final SearchProvider provider = KissApplication.getApplication(SettingsActivity.this).getDataHandler().getSearchProvider();
                 if (provider != null) {
                     provider.reload();
                 }
@@ -249,7 +249,7 @@ public class SettingsActivity extends PreferenceActivity implements
             KissApplication.getApplication(this).getIconsHandler().loadIconsPack(sharedPreferences.getString(key, "default"));
         } else if (key.equalsIgnoreCase("sort-apps")) {
             // Reload application list
-            final AppProvider provider = KissApplication.getApplication(this).getDataHandler(this).getAppProvider();
+            final AppProvider provider = KissApplication.getApplication(this).getDataHandler().getAppProvider();
             if (provider != null) {
                 provider.reload();
             }
@@ -279,7 +279,7 @@ public class SettingsActivity extends PreferenceActivity implements
 
     @SuppressWarnings("deprecation")
     private void fixSummaries() {
-        int historyLength = KissApplication.getApplication(this).getDataHandler(this).getHistoryLength();
+        int historyLength = KissApplication.getApplication(this).getDataHandler().getHistoryLength();
         if (historyLength > 5) {
             findPreference("reset").setSummary(String.format(getString(R.string.items_title), historyLength));
         }

--- a/app/src/main/java/fr/neamar/kiss/TagsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/TagsHandler.java
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -21,11 +20,11 @@ import fr.neamar.kiss.db.DBHelper;
  */
 
 public class TagsHandler {
-    Context context;
+    private Context context;
     //cached tags
     private Map<String, String> tagsCache;
 
-    public TagsHandler(Context context) {
+    TagsHandler(Context context) {
         this.context = context;
         tagsCache = DBHelper.loadTags(this.context);
         addDefaultAliases();
@@ -50,7 +49,6 @@ public class TagsHandler {
 
     public String[] getAllTagsAsArray() {
         Set<String> tags = new HashSet<>();
-        String[] tagsNew;
         for (Map.Entry<String, String> entry : tagsCache.entrySet()) {
             tags.addAll(Arrays.asList(entry.getValue().split("\\s+")));
         }
@@ -60,7 +58,6 @@ public class TagsHandler {
 
     private void addDefaultAliases() {
         final PackageManager pm = context.getPackageManager();
-        ArrayList alias = new ArrayList<>();
 
         String phoneApp = getApp(pm, Intent.ACTION_DIAL);
         if (phoneApp != null) {

--- a/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallHandler.java
@@ -21,7 +21,7 @@ public class IncomingCallHandler extends BroadcastReceiver {
         }
 
         try {
-            DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler(context);
+            DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
             ContactsProvider contactsProvider = dataHandler.getContactsProvider();
 
             // Stop if contacts are not enabled

--- a/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallHandler.java
@@ -15,9 +15,13 @@ public class IncomingCallHandler extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, Intent intent) {
+        // Only handle calls received
+        if (!intent.getAction().equals("android.intent.action.PHONE_STATE")) {
+            return;
+        }
 
         try {
-            DataHandler dataHandler = KissApplication.getDataHandler(context);
+            DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler(context);
             ContactsProvider contactsProvider = dataHandler.getContactsProvider();
 
             // Stop if contacts are not enabled

--- a/app/src/main/java/fr/neamar/kiss/broadcast/IncomingSmsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/IncomingSmsHandler.java
@@ -20,7 +20,7 @@ public class IncomingSmsHandler extends BroadcastReceiver {
         }
 
         // Stop if contacts are not enabled
-        DataHandler dataHandler = KissApplication.getDataHandler(context);
+        DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler(context);
         ContactsProvider contactsProvider = dataHandler.getContactsProvider();
         if (contactsProvider == null) {
             // Contacts have been disabled from settings

--- a/app/src/main/java/fr/neamar/kiss/broadcast/IncomingSmsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/IncomingSmsHandler.java
@@ -20,7 +20,7 @@ public class IncomingSmsHandler extends BroadcastReceiver {
         }
 
         // Stop if contacts are not enabled
-        DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler(context);
+        DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
         ContactsProvider contactsProvider = dataHandler.getContactsProvider();
         if (contactsProvider == null) {
             // Contacts have been disabled from settings

--- a/app/src/main/java/fr/neamar/kiss/broadcast/InstallShortcutHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/InstallShortcutHandler.java
@@ -19,7 +19,7 @@ public class InstallShortcutHandler extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent data) {
 
-        DataHandler dh = KissApplication.getApplication(context).getDataHandler(context);
+        DataHandler dh = KissApplication.getApplication(context).getDataHandler();
         ShortcutsProvider sp = dh.getShortcutsProvider();
 
         if (sp == null)

--- a/app/src/main/java/fr/neamar/kiss/broadcast/InstallShortcutHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/InstallShortcutHandler.java
@@ -19,7 +19,7 @@ public class InstallShortcutHandler extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent data) {
 
-        DataHandler dh = KissApplication.getDataHandler(context);
+        DataHandler dh = KissApplication.getApplication(context).getDataHandler(context);
         ShortcutsProvider sp = dh.getShortcutsProvider();
 
         if (sp == null)

--- a/app/src/main/java/fr/neamar/kiss/broadcast/LocaleChangedReceiver.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/LocaleChangedReceiver.java
@@ -16,10 +16,10 @@ public class LocaleChangedReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context ctx, Intent intent) {
         // If new locale, then reset tags to load the correct aliases
-        KissApplication.getDataHandler(ctx).resetTagsHandler();
+        KissApplication.getApplication(ctx).getDataHandler(ctx).resetTagsHandler();
 
         // Reload application list
-        final AppProvider provider = KissApplication.getDataHandler(ctx).getAppProvider();
+        final AppProvider provider = KissApplication.getApplication(ctx).getDataHandler(ctx).getAppProvider();
         if (provider != null) {
             provider.reload();
         }

--- a/app/src/main/java/fr/neamar/kiss/broadcast/LocaleChangedReceiver.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/LocaleChangedReceiver.java
@@ -16,10 +16,10 @@ public class LocaleChangedReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context ctx, Intent intent) {
         // If new locale, then reset tags to load the correct aliases
-        KissApplication.getApplication(ctx).getDataHandler(ctx).resetTagsHandler();
+        KissApplication.getApplication(ctx).getDataHandler().resetTagsHandler();
 
         // Reload application list
-        final AppProvider provider = KissApplication.getApplication(ctx).getDataHandler(ctx).getAppProvider();
+        final AppProvider provider = KissApplication.getApplication(ctx).getDataHandler().getAppProvider();
         if (provider != null) {
             provider.reload();
         }

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -32,21 +32,21 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
                 String className = launchIntent.getComponent().getClassName();
                 if (className != null) {
                     String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
-                    KissApplication.getApplication(ctx).getDataHandler(ctx).addToHistory(pojoID);
+                    KissApplication.getApplication(ctx).getDataHandler().addToHistory(pojoID);
                 }
             }
         }
 
         if ("android.intent.action.PACKAGE_REMOVED".equals(action) && !replacing) {
             // Removed all installed shortcuts
-            KissApplication.getApplication(ctx).getDataHandler(ctx).removeShortcuts(packageName);
-            KissApplication.getApplication(ctx).getDataHandler(ctx).removeFromExcluded(packageName, user);
+            KissApplication.getApplication(ctx).getDataHandler().removeShortcuts(packageName);
+            KissApplication.getApplication(ctx).getDataHandler().removeFromExcluded(packageName, user);
         }
 
         KissApplication.getApplication(ctx).resetIconsHandler();
 
         // Reload application list
-        final AppProvider provider = KissApplication.getApplication(ctx).getDataHandler(ctx).getAppProvider();
+        final AppProvider provider = KissApplication.getApplication(ctx).getDataHandler().getAppProvider();
         if (provider != null) {
             provider.reload();
         }

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -32,21 +32,21 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
                 String className = launchIntent.getComponent().getClassName();
                 if (className != null) {
                     String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
-                    KissApplication.getDataHandler(ctx).addToHistory(pojoID);
+                    KissApplication.getApplication(ctx).getDataHandler(ctx).addToHistory(pojoID);
                 }
             }
         }
 
         if ("android.intent.action.PACKAGE_REMOVED".equals(action) && !replacing) {
             // Removed all installed shortcuts
-            KissApplication.getDataHandler(ctx).removeShortcuts(packageName);
-            KissApplication.getDataHandler(ctx).removeFromExcluded(packageName, user);
+            KissApplication.getApplication(ctx).getDataHandler(ctx).removeShortcuts(packageName);
+            KissApplication.getApplication(ctx).getDataHandler(ctx).removeFromExcluded(packageName, user);
         }
 
-        KissApplication.resetIconsHandler(ctx);
+        KissApplication.getApplication(ctx).resetIconsHandler();
 
         // Reload application list
-        final AppProvider provider = KissApplication.getDataHandler(ctx).getAppProvider();
+        final AppProvider provider = KissApplication.getApplication(ctx).getDataHandler(ctx).getAppProvider();
         if (provider != null) {
             provider.reload();
         }

--- a/app/src/main/java/fr/neamar/kiss/broadcast/UninstallShortcutHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/UninstallShortcutHandler.java
@@ -15,7 +15,7 @@ public class UninstallShortcutHandler extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent data) {
 
-        DataHandler dh = KissApplication.getApplication(context).getDataHandler(context);
+        DataHandler dh = KissApplication.getApplication(context).getDataHandler();
         ShortcutsProvider sp = dh.getShortcutsProvider();
 
         if (sp == null)

--- a/app/src/main/java/fr/neamar/kiss/broadcast/UninstallShortcutHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/UninstallShortcutHandler.java
@@ -15,7 +15,7 @@ public class UninstallShortcutHandler extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent data) {
 
-        DataHandler dh = KissApplication.getDataHandler(context);
+        DataHandler dh = KissApplication.getApplication(context).getDataHandler(context);
         ShortcutsProvider sp = dh.getShortcutsProvider();
 
         if (sp == null)

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -9,6 +9,7 @@ import android.content.pm.LauncherApps;
 import android.os.Build;
 import android.os.Process;
 import android.os.UserManager;
+import android.support.annotation.RequiresApi;
 import android.util.Pair;
 
 import java.util.ArrayList;
@@ -97,12 +98,13 @@ public class AppProvider extends Provider<AppPojo> {
             filter.addAction(Intent.ACTION_MANAGED_PROFILE_ADDED);
             filter.addAction(Intent.ACTION_MANAGED_PROFILE_REMOVED);
             this.registerReceiver(new BroadcastReceiver() {
+                @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
                 @Override
                 public void onReceive(Context context, Intent intent) {
                     if (Objects.equals(intent.getAction(), Intent.ACTION_MANAGED_PROFILE_ADDED)) {
                         AppProvider.this.reload();
                     } else if (Objects.equals(intent.getAction(), Intent.ACTION_MANAGED_PROFILE_REMOVED)) {
-                        android.os.UserHandle profile = (android.os.UserHandle) intent.getParcelableExtra(Intent.EXTRA_USER);
+                        android.os.UserHandle profile = intent.getParcelableExtra(Intent.EXTRA_USER);
 
                         UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -108,8 +108,8 @@ public class AppProvider extends Provider<AppPojo> {
 
                         UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
 
-                        KissApplication.getApplication(context).getDataHandler(context).removeFromExcluded(user);
-                        KissApplication.getApplication(context).getDataHandler(context).removeFromFavorites(user);
+                        KissApplication.getApplication(context).getDataHandler().removeFromExcluded(user);
+                        KissApplication.getApplication(context).getDataHandler().removeFromFavorites(user);
                         AppProvider.this.reload();
                     }
                 }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.dataprovider;
 
+import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -12,6 +13,7 @@ import android.util.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.broadcast.PackageAddedRemovedHandler;
@@ -27,12 +29,16 @@ import fr.neamar.kiss.utils.UserHandle;
 public class AppProvider extends Provider<AppPojo> {
 
     @Override
+    @SuppressLint("NewApi")
     public void onCreate() {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             // Package installation/uninstallation events for the main
             // profile are still handled using PackageAddedRemovedHandler itself
             final UserManager manager = (UserManager) this.getSystemService(Context.USER_SERVICE);
+            assert manager != null;
+
             final LauncherApps launcher = (LauncherApps) this.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            assert launcher != null;
 
             launcher.registerCallback(new LauncherApps.Callback() {
                 @Override
@@ -93,9 +99,9 @@ public class AppProvider extends Provider<AppPojo> {
             this.registerReceiver(new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
-                    if (intent.getAction().equals(Intent.ACTION_MANAGED_PROFILE_ADDED)) {
+                    if (Objects.equals(intent.getAction(), Intent.ACTION_MANAGED_PROFILE_ADDED)) {
                         AppProvider.this.reload();
-                    } else if (intent.getAction().equals(Intent.ACTION_MANAGED_PROFILE_REMOVED)) {
+                    } else if (Objects.equals(intent.getAction(), Intent.ACTION_MANAGED_PROFILE_REMOVED)) {
                         android.os.UserHandle profile = (android.os.UserHandle) intent.getParcelableExtra(Intent.EXTRA_USER);
 
                         UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
@@ -171,19 +177,17 @@ public class AppProvider extends Provider<AppPojo> {
      * Return a Pojo
      *
      * @param id              we're looking for
-     * @param allowSideEffect do we allow this function to have potential side effect? Set to false to ensure none.
      * @return an AppPojo, or null
      */
-    public Pojo findById(String id, Boolean allowSideEffect) {
+    @Override
+    public Pojo findById(String id) {
         for (Pojo pojo : pojos) {
             if (pojo.id.equals(id)) {
                 // Reset displayName to default value
-                if (allowSideEffect) {
-                    pojo.displayName = pojo.getName();
-                    if (pojo instanceof PojoWithTags) {
-                        PojoWithTags tagsPojo = (PojoWithTags) pojo;
-                        tagsPojo.displayTags = tagsPojo.getTags();
-                    }
+                pojo.displayName = pojo.getName();
+                if (pojo instanceof PojoWithTags) {
+                    PojoWithTags tagsPojo = (PojoWithTags) pojo;
+                    tagsPojo.displayTags = tagsPojo.getTags();
                 }
                 return pojo;
             }
@@ -191,11 +195,6 @@ public class AppProvider extends Provider<AppPojo> {
         }
 
         return null;
-    }
-
-    @Override
-    public Pojo findById(String id) {
-        return findById(id, true);
     }
 
     public ArrayList<Pojo> getAllApps() {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -108,8 +108,8 @@ public class AppProvider extends Provider<AppPojo> {
 
                         UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
 
-                        KissApplication.getDataHandler(context).removeFromExcluded(user);
-                        KissApplication.getDataHandler(context).removeFromFavorites(user);
+                        KissApplication.getApplication(context).getDataHandler(context).removeFromExcluded(user);
+                        KissApplication.getApplication(context).getDataHandler(context).removeFromFavorites(user);
                         AppProvider.this.reload();
                     }
                 }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/FavoriteForwarder.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/FavoriteForwarder.java
@@ -83,7 +83,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
     public void onFavoriteChange() {
         int[] favoritesIds = FAV_IDS;
 
-        favoritesPojo = KissApplication.getDataHandler(mainActivity)
+        favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler(mainActivity)
                 .getFavorites(TRY_TO_RETRIEVE);
 
         // Don't look for items after favIds length, we won't be able to display them
@@ -134,7 +134,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
                 if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
-                    KissApplication.getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
+                    KissApplication.getApplication(mainActivity).getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
         }
@@ -145,7 +145,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
                 if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
-                    KissApplication.getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
+                    KissApplication.getApplication(mainActivity).getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
 
@@ -158,7 +158,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
                 String packageName = resolveInfo.activityInfo.packageName;
 
                 if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
-                    KissApplication.getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
+                    KissApplication.getApplication(mainActivity).getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/FavoriteForwarder.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/FavoriteForwarder.java
@@ -83,7 +83,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
     public void onFavoriteChange() {
         int[] favoritesIds = FAV_IDS;
 
-        favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler(mainActivity)
+        favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler()
                 .getFavorites(TRY_TO_RETRIEVE);
 
         // Don't look for items after favIds length, we won't be able to display them
@@ -134,7 +134,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
                 if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
-                    KissApplication.getApplication(mainActivity).getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
+                    KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
         }
@@ -145,7 +145,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
                 if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
-                    KissApplication.getApplication(mainActivity).getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
+                    KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
 
@@ -158,7 +158,7 @@ public class FavoriteForwarder extends Forwarder implements View.OnClickListener
                 String packageName = resolveInfo.activityInfo.packageName;
 
                 if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
-                    KissApplication.getApplication(mainActivity).getDataHandler(mainActivity).addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
+                    KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -27,7 +27,7 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 
     public LoadAppPojos(Context context) {
         super(context, "app://");
-        tagsHandler = KissApplication.getApplication(context).getDataHandler(context).getTagsHandler();
+        tagsHandler = KissApplication.getApplication(context).getDataHandler().getTagsHandler();
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -27,7 +27,7 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 
     public LoadAppPojos(Context context) {
         super(context, "app://");
-        tagsHandler = KissApplication.getDataHandler(context).getTagsHandler();
+        tagsHandler = KissApplication.getApplication(context).getDataHandler(context).getTagsHandler();
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
@@ -18,7 +18,7 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutsPojo> {
 
     public LoadShortcutsPojos(Context context) {
         super(context, ShortcutsPojo.SCHEME);
-        tagsHandler = KissApplication.getDataHandler(context).getTagsHandler();
+        tagsHandler = KissApplication.getApplication(context).getDataHandler(context).getTagsHandler();
     }
 
     @Override
@@ -42,7 +42,7 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutsPojo> {
         return pojos;
     }
 
-    public ShortcutsPojo createPojo(String name) {
+    private ShortcutsPojo createPojo(String name) {
         ShortcutsPojo pojo = new ShortcutsPojo();
 
         pojo.id = ShortcutsPojo.SCHEME + name.toLowerCase();

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
@@ -18,7 +18,7 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutsPojo> {
 
     public LoadShortcutsPojos(Context context) {
         super(context, ShortcutsPojo.SCHEME);
-        tagsHandler = KissApplication.getApplication(context).getDataHandler(context).getTagsHandler();
+        tagsHandler = KissApplication.getApplication(context).getDataHandler().getTagsHandler();
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
@@ -179,8 +179,8 @@ public class AddSearchProviderPreference extends DialogPreference {
             //persistString(providerName.getText().toString());
             Set<String> availableProviders = new HashSet<String>(prefs.getStringSet("available-search-providers", SearchProvider.getSearchProviders(this.getContext())));
             availableProviders.add(providerName.getText().toString() + "|" + providerUrl.getText().toString().toLowerCase());
-            prefs.edit().putStringSet("available-search-providers", availableProviders).commit();
-            prefs.edit().putStringSet("deleting-search-providers-names", availableProviders).commit();
+            prefs.edit().putStringSet("available-search-providers", availableProviders).apply();
+            prefs.edit().putStringSet("deleting-search-providers-names", availableProviders).apply();
 
             Toast.makeText(getContext(), R.string.search_provider_added, Toast.LENGTH_LONG).show();
         }

--- a/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
@@ -120,6 +120,7 @@ public class ColorPreference extends DialogPreference implements OnColorSelected
 
     @Override
     protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
         android.util.Log.i("ColorPreference", "View Width:  " + view.getWidth() + " | " + view.getMeasuredWidth());
         // Set selected color value based on the actual color value currently used
         // (but fall back to default from XML)

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
@@ -21,7 +21,7 @@ public class ResetExcludedAppsPreference extends DialogPreference {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
-                    .putString("excluded-apps-list", getContext().getPackageName() + ";").commit();
+                    .putString("excluded-apps-list", getContext().getPackageName() + ";").apply();
             KissApplication.getDataHandler(getContext()).getAppProvider().reload();
             Toast.makeText(getContext(), R.string.excluded_app_list_erased, Toast.LENGTH_LONG).show();
         }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
@@ -22,7 +22,7 @@ public class ResetExcludedAppsPreference extends DialogPreference {
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
                     .putString("excluded-apps-list", getContext().getPackageName() + ";").apply();
-            KissApplication.getApplication(getContext()).getDataHandler(getContext()).getAppProvider().reload();
+            KissApplication.getApplication(getContext()).getDataHandler().getAppProvider().reload();
             Toast.makeText(getContext(), R.string.excluded_app_list_erased, Toast.LENGTH_LONG).show();
         }
 

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
@@ -22,7 +22,7 @@ public class ResetExcludedAppsPreference extends DialogPreference {
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
                     .putString("excluded-apps-list", getContext().getPackageName() + ";").apply();
-            KissApplication.getDataHandler(getContext()).getAppProvider().reload();
+            KissApplication.getApplication(getContext()).getDataHandler(getContext()).getAppProvider().reload();
             Toast.makeText(getContext(), R.string.excluded_app_list_erased, Toast.LENGTH_LONG).show();
         }
 

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetFavoritesPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetFavoritesPreference.java
@@ -21,7 +21,7 @@ public class ResetFavoritesPreference extends DialogPreference {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
-                    .putString("favorite-apps-list", "").commit();
+                    .putString("favorite-apps-list", "").apply();
             KissApplication.getDataHandler(getContext()).getAppProvider().reload();
             Toast.makeText(getContext(), R.string.favorites_erased, Toast.LENGTH_LONG).show();
         }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetFavoritesPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetFavoritesPreference.java
@@ -22,7 +22,7 @@ public class ResetFavoritesPreference extends DialogPreference {
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
                     .putString("favorite-apps-list", "").apply();
-            KissApplication.getDataHandler(getContext()).getAppProvider().reload();
+            KissApplication.getApplication(getContext()).getDataHandler(getContext()).getAppProvider().reload();
             Toast.makeText(getContext(), R.string.favorites_erased, Toast.LENGTH_LONG).show();
         }
 

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetFavoritesPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetFavoritesPreference.java
@@ -22,7 +22,7 @@ public class ResetFavoritesPreference extends DialogPreference {
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
                     .putString("favorite-apps-list", "").apply();
-            KissApplication.getApplication(getContext()).getDataHandler(getContext()).getAppProvider().reload();
+            KissApplication.getApplication(getContext()).getDataHandler().getAppProvider().reload();
             Toast.makeText(getContext(), R.string.favorites_erased, Toast.LENGTH_LONG).show();
         }
 

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetPreference.java
@@ -20,7 +20,9 @@ public class ResetPreference extends DialogPreference {
     public void onClick(DialogInterface dialog, int which) {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
-            KissApplication.getApplication(getContext()).getDataHandler(getContext()).clearHistory();
+            KissApplication.getApplication(getContext()).getDataHandler().clearHistory();
+
+            // We'll have to redraw the list, so add a flag for MainActivity to restart
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit().putBoolean("require-layout-update", true).apply();
 
             Toast.makeText(getContext(), R.string.history_erased, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetPreference.java
@@ -20,7 +20,7 @@ public class ResetPreference extends DialogPreference {
     public void onClick(DialogInterface dialog, int which) {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
-            KissApplication.getDataHandler(getContext()).clearHistory();
+            KissApplication.getApplication(getContext()).getDataHandler(getContext()).clearHistory();
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit().putBoolean("require-layout-update", true).apply();
 
             Toast.makeText(getContext(), R.string.history_erased, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetSearchProvidersPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetSearchProvidersPreference.java
@@ -24,7 +24,7 @@ public class ResetSearchProvidersPreference extends DialogPreference {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
                     .remove("available-search-providers").apply();
             Toast.makeText(getContext(), R.string.search_provider_reset_done_desc, Toast.LENGTH_LONG).show();
-            SearchProvider searchProvider = KissApplication.getDataHandler(this.getContext()).getSearchProvider();
+            SearchProvider searchProvider = KissApplication.getApplication(getContext()).getDataHandler(getContext()).getSearchProvider();
             if (searchProvider != null) {
                 searchProvider.reload();
             }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetSearchProvidersPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetSearchProvidersPreference.java
@@ -24,7 +24,7 @@ public class ResetSearchProvidersPreference extends DialogPreference {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
                     .remove("available-search-providers").apply();
             Toast.makeText(getContext(), R.string.search_provider_reset_done_desc, Toast.LENGTH_LONG).show();
-            SearchProvider searchProvider = KissApplication.getApplication(getContext()).getDataHandler(getContext()).getSearchProvider();
+            SearchProvider searchProvider = KissApplication.getApplication(getContext()).getDataHandler().getSearchProvider();
             if (searchProvider != null) {
                 searchProvider.reload();
             }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetSearchProvidersPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetSearchProvidersPreference.java
@@ -22,7 +22,7 @@ public class ResetSearchProvidersPreference extends DialogPreference {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
-                    .remove("available-search-providers").commit();
+                    .remove("available-search-providers").apply();
             Toast.makeText(getContext(), R.string.search_provider_reset_done_desc, Toast.LENGTH_LONG).show();
             SearchProvider searchProvider = KissApplication.getDataHandler(this.getContext()).getSearchProvider();
             if (searchProvider != null) {

--- a/app/src/main/java/fr/neamar/kiss/preference/RootModePreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RootModePreference.java
@@ -18,7 +18,7 @@ public class RootModePreference extends CheckBoxPreference {
 
     @Override
     protected void onClick() {
-        if (!isChecked() && !KissApplication.getRootHandler(getContext()).isRootAvailable()) {
+        if (!isChecked() && !KissApplication.getApplication(getContext()).getRootHandler(getContext()).isRootAvailable()) {
             //show error dialog
             new AlertDialog.Builder(getContext()).setMessage(R.string.root_mode_error)
                     .setPositiveButton(android.R.string.ok, new OnClickListener() {
@@ -33,7 +33,7 @@ public class RootModePreference extends CheckBoxPreference {
         }
 
         try {
-            KissApplication.resetRootHandler(getContext());
+            KissApplication.getApplication(getContext()).resetRootHandler(getContext());
         } catch (NullPointerException e) {
             // uninitialized roothandler.
         }

--- a/app/src/main/java/fr/neamar/kiss/preference/RootModePreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RootModePreference.java
@@ -18,7 +18,7 @@ public class RootModePreference extends CheckBoxPreference {
 
     @Override
     protected void onClick() {
-        if (!isChecked() && !KissApplication.getApplication(getContext()).getRootHandler(getContext()).isRootAvailable()) {
+        if (!isChecked() && !KissApplication.getApplication(getContext()).getRootHandler().isRootAvailable()) {
             //show error dialog
             new AlertDialog.Builder(getContext()).setMessage(R.string.root_mode_error)
                     .setPositiveButton(android.R.string.ok, new OnClickListener() {

--- a/app/src/main/java/fr/neamar/kiss/preference/RootModeSwitch.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RootModeSwitch.java
@@ -17,7 +17,7 @@ public class RootModeSwitch extends SwitchPreference {
 
     @Override
     protected void onClick() {
-        if (!isChecked() && !KissApplication.getApplication(getContext()).getRootHandler(getContext()).isRootAvailable()) {
+        if (!isChecked() && !KissApplication.getApplication(getContext()).getRootHandler().isRootAvailable()) {
             //show error dialog
             new AlertDialog.Builder(getContext()).setMessage(R.string.root_mode_error)
                     .setPositiveButton(android.R.string.ok, new OnClickListener() {

--- a/app/src/main/java/fr/neamar/kiss/preference/RootModeSwitch.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RootModeSwitch.java
@@ -11,22 +11,13 @@ import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 
 public class RootModeSwitch extends SwitchPreference {
-
-    public RootModeSwitch(Context context) {
-        this(context, null);
-    }
-
-    public RootModeSwitch(Context context, AttributeSet attrs) {
-        this(context, attrs, android.R.attr.switchPreferenceStyle);
-    }
-
     public RootModeSwitch(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
     }
 
     @Override
     protected void onClick() {
-        if (!isChecked() && !KissApplication.getRootHandler(getContext()).isRootAvailable()) {
+        if (!isChecked() && !KissApplication.getApplication(getContext()).getRootHandler(getContext()).isRootAvailable()) {
             //show error dialog
             new AlertDialog.Builder(getContext()).setMessage(R.string.root_mode_error)
                     .setPositiveButton(android.R.string.ok, new OnClickListener() {
@@ -41,7 +32,7 @@ public class RootModeSwitch extends SwitchPreference {
         }
 
         try {
-            KissApplication.resetRootHandler(getContext());
+            KissApplication.getApplication(getContext()).resetRootHandler(getContext());
         } catch (NullPointerException e) {
             // uninitialized roothandler.
         }

--- a/app/src/main/java/fr/neamar/kiss/preference/RootModeSwitch.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RootModeSwitch.java
@@ -11,6 +11,14 @@ import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 
 public class RootModeSwitch extends SwitchPreference {
+    public RootModeSwitch(Context context) {
+        this(context, null);
+    }
+
+    public RootModeSwitch(Context context, AttributeSet attrs) {
+        this(context, attrs, android.R.attr.switchPreferenceStyle);
+    }
+
     public RootModeSwitch(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
     }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -158,7 +158,6 @@ public class AppResult extends Result {
         builder.setTitle(context.getResources().getString(R.string.tags_add_title));
 
         // Create the tag dialog
-
         final View v = LayoutInflater.from(context).inflate(R.layout.tags_dialog, null);
         final MultiAutoCompleteTextView tagInput = (MultiAutoCompleteTextView) v.findViewById(R.id.tag_input);
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(context,

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -112,7 +112,7 @@ public class AppResult extends Result {
         }
 
         //append root menu if available
-        if (KissApplication.getRootHandler(context).isRootActivated() && KissApplication.getRootHandler(context).isRootAvailable()) {
+        if (KissApplication.getApplication(context).getRootHandler(context).isRootActivated() && KissApplication.getApplication(context).getRootHandler(context).isRootAvailable()) {
             adapter.add(new ListPopup.Item(context, R.string.menu_app_hibernate));
         }
         return menu;
@@ -144,10 +144,10 @@ public class AppResult extends Result {
     }
 
     private void excludeFromAppList(Context context, AppPojo appPojo) {
-        KissApplication.getDataHandler(context).addToExcluded(appPojo.packageName, appPojo.userHandle);
+        KissApplication.getApplication(context).getDataHandler(context).addToExcluded(appPojo.packageName, appPojo.userHandle);
         //remove app pojo from appProvider results - no need to reset handler
-        KissApplication.getDataHandler(context).getAppProvider().removeApp(appPojo);
-        KissApplication.getDataHandler(context).removeFromFavorites((MainActivity) context, appPojo.id);
+        KissApplication.getApplication(context).getDataHandler(context).getAppProvider().removeApp(appPojo);
+        KissApplication.getApplication(context).getDataHandler(context).removeFromFavorites((MainActivity) context, appPojo.id);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
 
     }
@@ -161,7 +161,7 @@ public class AppResult extends Result {
         final View v = LayoutInflater.from(context).inflate(R.layout.tags_dialog, null);
         final MultiAutoCompleteTextView tagInput = (MultiAutoCompleteTextView) v.findViewById(R.id.tag_input);
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(context,
-                android.R.layout.simple_dropdown_item_1line, KissApplication.getDataHandler(context).getTagsHandler().getAllTagsAsArray());
+                android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().getAllTagsAsArray());
         tagInput.setTokenizer(new SpaceTokenizer());
         tagInput.setText(appPojo.getTags());
 
@@ -174,7 +174,7 @@ public class AppResult extends Result {
                 dialog.dismiss();
                 // Refresh tags for given app
                 app.setTags(tagInput.getText().toString());
-                KissApplication.getDataHandler(context).getTagsHandler().setTags(app.id, app.getTags());
+                KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().setTags(app.id, app.getTags());
                 // TODO: update the displayTags with proper highlight
                 app.displayTags = app.getTags();
                 // Show toast message
@@ -201,6 +201,7 @@ public class AppResult extends Result {
     private void launchAppDetails(Context context, AppPojo app) {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            assert launcher != null;
             launcher.startAppDetailsActivity(className, appPojo.userHandle.getRealHandle(), null, null);
         } else {
             Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
@@ -211,7 +212,7 @@ public class AppResult extends Result {
 
     private void hibernate(Context context, AppPojo app) {
         String msg = context.getResources().getString(R.string.toast_hibernate_completed);
-        if (!KissApplication.getRootHandler(context).hibernateApp(appPojo.packageName)) {
+        if (!KissApplication.getApplication(context).getRootHandler(context).hibernateApp(appPojo.packageName)) {
             msg = context.getResources().getString(R.string.toast_hibernate_error);
         }
 
@@ -241,7 +242,7 @@ public class AppResult extends Result {
     public Drawable getDrawable(Context context) {
         synchronized (this) {
             if (icon == null) {
-                icon = KissApplication.getIconsHandler(context)
+                icon = KissApplication.getApplication(context).getIconsHandler()
                         .getDrawableIconForPackage(className, this.appPojo.userHandle);
             }
 
@@ -254,6 +255,7 @@ public class AppResult extends Result {
         try {
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+                assert launcher != null;
                 launcher.startMainActivity(className, appPojo.userHandle.getRealHandle(), v.getClipBounds(), null);
             } else {
                 Intent intent = new Intent(Intent.ACTION_MAIN);

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -112,7 +112,7 @@ public class AppResult extends Result {
         }
 
         //append root menu if available
-        if (KissApplication.getApplication(context).getRootHandler(context).isRootActivated() && KissApplication.getApplication(context).getRootHandler(context).isRootAvailable()) {
+        if (KissApplication.getApplication(context).getRootHandler().isRootActivated() && KissApplication.getApplication(context).getRootHandler().isRootAvailable()) {
             adapter.add(new ListPopup.Item(context, R.string.menu_app_hibernate));
         }
         return menu;
@@ -144,10 +144,10 @@ public class AppResult extends Result {
     }
 
     private void excludeFromAppList(Context context, AppPojo appPojo) {
-        KissApplication.getApplication(context).getDataHandler(context).addToExcluded(appPojo.packageName, appPojo.userHandle);
+        KissApplication.getApplication(context).getDataHandler().addToExcluded(appPojo.packageName, appPojo.userHandle);
         //remove app pojo from appProvider results - no need to reset handler
-        KissApplication.getApplication(context).getDataHandler(context).getAppProvider().removeApp(appPojo);
-        KissApplication.getApplication(context).getDataHandler(context).removeFromFavorites((MainActivity) context, appPojo.id);
+        KissApplication.getApplication(context).getDataHandler().getAppProvider().removeApp(appPojo);
+        KissApplication.getApplication(context).getDataHandler().removeFromFavorites((MainActivity) context, appPojo.id);
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
 
     }
@@ -161,7 +161,7 @@ public class AppResult extends Result {
         final View v = LayoutInflater.from(context).inflate(R.layout.tags_dialog, null);
         final MultiAutoCompleteTextView tagInput = (MultiAutoCompleteTextView) v.findViewById(R.id.tag_input);
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(context,
-                android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().getAllTagsAsArray());
+                android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler().getTagsHandler().getAllTagsAsArray());
         tagInput.setTokenizer(new SpaceTokenizer());
         tagInput.setText(appPojo.getTags());
 
@@ -174,7 +174,7 @@ public class AppResult extends Result {
                 dialog.dismiss();
                 // Refresh tags for given app
                 app.setTags(tagInput.getText().toString());
-                KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().setTags(app.id, app.getTags());
+                KissApplication.getApplication(context).getDataHandler().getTagsHandler().setTags(app.id, app.getTags());
                 // TODO: update the displayTags with proper highlight
                 app.displayTags = app.getTags();
                 // Show toast message
@@ -212,7 +212,7 @@ public class AppResult extends Result {
 
     private void hibernate(Context context, AppPojo app) {
         String msg = context.getResources().getString(R.string.toast_hibernate_completed);
-        if (!KissApplication.getApplication(context).getRootHandler(context).hibernateApp(appPojo.packageName)) {
+        if (!KissApplication.getApplication(context).getRootHandler().hibernateApp(appPojo.packageName)) {
             msg = context.getResources().getString(R.string.toast_hibernate_error);
         }
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -202,13 +202,13 @@ public abstract class Result {
 
     private void launchAddToFavorites(Context context, Pojo app) {
         String msg = context.getResources().getString(R.string.toast_favorites_added);
-        KissApplication.getDataHandler(context).addToFavorites((MainActivity) context, app.id);
+        KissApplication.getApplication(context).getDataHandler(context).addToFavorites((MainActivity) context, app.id);
         Toast.makeText(context, String.format(msg, app.getName()), Toast.LENGTH_SHORT).show();
     }
 
     private void launchRemoveFromFavorites(Context context, Pojo app) {
         String msg = context.getResources().getString(R.string.toast_favorites_removed);
-        KissApplication.getDataHandler(context).removeFromFavorites((MainActivity) context, app.id);
+        KissApplication.getApplication(context).getDataHandler(context).removeFromFavorites((MainActivity) context, app.id);
         Toast.makeText(context, String.format(msg, app.getName()), Toast.LENGTH_SHORT).show();
     }
 
@@ -313,7 +313,7 @@ public abstract class Result {
      */
     void recordLaunch(Context context) {
         // Save in history
-        KissApplication.getDataHandler(context).addToHistory(pojo.id);
+        KissApplication.getApplication(context).getDataHandler(context).addToHistory(pojo.id);
     }
 
     public void deleteRecord(Context context) {

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -202,13 +202,13 @@ public abstract class Result {
 
     private void launchAddToFavorites(Context context, Pojo app) {
         String msg = context.getResources().getString(R.string.toast_favorites_added);
-        KissApplication.getApplication(context).getDataHandler(context).addToFavorites((MainActivity) context, app.id);
+        KissApplication.getApplication(context).getDataHandler().addToFavorites((MainActivity) context, app.id);
         Toast.makeText(context, String.format(msg, app.getName()), Toast.LENGTH_SHORT).show();
     }
 
     private void launchRemoveFromFavorites(Context context, Pojo app) {
         String msg = context.getResources().getString(R.string.toast_favorites_removed);
-        KissApplication.getApplication(context).getDataHandler(context).removeFromFavorites((MainActivity) context, app.id);
+        KissApplication.getApplication(context).getDataHandler().removeFromFavorites((MainActivity) context, app.id);
         Toast.makeText(context, String.format(msg, app.getName()), Toast.LENGTH_SHORT).show();
     }
 
@@ -313,7 +313,7 @@ public abstract class Result {
      */
     void recordLaunch(Context context) {
         // Save in history
-        KissApplication.getApplication(context).getDataHandler(context).addToHistory(pojo.id);
+        KissApplication.getApplication(context).getDataHandler().addToHistory(pojo.id);
     }
 
     public void deleteRecord(Context context) {

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -28,7 +28,6 @@ import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
-import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.ShortcutsPojo;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.SpaceTokenizer;
@@ -153,7 +152,7 @@ public class ShortcutsResult extends Result {
         final View v = LayoutInflater.from(context).inflate(R.layout.tags_dialog, null);
         final MultiAutoCompleteTextView tagInput = (MultiAutoCompleteTextView) v.findViewById(R.id.tag_input);
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(context,
-                android.R.layout.simple_dropdown_item_1line, KissApplication.getDataHandler(context).getTagsHandler().getAllTagsAsArray());
+                android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().getAllTagsAsArray());
         tagInput.setTokenizer(new SpaceTokenizer());
         tagInput.setText(shortcutPojo.getTags());
 
@@ -166,7 +165,7 @@ public class ShortcutsResult extends Result {
                 dialog.dismiss();
                 // Refresh tags for given app
                 pojo.setTags(tagInput.getText().toString());
-                KissApplication.getDataHandler(context).getTagsHandler().setTags(pojo.id, pojo.getTags());
+                KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().setTags(pojo.id, pojo.getTags());
                 // TODO: update the displayTags with proper highlight
                 pojo.displayTags = pojo.getTags();
                 // Show toast message
@@ -189,7 +188,7 @@ public class ShortcutsResult extends Result {
 
 
     private void launchUninstall(Context context, ShortcutsPojo shortcutPojo) {
-        DataHandler dh = KissApplication.getDataHandler(context);
+        DataHandler dh = KissApplication.getApplication(context).getDataHandler(context);
         if (dh != null) {
             dh.removeShortcut(shortcutPojo);
         }

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -152,7 +152,7 @@ public class ShortcutsResult extends Result {
         final View v = LayoutInflater.from(context).inflate(R.layout.tags_dialog, null);
         final MultiAutoCompleteTextView tagInput = (MultiAutoCompleteTextView) v.findViewById(R.id.tag_input);
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(context,
-                android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().getAllTagsAsArray());
+                android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler().getTagsHandler().getAllTagsAsArray());
         tagInput.setTokenizer(new SpaceTokenizer());
         tagInput.setText(shortcutPojo.getTags());
 
@@ -165,7 +165,7 @@ public class ShortcutsResult extends Result {
                 dialog.dismiss();
                 // Refresh tags for given app
                 pojo.setTags(tagInput.getText().toString());
-                KissApplication.getApplication(context).getDataHandler(context).getTagsHandler().setTags(pojo.id, pojo.getTags());
+                KissApplication.getApplication(context).getDataHandler().getTagsHandler().setTags(pojo.id, pojo.getTags());
                 // TODO: update the displayTags with proper highlight
                 pojo.displayTags = pojo.getTags();
                 // Show toast message
@@ -188,7 +188,7 @@ public class ShortcutsResult extends Result {
 
 
     private void launchUninstall(Context context, ShortcutsPojo shortcutPojo) {
-        DataHandler dh = KissApplication.getApplication(context).getDataHandler(context);
+        DataHandler dh = KissApplication.getApplication(context).getDataHandler();
         if (dh != null) {
             dh.removeShortcut(shortcutPojo);
         }

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -43,7 +43,7 @@ public class ApplicationsSearcher extends Searcher {
         if (activity == null)
             return null;
 
-        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler(activity).getApplications();
+        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler().getApplications();
         this.addResult(pojos.toArray(new Pojo[0]));
         return null;
     }

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -43,7 +43,7 @@ public class ApplicationsSearcher extends Searcher {
         if (activity == null)
             return null;
 
-        List<Pojo> pojos = KissApplication.getDataHandler(activity).getApplications();
+        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler(activity).getApplications();
         this.addResult(pojos.toArray(new Pojo[0]));
         return null;
     }

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -39,13 +39,13 @@ public class HistorySearcher extends Searcher {
         if (activity == null)
             return null;
 
-        //Gather favorites
+        // Gather favorites
         ArrayList<Pojo> favoritesPojo = new ArrayList<>(0);
         if (excludeFavorites) {
-            favoritesPojo = KissApplication.getDataHandler(activity).getFavorites(FavoriteForwarder.TRY_TO_RETRIEVE);
+            favoritesPojo = KissApplication.getApplication(activity).getDataHandler(activity).getFavorites(FavoriteForwarder.TRY_TO_RETRIEVE);
         }
 
-        List<Pojo> pojos = KissApplication.getDataHandler(activity).getHistory(activity, getMaxResultCount(), smartHistory, favoritesPojo);
+        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler(activity).getHistory(activity, getMaxResultCount(), smartHistory, favoritesPojo);
 
         int size = pojos.size();
         for(int i = 0; i < size; i += 1) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -42,10 +42,10 @@ public class HistorySearcher extends Searcher {
         // Gather favorites
         ArrayList<Pojo> favoritesPojo = new ArrayList<>(0);
         if (excludeFavorites) {
-            favoritesPojo = KissApplication.getApplication(activity).getDataHandler(activity).getFavorites(FavoriteForwarder.TRY_TO_RETRIEVE);
+            favoritesPojo = KissApplication.getApplication(activity).getDataHandler().getFavorites(FavoriteForwarder.TRY_TO_RETRIEVE);
         }
 
-        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler(activity).getHistory(activity, getMaxResultCount(), smartHistory, favoritesPojo);
+        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler().getHistory(activity, getMaxResultCount(), smartHistory, favoritesPojo);
 
         int size = pojos.size();
         for(int i = 0; i < size; i += 1) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -70,7 +70,7 @@ public class QuerySearcher extends Searcher {
         }
 
         // Request results via "addResult"
-        KissApplication.getDataHandler(activity).requestResults(query, this);
+        KissApplication.getApplication(activity).getDataHandler(activity).requestResults(query, this);
         return null;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -70,7 +70,7 @@ public class QuerySearcher extends Searcher {
         }
 
         // Request results via "addResult"
-        KissApplication.getApplication(activity).getDataHandler(activity).requestResults(query, this);
+        KissApplication.getApplication(activity).getDataHandler().requestResults(query, this);
         return null;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/toggles/TogglesHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/toggles/TogglesHandler.java
@@ -16,6 +16,7 @@ import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.pojo.TogglesPojo;
 
 public class TogglesHandler {
+    private final Context context;
     private final ConnectivityManager connectivityManager;
     private final WifiManager wifiManager;
     private final BluetoothAdapter bluetoothAdapter;
@@ -28,6 +29,7 @@ public class TogglesHandler {
      * @param context android context
      */
     public TogglesHandler(Context context) {
+        this.context = context.getApplicationContext();
         this.connectivityManager = (ConnectivityManager) context
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         this.wifiManager = (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
@@ -148,12 +150,12 @@ public class TogglesHandler {
     }
 
     private Boolean getTorchState() {
-        return KissApplication.getCameraHandler().isTorchAvailable() && KissApplication.getCameraHandler().getTorchState();
+        return KissApplication.getApplication(context).getCameraHandler().isTorchAvailable() && KissApplication.getApplication(context).getCameraHandler().getTorchState();
     }
 
     private void setTorchState(Boolean state) {
-        if (KissApplication.getCameraHandler().isTorchAvailable()) {
-            KissApplication.getCameraHandler().setTorchState(state);
+        if (KissApplication.getApplication(context).getCameraHandler().isTorchAvailable()) {
+            KissApplication.getApplication(context).getCameraHandler().setTorchState(state);
         }
     }
 


### PR DESCRIPTION
This issue has been here since day 1...

Back then, I didn't know how to code for Android (not much has changed since then!)

The DataHandler was static, and that way everyone had access to it.

Turns out that pretty much every single class needs it, and the DataHandler needs the context for various tasks and services.

This means the context was stored in a static field, and that's BAD DESIGN™ (especially since the context was often an instance of MainActivity...)

This PR finally uses the "standard" Android Application class overrides, and store everything on the application.