### PR TITLE
Improved startup time

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -10,6 +10,7 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap.CompressFormat;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.widget.Toast;
 
 import java.io.ByteArrayOutputStream;
@@ -36,6 +37,8 @@ import fr.neamar.kiss.utils.UserHandle;
 
 public class DataHandler extends BroadcastReceiver
         implements SharedPreferences.OnSharedPreferenceChangeListener {
+    final static private String TAG = "DataHandler";
+
     /**
      * Package the providers reside in
      */
@@ -127,6 +130,9 @@ public class DataHandler extends BroadcastReceiver
             return;
         }
 
+        Log.v(TAG, "Connecting to " + name);
+
+
         // Find provider class for the given service name
         Intent intent = this.providerName2Intent(name);
         if (intent == null) {
@@ -203,20 +209,22 @@ public class DataHandler extends BroadcastReceiver
             }
         }
 
+        Log.v(TAG, "All providers are loaded.");
+        this.allProvidersHaveLoaded = true;
+
         // Broadcast the fact that the new providers list is ready
         try {
             this.context.unregisterReceiver(this);
             Intent i = new Intent(MainActivity.FULL_LOAD_OVER);
             this.context.sendBroadcast(i);
         } catch (IllegalArgumentException e) {
-            // Nothing
+            e.printStackTrace();
         }
-
-        this.allProvidersHaveLoaded = true;
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        // A provider finished loading and contacted us
         this.handleProviderLoaded();
     }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -342,6 +342,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
         if(KissApplication.getApplication(this).getDataHandler().allProvidersHaveLoaded) {
             displayLoader(false);
+            onFavoriteChange();
         }
 
         forwarderManager.onResume();
@@ -567,9 +568,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         if (display) {
             searchEditText.setText("");
             // Display the app list
-            if (searchTask != null) {
-                searchTask.cancel(true);
-            }
+            resetTask();
+
             searchTask = new ApplicationsSearcher(MainActivity.this);
             searchTask.executeOnExecutor(Searcher.SEARCH_THREAD);
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      * Favorites bar. Can be either the favorites within the KISS bar,
      * or the external favorites bar (default)
      */
-    public View favorites;
+    public View favoritesBar;
 
     /**
      * Task launched on text change

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -112,11 +112,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     private Searcher searchTask;
 
     /**
-     * A flag set to true after all providers reported loading is over
-     */
-    public Boolean allProvidersHaveLoaded = false;
-
-    /**
      * SystemUiVisibility helper
      */
     public SystemUiVisibilityHelper systemUiVisibilityHelper;
@@ -131,6 +126,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Log.d(TAG, "onCreate()");
 
         /*
          * Initialize preferences
@@ -158,7 +154,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 } else if (intent.getAction().equalsIgnoreCase(FULL_LOAD_OVER)) {
                     Log.v(TAG, "All providers are done loading.");
 
-                    allProvidersHaveLoaded = true;
                     displayLoader(false);
 
                     // Run GC once to free all the garbage accumulated during provider initialization
@@ -327,7 +322,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      */
     @SuppressLint("CommitPrefEdits")
     protected void onResume() {
-        Log.i(TAG, "Resuming KISS");
+        Log.d(TAG, "onResume()");
 
         if (prefs.getBoolean("require-layout-update", false)) {
             super.onResume();
@@ -343,11 +338,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             mPopup.dismiss();
         }
 
-        if (isViewingSearchResults()) {
-            updateRecords();
-            displayClearOnInput();
-        } else {
-            displayKissBar(false);
+        if(KissApplication.getApplication(this).getDataHandler().allProvidersHaveLoaded) {
+            displayLoader(false);
         }
 
         forwarderManager.onResume();
@@ -665,7 +657,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         // now we can cleanup the filter:
         if (!searchEditText.getText().toString().isEmpty()) {
             searchEditText.setText("");
+            displayClearOnInput();
             hideKeyboard();
+        }
+        else if(isViewingAllApps()) {
+            displayKissBar(false);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -217,9 +217,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             public void onChanged() {
                 super.onChanged();
                 if (adapter.isEmpty()) {
+                    // Display help text when no results available
                     listContainer.setVisibility(View.GONE);
                     emptyListView.setVisibility(View.VISIBLE);
                 } else {
+                    // Otherwise, display results
                     listContainer.setVisibility(View.VISIBLE);
                     emptyListView.setVisibility(View.GONE);
                 }

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -159,7 +159,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                     Log.v(TAG, "All providers are done loading.");
 
                     allProvidersHaveLoaded = true;
-                    forwarderManager.onAllProvidersLoaded();
+                    displayLoader(false);
 
                     // Run GC once to free all the garbage accumulated during provider initialization
                     System.gc();

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -54,9 +54,18 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context ctx, Intent intent) {
+        String packageName = intent.getData().getSchemeSpecificPart();
+
+        if(packageName.equalsIgnoreCase(ctx.getPackageName())) {
+            // When running KISS locally, sending a new version of the APK immediately triggers a "package removed" for fr.neamar.kiss,
+            // There is no need to handle this event.
+            // Discarding it makes startup time much faster locally as apps don't have to be loaded twice.
+            return;
+        }
+
         handleEvent(ctx,
                 intent.getAction(),
-                intent.getData().getSchemeSpecificPart(), new UserHandle(),
+                packageName, new UserHandle(),
                 intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)
         );
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -121,6 +121,7 @@ public class AppProvider extends Provider<AppPojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadAppPojos(this));
     }
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
@@ -26,6 +26,7 @@ public class ContactsProvider extends Provider<ContactsPojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadContactsPojos(this));
     }
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/PhoneProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/PhoneProvider.java
@@ -16,6 +16,7 @@ public class PhoneProvider extends Provider<PhonePojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadPhonePojos(this));
 
         PackageManager pm = this.getPackageManager();

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
@@ -14,6 +14,8 @@ import fr.neamar.kiss.loader.LoadPojos;
 import fr.neamar.kiss.pojo.Pojo;
 
 public abstract class Provider<T extends Pojo> extends Service implements IProvider {
+    private final static String TAG = "Provider";
+
     /**
      * Binder given to clients
      */
@@ -41,21 +43,25 @@ public abstract class Provider<T extends Pojo> extends Service implements IProvi
 
 
     void initialize(LoadPojos<T> loader) {
-        Log.i("Provider.initialize", "Starting provider: " + this.getClass().getSimpleName());
+        Log.i(TAG, "Starting provider: " + this.getClass().getSimpleName());
 
         loader.setProvider(this);
         this.pojoScheme = loader.getPojoScheme();
         loader.execute();
     }
 
-    public abstract void reload();
+    public void reload() {
+        if(pojos.size() > 0) {
+            Log.v(TAG, "Reloading provider: " + this.getClass().getSimpleName());
+        }
+    };
 
     public boolean isLoaded() {
         return this.loaded;
     }
 
     public void loadOver(ArrayList<T> results) {
-        Log.i("Provider.loadOver", "Done loading provider: " + this.getClass().getSimpleName());
+        Log.i(TAG, "Done loading provider: " + this.getClass().getSimpleName());
 
         // Store results
         this.pojos = results;

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/SearchProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/SearchProvider.java
@@ -28,6 +28,7 @@ public class SearchProvider extends Provider<SearchPojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadSearchPojos(this));
     }
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/SettingsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/SettingsProvider.java
@@ -12,6 +12,7 @@ public class SettingsProvider extends Provider<SettingsPojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadSettingsPojos(this));
 
         settingName = this.getString(R.string.settings_prefix).toLowerCase();

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ShortcutsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ShortcutsProvider.java
@@ -16,6 +16,7 @@ public class ShortcutsProvider extends Provider<ShortcutsPojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadShortcutsPojos(this));
     }
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/TogglesProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/TogglesProvider.java
@@ -12,6 +12,7 @@ public class TogglesProvider extends Provider<TogglesPojo> {
 
     @Override
     public void reload() {
+        super.reload();
         this.initialize(new LoadTogglesPojos(this));
 
         toggleName = this.getString(R.string.toggles_prefix).toLowerCase();

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -44,6 +44,8 @@ class ExperienceTweaks extends Forwarder {
         }
     };
 
+    private View mainEmptyView;
+
     ExperienceTweaks(MainActivity mainActivity) {
         super(mainActivity);
 
@@ -62,6 +64,7 @@ class ExperienceTweaks extends Forwarder {
 
     void onCreate() {
         adjustInputType(null);
+        mainEmptyView = mainActivity.findViewById(R.id.main_empty);
     }
 
     void onResume() {
@@ -82,6 +85,13 @@ class ExperienceTweaks extends Forwarder {
             // Not used (thanks windowSoftInputMode)
             // unless coming back from KISS settings
             mainActivity.hideKeyboard();
+        }
+
+        if (isMinimalisticModeEnabled()) {
+            mainEmptyView.setVisibility(View.GONE);
+
+            mainActivity.list.setVerticalScrollBarEnabled(false);
+            mainActivity.searchEditText.setHint("");
         }
     }
 
@@ -132,21 +142,15 @@ class ExperienceTweaks extends Forwarder {
 
         if (query.isEmpty()) {
             if (isMinimalisticModeEnabled()) {
-                mainActivity.list.setVerticalScrollBarEnabled(false);
-                mainActivity.searchEditText.setHint("");
                 mainActivity.runTask(new NullSearcher(mainActivity));
-                //Hide default scrollview
-                mainActivity.findViewById(R.id.main_empty).setVisibility(View.GONE);
+                // By default, help text is displayed -- not in minimalistic mode.
+                mainEmptyView.setVisibility(View.GONE);
 
                 if (isMinimalisticModeEnabledForFavorites()) {
                     mainActivity.favoritesBar.setVisibility(View.GONE);
                 }
             } else {
-                mainActivity.list.setVerticalScrollBarEnabled(true);
-                mainActivity.searchEditText.setHint(R.string.ui_search_hint);
                 mainActivity.runTask(new HistorySearcher(mainActivity));
-                //Show default scrollview
-                mainActivity.findViewById(R.id.main_empty).setVisibility(View.VISIBLE);
             }
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -101,7 +101,7 @@ class ExperienceTweaks extends Forwarder {
             }
 
             if (isMinimalisticModeEnabledForFavorites()) {
-                mainActivity.favorites.setVisibility(View.VISIBLE);
+                mainActivity.favoritesBar.setVisibility(View.VISIBLE);
             }
         }
     }
@@ -115,9 +115,9 @@ class ExperienceTweaks extends Forwarder {
     void onDisplayKissBar(Boolean display) {
         if (isMinimalisticModeEnabledForFavorites()) {
             if (display) {
-                mainActivity.favorites.setVisibility(View.VISIBLE);
+                mainActivity.favoritesBar.setVisibility(View.VISIBLE);
             } else {
-                mainActivity.favorites.setVisibility(View.GONE);
+                mainActivity.favoritesBar.setVisibility(View.GONE);
             }
         }
 
@@ -139,7 +139,7 @@ class ExperienceTweaks extends Forwarder {
                 mainActivity.findViewById(R.id.main_empty).setVisibility(View.GONE);
 
                 if (isMinimalisticModeEnabledForFavorites()) {
-                    mainActivity.favorites.setVisibility(View.GONE);
+                    mainActivity.favoritesBar.setVisibility(View.GONE);
                 }
             } else {
                 mainActivity.list.setVerticalScrollBarEnabled(true);

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -73,10 +73,6 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         }
     }
 
-    void onAllProvidersLoaded() {
-        onFavoriteChange();
-    }
-
     void onFavoriteChange() {
         int[] favoritesIds = FAV_IDS;
 
@@ -94,7 +90,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
             if (drawable != null) {
                 image.setImageDrawable(drawable);
             } else {
-                Log.e(TAG, "Falling back to default image for favorite.");
+                Log.w(TAG, "Falling back to default image for favorite.");
                 // Use the default contact image otherwise
                 image.setImageResource(R.drawable.ic_contact);
             }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -30,7 +30,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
      * IDs for the favorites buttons
      */
     private final static int[] FAV_IDS = new int[]{R.id.favorite0, R.id.favorite1, R.id.favorite2, R.id.favorite3, R.id.favorite4, R.id.favorite5};
-    private View[] favoritesView;
+    private View[] favoritesViews;
 
     /**
      * Number of favorites that can be displayed
@@ -63,9 +63,9 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
             mainActivity.findViewById(R.id.externalFavoriteBar).setVisibility(View.GONE);
         }
 
-        favoritesView = new View[FAV_IDS.length];
+        favoritesViews = new View[FAV_IDS.length];
         for (int i = 0; i < FAV_IDS.length; i++) {
-            favoritesView[i] = mainActivity.favoritesBar.findViewById(FAV_IDS[i]);
+            favoritesViews[i] = mainActivity.favoritesBar.findViewById(FAV_IDS[i]);
         }
 
         registerClickOnFavorites();
@@ -91,7 +91,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         for (int i = 0; i < Math.min(favoritesIds.length, favoritesPojo.size()); i++) {
             Pojo pojo = favoritesPojo.get(i);
 
-            ImageView image = (ImageView) favoritesView[i];
+            ImageView image = (ImageView) favoritesViews[i];
 
             Result result = Result.fromPojo(mainActivity, pojo);
             Drawable drawable = result.getDrawable(mainActivity);
@@ -109,7 +109,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
 
         // Hide empty favorites (not enough favorites yet)
         for (int i = favoritesPojo.size(); i < favoritesIds.length; i++) {
-            favoritesView[i].setVisibility(View.GONE);
+            favoritesViews[i].setVisibility(View.GONE);
         }
     }
 
@@ -164,13 +164,13 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
     }
 
     private void registerClickOnFavorites() {
-        for (View v : favoritesView) {
+        for (View v : favoritesViews) {
             v.setOnClickListener(this);
         }
     }
 
     private void registerLongClickOnFavorites() {
-        for (View v : favoritesView) {
+        for (View v : favoritesViews) {
             v.setOnLongClickListener(this);
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -23,10 +23,14 @@ import fr.neamar.kiss.ui.ListPopup;
 public class Favorites extends Forwarder implements View.OnClickListener, View.OnLongClickListener {
     private static final String TAG = "FavoriteForwarder";
 
+    // Package used by Android when an Intent can be matched with more than one app
+    private static final String DEFAULT_RESOLVER = "com.android.internal.app.ResolverActivity";
+
     /**
      * IDs for the favorites buttons
      */
     private final static int[] FAV_IDS = new int[]{R.id.favorite0, R.id.favorite1, R.id.favorite2, R.id.favorite3, R.id.favorite4, R.id.favorite5};
+    private View[] favoritesView;
 
     /**
      * Number of favorites that can be displayed
@@ -49,15 +53,19 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
     }
 
     void onCreate() {
-        if(prefs.getBoolean("enable-favorites-bar", true)) {
-            mainActivity.favorites = mainActivity.findViewById(R.id.externalFavoriteBar);
+        if (prefs.getBoolean("enable-favorites-bar", true)) {
+            mainActivity.favoritesBar = mainActivity.findViewById(R.id.externalFavoriteBar);
             // Hide the embedded bar
             mainActivity.findViewById(R.id.embeddedFavoritesBar).setVisibility(View.INVISIBLE);
-        }
-        else {
-            mainActivity.favorites = mainActivity.findViewById(R.id.embeddedFavoritesBar);
+        } else {
+            mainActivity.favoritesBar = mainActivity.findViewById(R.id.embeddedFavoritesBar);
             // Hide the external bar
             mainActivity.findViewById(R.id.externalFavoriteBar).setVisibility(View.GONE);
+        }
+
+        favoritesView = new View[FAV_IDS.length];
+        for (int i = 0; i < FAV_IDS.length; i++) {
+            favoritesView[i] = mainActivity.favoritesBar.findViewById(FAV_IDS[i]);
         }
 
         registerClickOnFavorites();
@@ -83,7 +91,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         for (int i = 0; i < Math.min(favoritesIds.length, favoritesPojo.size()); i++) {
             Pojo pojo = favoritesPojo.get(i);
 
-            ImageView image = (ImageView) mainActivity.favorites.findViewById(favoritesIds[i]);
+            ImageView image = (ImageView) favoritesView[i];
 
             Result result = Result.fromPojo(mainActivity, pojo);
             Drawable drawable = result.getDrawable(mainActivity);
@@ -101,16 +109,15 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
 
         // Hide empty favorites (not enough favorites yet)
         for (int i = favoritesPojo.size(); i < favoritesIds.length; i++) {
-            mainActivity.favorites.findViewById(favoritesIds[i]).setVisibility(View.GONE);
+            favoritesView[i].setVisibility(View.GONE);
         }
     }
 
     void updateRecords(String query) {
-        if(query.isEmpty()) {
-            mainActivity.favorites.setVisibility(View.VISIBLE);
-        }
-        else {
-            mainActivity.favorites.setVisibility(View.GONE);
+        if (query.isEmpty()) {
+            mainActivity.favoritesBar.setVisibility(View.VISIBLE);
+        } else {
+            mainActivity.favoritesBar.setVisibility(View.GONE);
         }
     }
 
@@ -125,7 +132,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
             ResolveInfo resolveInfo = mainActivity.getPackageManager().resolveActivity(phoneIntent, PackageManager.MATCH_DEFAULT_ONLY);
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
-                if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
+                if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals(DEFAULT_RESOLVER))) {
                     KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
@@ -136,7 +143,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
             ResolveInfo resolveInfo = mainActivity.getPackageManager().resolveActivity(contactsIntent, PackageManager.MATCH_DEFAULT_ONLY);
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
-                if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
+                if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals(DEFAULT_RESOLVER))) {
                     KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
@@ -149,7 +156,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
             if (resolveInfo != null) {
                 String packageName = resolveInfo.activityInfo.packageName;
 
-                if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals("com.android.internal.app.ResolverActivity"))) {
+                if ((resolveInfo.activityInfo.name != null) && (!resolveInfo.activityInfo.name.equals(DEFAULT_RESOLVER))) {
                     KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(mainActivity, "app://" + packageName + "/" + resolveInfo.activityInfo.name);
                 }
             }
@@ -157,14 +164,14 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
     }
 
     private void registerClickOnFavorites() {
-        for (int id : FAV_IDS) {
-            mainActivity.favorites.findViewById(id).setOnClickListener(this);
+        for (View v : favoritesView) {
+            v.setOnClickListener(this);
         }
     }
 
     private void registerLongClickOnFavorites() {
-        for (int id : FAV_IDS) {
-            mainActivity.favorites.findViewById(id).setOnLongClickListener(this);
+        for (View v : favoritesView) {
+            v.setOnLongClickListener(this);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
@@ -75,10 +75,6 @@ public class ForwarderManager extends Forwarder {
         experienceTweaksProvider.updateRecords(query);
     }
 
-    public void onAllProvidersLoaded() {
-        favoritesForwarder.onAllProvidersLoaded();
-    }
-
     public void onFavoriteChange() {
         favoritesForwarder.onFavoriteChange();
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -44,7 +44,7 @@ class InterfaceTweaks extends Forwarder {
         // Transparent Search and Favorites bar
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             if (prefs.getBoolean("transparent-favorites", false)) {
-                mainActivity.favorites.setBackgroundColor(Color.TRANSPARENT);
+                mainActivity.favoritesBar.setBackgroundColor(Color.TRANSPARENT);
             }
             if (prefs.getBoolean("transparent-search", false)) {
                 mainActivity.findViewById(R.id.searchEditLayout).setBackgroundColor(Color.TRANSPARENT);

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -43,6 +43,7 @@ public abstract class Result {
     /**
      * Current information pojo
      */
+    @NonNull
     final Pojo pojo;
 
     Result(@NonNull Pojo pojo) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -16,6 +16,7 @@ import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoComparator;
@@ -125,7 +126,7 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
             return;
 
         // Loader should still be displayed until all the providers have finished loading
-        activity.displayLoader(!activity.allProvidersHaveLoaded);
+        activity.displayLoader(!KissApplication.getApplication(activity).getDataHandler().allProvidersHaveLoaded);
 
         if (this.processedPojos.isEmpty()) {
             activity.adapter.clear();

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -32,6 +32,8 @@
         android:layout_marginTop="10dp"
         android:background="?attr/listBackgroundColor"
         android:elevation="2dp"
+        android:visibility="gone"
+        tools:visibility="visible"
         tools:ignore="UnusedAttribute">
 
         <fr.neamar.kiss.ui.AnimatedListView
@@ -242,7 +244,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@id/externalFavoriteBar"
-        android:visibility="gone">
+        android:visibility="visible"
+        tools:visibility="gone">
 
         <include
             android:id="@+id/main_empty"

--- a/qa-suite.md
+++ b/qa-suite.md
@@ -6,6 +6,7 @@ As best as possible, only actual KISS code is tested, not standard Android syste
 
 ### Get started...
 * [ ] Loader appears when opening the app
+* [ ] Help text appears while app is loading
 * [ ] After some time, loader disappears and is replaced by launcher icon
 * [ ] Searching for text displays results
 * [ ] Clicking the launcher displays the list of apps
@@ -15,7 +16,7 @@ As best as possible, only actual KISS code is tested, not standard Android syste
 * [ ] When going back to KISS, the item has been added to history
 * [ ] Three dots menu is displayed to the right
 * [ ] Entering a search query replaces the three-dots menu with an "X"
-* [ ] Clicking the "X" empties the search field and displays three dots menu
+* [ ] Clicking the "X" empties the search field, displays three dots menu and displays help text
 * [ ] When searching, pressing enter on the keyboard launches the first result
 * [ ] When keyboard is displayed, scrolling the list down hides the keyboard
 * [ ] When searching, pressing space as the first character does nothing (left-hand side trimming)
@@ -209,6 +210,8 @@ As best as possible, only actual KISS code is tested, not standard Android syste
 * [ ] Select a search provider. Ensure it is available in search
 * [ ] Reset search providers. Ensure only default providers are visible
 * [ ] Delete a search provider. Ensure it is not available in search anymore
+* [ ] Disable search providers. Enter a query with no results. Help text is displayed.
+* [ ] Disable search providers. Enable minimalistic mode. Enter a query with no results. Nothing is displayed
 
 ### Advanced settings
 * [ ] Change default launcher option opens system dialog to pick a launcher


### PR DESCRIPTION
Improved startup time:

* When running DEBUG builds, ensure AppProvider only loads once (there was a bug where the sytemn would notify KISS that a package was changed [KISS itself], triggering a useless reload)
* Default visibility for views has been updated (using `tools:visibility`, nothing changed in the IDE)
* No `Searcher` instance is created until required
* Ensure the loader is not stuck spinning forever
* Minimize number of calls to `findViewById()`