### PR TITLE
Optimization: do not refresh list when clicking on a favorite

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -613,9 +613,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 kissBar.setVisibility(View.GONE);
             }
 
-            // Empty text field if not already empty
-            // (we need to check otherwise the textField dispatch onChange() and trigger a search for no reason)
-            if (clearSearchText && !searchEditText.getText().toString().isEmpty()) {
+            if (clearSearchText) {
                 searchEditText.setText("");
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -150,7 +150,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             public void onReceive(Context context, Intent intent) {
                 //noinspection ConstantConditions
                 if (intent.getAction().equalsIgnoreCase(LOAD_OVER)) {
-                    updateRecords(searchEditText.getText().toString());
+                    updateRecords();
                 } else if (intent.getAction().equalsIgnoreCase(FULL_LOAD_OVER)) {
                     Log.v(TAG, "All providers are done loading.");
 
@@ -612,7 +612,10 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 // No animation before Lollipop
                 kissBar.setVisibility(View.GONE);
             }
-            if (clearSearchText) {
+
+            // Empty text field if not already empty
+            // (we need to check otherwise the textField dispatch onChange() and trigger a search for no reason)
+            if (clearSearchText && !searchEditText.getText().toString().isEmpty()) {
                 searchEditText.setText("");
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -1,13 +1,11 @@
 package fr.neamar.kiss.forwarder;
 
-import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.os.Handler;
 import android.text.InputType;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 
 import java.util.regex.Pattern;
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -201,9 +201,6 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
 
     @Override
     public void onClick(View v) {
-        // The bar is shown due to dispatchTouchEvent, hide it again to stop the bad ux.
-        mainActivity.displayKissBar(false);
-
         int favNumber = Integer.parseInt((String) v.getTag());
         if (favNumber >= favoritesPojo.size()) {
             // Clicking on a favorite before everything is loaded.


### PR DESCRIPTION
Clicking on a favorite hides the KISS bar, which in turn changes the text content, which was triggering a refresh for no reason. This change ensures nothing happened if the search bar was already empty