### PR TITLE
Disable shadows for flat light and dark themes

### DIFF
--- a/app/src/main/res/layout/item_app.xml
+++ b/app/src/main/res/layout/item_app.xml
@@ -47,7 +47,7 @@
             android:shadowColor="?attr/resultShadowColor"
             android:shadowDx="1"
             android:shadowDy="2"
-            android:shadowRadius="3"
+            android:shadowRadius="?attr/textShadowRadius"
             android:text="@string/stub_application"
             android:textColor="?attr/resultColor"
             android:textSize="@dimen/result_title_size"
@@ -64,7 +64,7 @@
             android:shadowColor="?attr/resultShadowColor"
             android:shadowDx="1"
             android:shadowDy="2"
-            android:shadowRadius="3"
+            android:shadowRadius="?attr/textShadowRadius"
             android:text="@string/stub_app_tag"
             android:textColor="?android:attr/textColorSecondary"
             tools:ignore="RtlSymmetry" />

--- a/app/src/main/res/layout/item_contact.xml
+++ b/app/src/main/res/layout/item_contact.xml
@@ -44,7 +44,7 @@
         android:shadowColor="?attr/resultShadowColor"
         android:shadowDx="1"
         android:shadowDy="2"
-        android:shadowRadius="3"
+        android:shadowRadius="?attr/textShadowRadius"
         android:singleLine="true"
         android:text="@string/stub_contact"
         android:textColor="?attr/resultColor"
@@ -63,7 +63,7 @@
         android:shadowColor="?attr/resultShadowColor"
         android:shadowDx="1"
         android:shadowDy="2"
-        android:shadowRadius="3"
+        android:shadowRadius="?attr/textShadowRadius"
         android:text="@string/stub_contact_phone"
         android:textColor="?android:attr/textColorSecondary"
         tools:ignore="RtlSymmetry" />

--- a/app/src/main/res/layout/item_contact.xml
+++ b/app/src/main/res/layout/item_contact.xml
@@ -41,6 +41,7 @@
         android:ellipsize="end"
         android:paddingEnd="2dp"
         android:paddingRight="2dp"
+        android:paddingBottom="2dp"
         android:shadowColor="?attr/resultShadowColor"
         android:shadowDx="1"
         android:shadowDy="2"

--- a/app/src/main/res/layout/item_phone.xml
+++ b/app/src/main/res/layout/item_phone.xml
@@ -31,7 +31,7 @@
         android:text="@string/stub_phone"
         android:textColor="?attr/resultColor"
         android:shadowColor="?attr/resultShadowColor"
-        android:shadowRadius="3"
+        android:shadowRadius="?attr/textShadowRadius"
         android:shadowDx="1"
         android:shadowDy="2"
         android:textSize="@dimen/result_title_size" />

--- a/app/src/main/res/layout/item_search.xml
+++ b/app/src/main/res/layout/item_search.xml
@@ -31,7 +31,7 @@
         android:text="@string/ui_item_search"
         android:textColor="?attr/resultColor"
         android:shadowColor="?attr/resultShadowColor"
-        android:shadowRadius="3"
+        android:shadowRadius="?attr/textShadowRadius"
         android:shadowDx="1"
         android:shadowDy="2"
         android:textSize="@dimen/result_title_size" />

--- a/app/src/main/res/layout/item_setting.xml
+++ b/app/src/main/res/layout/item_setting.xml
@@ -32,10 +32,13 @@
         android:layout_height="wrap_content"
         android:text="@string/stub_setting"
         android:textColor="?attr/resultColor"
+        android:paddingRight="2dp"
+        android:paddingBottom="2dp"
         android:shadowColor="?attr/resultShadowColor"
-        android:shadowRadius="3"
+        android:shadowRadius="?attr/textShadowRadius"
         android:shadowDx="1"
         android:shadowDy="2"
-        android:textSize="@dimen/result_title_size" />
+        android:textSize="@dimen/result_title_size"
+        tools:ignore="RtlHardcoded,RtlSymmetry" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_shortcut.xml
+++ b/app/src/main/res/layout/item_shortcut.xml
@@ -45,7 +45,7 @@
             android:text="@string/stub_application"
             android:textColor="?attr/resultColor"
             android:shadowColor="?attr/resultShadowColor"
-            android:shadowRadius="3"
+            android:shadowRadius="?attr/textShadowRadius"
             android:shadowDx="1"
             android:shadowDy="2"
             android:textSize="@dimen/result_title_size" />
@@ -58,7 +58,7 @@
             android:ellipsize="end"
             android:text="@string/stub_app_tag"
             android:shadowColor="?attr/resultShadowColor"
-            android:shadowRadius="3"
+            android:shadowRadius="?attr/textShadowRadius"
             android:shadowDx="1"
             android:shadowDy="2"
             android:textColor="?android:attr/textColorSecondary" />

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -10,6 +10,7 @@
         </item>
         <item name="android:alertDialogTheme">@android:style/Theme.Material.Light.Dialog.Alert
         </item>
+        <item name="textShadowRadius">0</item>
     </style>
 
     <style name="BaseThemeDark" parent="@android:style/Theme.Material.NoActionBar">
@@ -19,6 +20,7 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="appSelectableItemBackground">?android:attr/selectableItemBackgroundBorderless
         </item>
+        <item name="textShadowRadius">0</item>
     </style>
 
     <style name="AppThemeTransparent" parent="AppThemeLight">
@@ -27,23 +29,27 @@
         <item name="listBackgroundColor">@android:color/transparent</item>
         <item name="dividerDrawable">@drawable/list_separator_transparent</item>
         <item name="android:colorPrimaryDark">@android:color/transparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="AppThemeSemiTransparent" parent="AppThemeLight">
         <item name="resultShadowColor">@color/kiss_background_light_transparent</item>
         <item name="listBackgroundColor">@color/kiss_background_light_transparent</item>
         <item name="android:colorPrimaryDark">@color/kiss_green_semitransparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="AppThemeSemiTransparentDark" parent="AppThemeDark">
         <item name="listBackgroundColor">@color/kiss_background_dark_transparent</item>
         <item name="android:colorPrimaryDark">@color/kiss_green_semitransparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="AppThemeTransparentDark" parent="AppThemeDark">
         <item name="listBackgroundColor">@android:color/transparent</item>
         <item name="dividerDrawable">@drawable/list_separator_transparent</item>
         <item name="android:colorPrimaryDark">@android:color/transparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="SettingTheme" parent="AppThemeLight">

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -7,4 +7,5 @@
     <attr name="searchBackgroundColor" format="reference|color" />
     <attr name="dividerDrawable" format="reference" />
     <attr name="appSelectableItemBackground" format="reference" />
+    <attr name="textShadowRadius" format="reference|integer" />
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -7,5 +7,5 @@
     <attr name="searchBackgroundColor" format="reference|color" />
     <attr name="dividerDrawable" format="reference" />
     <attr name="appSelectableItemBackground" format="reference" />
-    <attr name="textShadowRadius" format="reference|integer" />
+    <attr name="textShadowRadius" format="reference|float" />
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -23,6 +23,7 @@
         <item name="listBackgroundColor">@android:color/white</item>
         <item name="searchBackgroundColor">@android:color/white</item>
         <item name="dividerDrawable">@drawable/list_separator_light</item>
+        <item name="textShadowRadius">0</item>
     </style>
 
     <style name="AppThemeDark" parent="BaseThemeDark">
@@ -37,6 +38,7 @@
         <item name="listBackgroundColor">@color/kiss_list_background_inverse</item>
         <item name="searchBackgroundColor">@color/kiss_list_background_inverse</item>
         <item name="dividerDrawable">@drawable/list_separator_dark</item>
+        <item name="textShadowRadius">0</item>
     </style>
 
     <style name="AppThemeTransparent" parent="AppThemeLight">
@@ -44,20 +46,24 @@
         <item name="resultShadowColor">@android:color/black</item>
         <item name="listBackgroundColor">@android:color/transparent</item>
         <item name="dividerDrawable">@drawable/list_separator_transparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="AppThemeSemiTransparent" parent="AppThemeLight">
         <item name="resultShadowColor">@color/kiss_background_light_transparent</item>
         <item name="listBackgroundColor">@color/kiss_background_light_transparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="AppThemeSemiTransparentDark" parent="AppThemeDark">
         <item name="listBackgroundColor">@color/kiss_background_dark_transparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="AppThemeTransparentDark" parent="AppThemeDark">
         <item name="listBackgroundColor">@android:color/transparent</item>
         <item name="dividerDrawable">@drawable/list_separator_transparent</item>
+        <item name="textShadowRadius">3</item>
     </style>
 
     <style name="SettingTheme" parent="AppThemeLight">


### PR DESCRIPTION
Shadows were used for every theme, 

For the default light and dark theme, it made the text "blurry" in a way, so disabling shadows there.