### PR TITLE
Keep database open as long as KISS is alive

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -13,12 +13,16 @@ import java.util.Map;
 import fr.neamar.kiss.pojo.ShortcutsPojo;
 
 public class DBHelper {
+    private static SQLiteDatabase database = null;
+
     private DBHelper() {
     }
 
     private static SQLiteDatabase getDatabase(Context context) {
-        DB db = new DB(context);
-        return db.getReadableDatabase();
+        if(database == null) {
+            database = new DB(context).getReadableDatabase();
+        }
+        return database;
     }
 
     private static ArrayList<ValuedHistoryRecord> readCursor(Cursor cursor) {
@@ -53,19 +57,16 @@ public class DBHelper {
         values.put("query", query);
         values.put("record", record);
         db.insert("history", null, values);
-        db.close();
     }
 
     public static void removeFromHistory(Context context, String record) {
         SQLiteDatabase db = getDatabase(context);
         db.delete("history", "record = ?", new String[]{record});
-        db.close();
     }
 
     public static void clearHistory(Context context) {
         SQLiteDatabase db = getDatabase(context);
         db.delete("history", "", null);
-        db.close();
     }
 
     private static Cursor getSmartHistoryCursor(SQLiteDatabase db, int limit) {
@@ -114,7 +115,6 @@ public class DBHelper {
 
         records = readCursor(cursor);
         cursor.close();
-        db.close();
         return records;
     }
 
@@ -137,7 +137,6 @@ public class DBHelper {
         cursor.moveToFirst();
         int historyLength = cursor.getInt(0);
         cursor.close();
-        db.close();
         return historyLength;
     }
 
@@ -160,7 +159,6 @@ public class DBHelper {
                 "query LIKE ?", new String[]{query + "%"}, "record", null, "COUNT(*) DESC", "10");
         records = readCursor(cursor);
         cursor.close();
-        db.close();
         return records;
     }
 
@@ -175,13 +173,11 @@ public class DBHelper {
         values.put("icon_blob", shortcut.icon_blob);
 
         db.insert("shortcuts", null, values);
-        db.close();
     }
 
     public static void removeShortcut(Context context, String name) {
         SQLiteDatabase db = getDatabase(context);
         db.delete("shortcuts", "name = ?", new String[]{name});
-        db.close();
     }
 
 
@@ -210,7 +206,6 @@ public class DBHelper {
         }
         cursor.close();
 
-        db.close();
         return records;
     }
 
@@ -232,8 +227,6 @@ public class DBHelper {
 
         //remove shortcuts
         db.delete("shortcuts", "intent_uri LIKE ?", new String[]{"%" + packageName + "%"});
-
-        db.close();
     }
 
     /**
@@ -250,7 +243,6 @@ public class DBHelper {
         values.put("tag", tag);
         values.put("record", record);
         db.insert("tags", null, values);
-        db.close();
     }
 
 
@@ -265,7 +257,6 @@ public class DBHelper {
         SQLiteDatabase db = getDatabase(context);
 
         db.delete("tags", "record = ?", new String[]{record});
-        db.close();
     }
 
     public static Map<String, String> loadTags(Context context) {
@@ -282,7 +273,6 @@ public class DBHelper {
             cursor.moveToNext();
         }
         cursor.close();
-        db.close();
         return records;
 
     }


### PR DESCRIPTION
Fix #900.

Instead of opening / closing the database on every search, we open one (and only one) connection to the DB the first time we need it and keep it lying around in a static property in `DBHelper`.

If the GC needs to clean it, it will call `.finalize()` which will clean this properly.

More details on https://stackoverflow.com/questions/4557154/android-sqlite-db-when-to-close

New flamegraph (see previous flamegraph on #900):

![image](https://user-images.githubusercontent.com/536844/37373814-2812aefa-2710-11e8-9300-cdd78e18f222.png)

(you'll notice that both flame graphs are subtly different even outside of the DB section, that's because I'm using a random sampler and do not get a perfectly accurate representation of time spent in functions) 

Expected gain: (hard to quantify exactly) 15% on all searches!