### PR TITLE
Fix custom providers dialog - add margins

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
@@ -45,8 +45,13 @@ public class AddSearchProviderPreference extends DialogPreference {
     protected View onCreateDialogView() {
         providerName.setHint(R.string.search_provider_name);
         providerUrl.setHint(R.string.search_provider_url);
-        layout.addView(providerName);
-        layout.addView(providerUrl);
+
+        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+        layoutParams.setMargins(40, 10, 40, 0);
+
+        layout.addView(providerName, layoutParams);
+        layout.addView(providerUrl, layoutParams);
 
         // default text color is white that doesn't work well on the light themes
         String theme = prefs.getString("theme", "light");

--- a/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
@@ -46,10 +46,12 @@ public class AddSearchProviderPreference extends DialogPreference {
         providerName.setHint(R.string.search_provider_name);
         providerUrl.setHint(R.string.search_provider_url);
 
+        //adding margins (default is zero)
         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
         layoutParams.setMargins(40, 10, 40, 0);
 
+        //add the two text fields (with margins)
         layout.addView(providerName, layoutParams);
         layout.addView(providerUrl, layoutParams);
 


### PR DESCRIPTION
Added margin on the text fields of custom search providers (add)
Looks much better
Tested on 7.1.1 / 6.0