### PR TITLE
:lipstick: Design fixes for the logo and the navbar on the help website

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.5)
+    eventmachine (1.2.5-x64-mingw32)
     ffi (1.9.18)
+    ffi (1.9.18-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.3)
@@ -50,6 +52,8 @@ GEM
     mini_portile2 (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.2-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.1)
@@ -67,6 +71,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jekyll (= 3.7.2)

--- a/docs/_sass/header.scss
+++ b/docs/_sass/header.scss
@@ -28,6 +28,8 @@ header {
 		}
 
 		.logo {
+			padding-bottom: 10px;
+
 			a {
 				display: block;
 				line-height: 0;
@@ -51,10 +53,12 @@ header {
 	}
 
 	nav {
+
 		@media #{$mid-point} {
 			flex: 1;
 			margin: 0 0 0 10px;
 			display: block;
+			text-align: right !important;
 
 			form {
 				position: absolute;
@@ -112,6 +116,7 @@ header {
 
 .nav-open header nav {
 	display: block;
+	text-align: left;
 }
 
 .nav-toggle {


### PR DESCRIPTION
Changes made on the help websites:
* Logo centered in the navbar (in mobile)
* Navigation bar aligned on the right (in desktop)