### PR TITLE
Use BaseAdapter instead of ArrayAdapter for performance

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -215,7 +215,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.emptyListView.setOnTouchListener(this);
 
         // Create adapter for records
-        this.adapter = new RecordAdapter(this, this, R.layout.item_app, new ArrayList<Result>());
+        this.adapter = new RecordAdapter(this, this, new ArrayList<Result>());
         this.list.setAdapter(this.adapter);
 
         this.list.setOnItemClickListener(new AdapterView.OnItemClickListener() {

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -78,6 +78,8 @@ public class RecordAdapter extends BaseAdapter {
 
     @Override
     public long getItemId(int position) {
+        // In some situation, Android tries to display an item that does not exist (e.g. item 24 in a list containing 22 items)
+        // See https://github.com/Neamar/KISS/issues/890
         return position < results.size() ? results.get(position).getUniqueId() : -1;
     }
 

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -31,8 +31,6 @@ public class RecordAdapter extends BaseAdapter {
     private List<Result> results;
 
     public RecordAdapter(Context context, QueryInterface parent, ArrayList<Result> results) {
-        super();
-
         this.context = context;
         this.parent = parent;
         this.results = results;

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -5,9 +5,10 @@ import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.result.AppResult;
@@ -20,18 +21,19 @@ import fr.neamar.kiss.result.ShortcutsResult;
 import fr.neamar.kiss.searcher.QueryInterface;
 import fr.neamar.kiss.ui.ListPopup;
 
-public class RecordAdapter extends ArrayAdapter<Result> {
-
+public class RecordAdapter extends BaseAdapter {
+    private final Context context;
     private final QueryInterface parent;
+
     /**
      * Array list containing all the results currently displayed
      */
-    private final ArrayList<Result> results;
+    private List<Result> results;
 
-    public RecordAdapter(Context context, QueryInterface parent, int textViewResourceId,
-                         ArrayList<Result> results) {
-        super(context, textViewResourceId, results);
+    public RecordAdapter(Context context, QueryInterface parent, ArrayList<Result> results) {
+        super();
 
+        this.context = context;
         this.parent = parent;
         this.results = results;
     }
@@ -65,10 +67,18 @@ public class RecordAdapter extends ArrayAdapter<Result> {
     }
 
     @Override
+    public int getCount() {
+        return results.size();
+    }
+
+    @Override
+    public Object getItem(int position) {
+        return results.get(position);
+    }
+
+    @Override
     public long getItemId(int position) {
-        // In some situation, Android tries to display an item that does not exist (e.g. item 24 in a list containing 22 items)
-        // See https://github.com/Neamar/KISS/issues/890
-        return position >= results.size() ? 0 : results.get(position).getUniqueId();
+        return position < results.size() ? results.get(position).getUniqueId() : -1;
     }
 
     @Override
@@ -83,14 +93,14 @@ public class RecordAdapter extends ArrayAdapter<Result> {
                 convertView = null;
             }
         }
-        View view = results.get(position).display(getContext(), results.size() - position, convertView);
+        View view = results.get(position).display(context, results.size() - position, convertView);
         //Log.d( "TBog", "getView pos " + position + " convertView " + ((convertView == null) ? "null" : convertView.toString()) + " will return " + view.toString() );
         view.setTag(getItemViewType(position));
         return view;
     }
 
     public void onLongClick(final int pos, View v) {
-        ListPopup menu = results.get(pos).getPopupMenu(getContext(), this, v);
+        ListPopup menu = results.get(pos).getPopupMenu(context, this, v);
 
         //check if menu contains elements and if yes show it
         if (menu.getAdapter().getCount() > 0) {
@@ -104,7 +114,7 @@ public class RecordAdapter extends ArrayAdapter<Result> {
 
         try {
             result = results.get(position);
-            result.launch(getContext(), v);
+            result.launch(context, v);
         } catch (ArrayIndexOutOfBoundsException ignored) {
             return;
         }
@@ -125,7 +135,17 @@ public class RecordAdapter extends ArrayAdapter<Result> {
 
     public void removeResult(Result result) {
         results.remove(result);
-        result.deleteRecord(getContext());
+        result.deleteRecord(context);
+        notifyDataSetChanged();
+    }
+
+    public void updateResults(List<Result> results) {
+        this.results = results;
+        notifyDataSetChanged();
+    }
+
+    public void clear() {
+        this.results.clear();
         notifyDataSetChanged();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -3,15 +3,12 @@ package fr.neamar.kiss.searcher;
 
 import android.content.Context;
 import android.os.AsyncTask;
-import android.os.Handler;
-import android.os.Looper;
 import android.support.annotation.CallSuper;
 import android.util.Log;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
@@ -30,22 +27,14 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
     private static final int DEFAULT_REFRESH_TIMER = 150;
     final WeakReference<MainActivity> activityWeakReference;
     private final PriorityQueue<Pojo> processedPojos;
-    private final RefreshTask refreshTask;
-    // It's better to have a Handler than a Timer. Note that java.util.Timer (and TimerTask) will be deprecated in JDK 9
-    private final Handler handler;
     private long start;
     private final String query;
-    private int refreshCounter;
 
     Searcher(MainActivity activity, String query) {
         super();
         this.query = query;
         this.activityWeakReference = new WeakReference<>(activity);
         this.processedPojos = getPojoProcessor(activity);
-        this.refreshTask = new RefreshTask();
-        this.refreshCounter = 0;
-        // This handler should run on the Ui thread. That's the only thread that can't be blocked.
-        this.handler = new Handler(Looper.getMainLooper());
     }
 
     PriorityQueue<Pojo> getPojoProcessor(Context context) {
@@ -72,21 +61,6 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
         while (this.processedPojos.size() > maxResults)
             this.processedPojos.poll();
 
-        int counter = this.refreshTask.runCounter;
-        // if timer passed, refresh list
-        if (this.refreshCounter < counter) {
-            this.refreshCounter = counter;
-
-            // clone the PriorityQueue so we can extract the pojos in sorted order and still keep them in the original list
-            PriorityQueue<Pojo> queue = new PriorityQueue<>(this.processedPojos);
-            Collection<Result> results = new ArrayList<>(queue.size());
-            while (queue.peek() != null) {
-                results.add(Result.fromPojo(activity, queue.poll()));
-            }
-            // make the adapter update from the main thread
-            publishProgress(results.toArray(new Result[0]));
-        }
-
         return true;
     }
 
@@ -96,7 +70,6 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
         super.onPreExecute();
         start = System.currentTimeMillis();
 
-        this.handler.postDelayed(this.refreshTask, DEFAULT_REFRESH_TIMER);
         displayActivityLoader();
     }
 
@@ -123,8 +96,6 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
 
     @Override
     protected void onPostExecute(Void param) {
-        this.handler.removeCallbacks(this.refreshTask);
-
         MainActivity activity = activityWeakReference.get();
         if (activity == null)
             return;
@@ -157,15 +128,5 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
         void beforeListChange();
 
         void afterListChange();
-    }
-
-    static class RefreshTask implements Runnable {
-        volatile int runCounter = 0;
-
-        @Override
-        @SuppressWarnings("NonAtomicVolatileUpdate")
-        public void run() {
-            runCounter += 1;
-        }
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -81,19 +81,6 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
     }
 
     @Override
-    protected void onProgressUpdate(Result... results) {
-        MainActivity activity = activityWeakReference.get();
-        if (activity == null)
-            return;
-
-        activity.beforeListChange();
-
-        activity.adapter.updateResults(Arrays.asList(results));
-
-        activity.afterListChange();
-    }
-
-    @Override
     protected void onPostExecute(Void param) {
         MainActivity activity = activityWeakReference.get();
         if (activity == null)

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -24,7 +24,6 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
     // define a different thread than the default AsyncTask thread or else we will block everything else that uses AsyncTask while we search
     public static final ExecutorService SEARCH_THREAD = Executors.newSingleThreadExecutor();
     static final int DEFAULT_MAX_RESULTS = 50;
-    private static final int DEFAULT_REFRESH_TIMER = 150;
     final WeakReference<MainActivity> activityWeakReference;
     private final PriorityQueue<Pojo> processedPojos;
     private long start;

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -12,6 +12,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -115,8 +116,7 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
 
         activity.beforeListChange();
 
-        activity.adapter.clear();
-        activity.adapter.addAll(results);
+        activity.adapter.updateResults(Arrays.asList(results));
 
         activity.afterListChange();
     }
@@ -136,14 +136,13 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
             activity.adapter.clear();
         } else {
             PriorityQueue<Pojo> queue = this.processedPojos;
-            Collection<Result> results = new ArrayList<>(queue.size());
+            List<Result> results = new ArrayList<>(queue.size());
             while (queue.peek() != null) {
                 results.add(Result.fromPojo(activity, queue.poll()));
             }
             activity.beforeListChange();
 
-            activity.adapter.clear();
-            activity.adapter.addAll(results);
+            activity.adapter.updateResults(results);
 
             activity.afterListChange();
         }


### PR DESCRIPTION
While working on #890 I noticed that ArrayAdapter comes with a lot of features and we don't use a single one of them -- our use case is actually a very simple BaseAdapter.

The only thing I had to change was to implement the `public Object getItem(int position)` (one line!) and then I was able to remove unused constructor parameter and implement a function to replace results in one pass (instead of `.clear()` and `.addAll()`, which was triggering `notifyDatasetChanged()`.

`ArrayAdapter` was also thread safe, but since we're doing all our changes from the UI thread we don't need this.

I also removed the `refreshTask` (considered in #906, potentially useful for #937).