### PR TITLE
Removed reflection code

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/ui/ImprovedQuickContactBadge.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/ImprovedQuickContactBadge.java
@@ -17,6 +17,7 @@ package fr.neamar.kiss.ui;
  */
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.QuickContactBadge;
@@ -32,14 +33,17 @@ public class ImprovedQuickContactBadge extends RoundedQuickContactBadge {
 
     public ImprovedQuickContactBadge(Context context) {
         super(context);
+        init(); //Set our initialization
     }
 
     public ImprovedQuickContactBadge(Context context, AttributeSet attrs) {
         super(context, attrs);
+        init(); //Set our initialization
     }
 
     public ImprovedQuickContactBadge(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        init(); //Set our initialization
     }
 
     @Override
@@ -52,6 +56,16 @@ public class ImprovedQuickContactBadge extends RoundedQuickContactBadge {
 
     public void setExtraOnClickListener(View.OnClickListener extraOnClickListener) {
         mExtraOnClickListener = extraOnClickListener;
+    }
+
+
+    /**
+     * Hide the overlay
+     */
+    private void init() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            setOverlay(null);
+        }
     }
 
 }

--- a/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
@@ -18,8 +18,6 @@ import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.widget.QuickContactBadge;
 
-import java.lang.reflect.Field;
-
 /**
  * A rounded version of {@link QuickContactBadge]
  *
@@ -29,17 +27,14 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
 
     public RoundedQuickContactBadge(Context context) {
         super(context);
-        init(); //Set our initialization
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init(); //Set our initialization
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        init(); //Set our initialization
     }
 
     public static class RoundedDrawable extends Drawable {
@@ -102,25 +97,6 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
         @Override
         public int getOpacity() {
             return PixelFormat.TRANSLUCENT;
-        }
-
-    }
-
-    /**
-     * Initialize our stuff
-     */
-    private void init() {
-
-        //Use reflection to reset the default triangular overlay from default quick contact badge
-        try {
-            Field field = QuickContactBadge.class.getDeclaredField("mOverlay");
-            field.setAccessible(true);
-
-            //Using null to not draw anything at all
-            field.set(this, null);
-
-        } catch (Exception e) {
-            //No-op, just well off with the default overlay
         }
 
     }

--- a/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
@@ -18,6 +18,8 @@ import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.widget.QuickContactBadge;
 
+import java.lang.reflect.Field;
+
 /**
  * A rounded version of {@link QuickContactBadge]
  *
@@ -27,14 +29,17 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
 
     public RoundedQuickContactBadge(Context context) {
         super(context);
+        init(); //Set our initialization
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs) {
         super(context, attrs);
+        init(); //Set our initialization
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        init(); //Set our initialization
     }
 
     public static class RoundedDrawable extends Drawable {
@@ -97,6 +102,25 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
         @Override
         public int getOpacity() {
             return PixelFormat.TRANSLUCENT;
+        }
+
+    }
+
+    /**
+     * Initialize our stuff
+     */
+    private void init() {
+
+        //Use reflection to reset the default triangular overlay from default quick contact badge
+        try {
+            Field field = QuickContactBadge.class.getDeclaredField("mOverlay");
+            field.setAccessible(true);
+
+            //Using null to not draw anything at all
+            field.set(this, null);
+
+        } catch (Exception e) {
+            //No-op, just well off with the default overlay
         }
 
     }


### PR DESCRIPTION
The reflection code was here to hide the triangular overlay displayed by default on the contact badge:

![image](https://user-images.githubusercontent.com/536844/38166279-558f9318-3519-11e8-86aa-6728f4eb7c50.png)

However, reflection is now disabled in Android P.

Since Android L, there is an open API to hide the triangular area, so we'll just use it, and devices pre-L will see the triangle :(

Fix #941.