### PR TITLE
Improvements on load time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId 'fr.neamar.kiss'
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 121
-        versionName "3.0.10"
+        versionCode 122
+        versionName "3.0.11"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import fr.neamar.kiss.forwarder.Permission;
 import fr.neamar.kiss.normalizer.PhoneNormalizer;
@@ -132,7 +131,6 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
             nickCursor.close();
         }
 
-        Pattern phoneFormatter = Pattern.compile("[ \\.\\(\\)]");
         for (List<ContactsPojo> phones : mapContacts.values()) {
             // Find primary phone and add this one.
             Boolean hasPrimary = false;
@@ -144,16 +142,12 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                 }
             }
 
-            // If not available, add all (excluding duplicates).
+            // If no primary available, add all (excluding duplicates).
             if (!hasPrimary) {
                 Map<String, Boolean> added = new HashMap<>();
                 for (ContactsPojo contact : phones) {
-                    String uniqueKey = phoneFormatter.matcher(contact.phone).replaceAll("");
-                    // TODO: what's this supposed to do?
-                    //uniqueKey = uniqueKey.replaceAll("^\\+33", "0");
-                    //uniqueKey = uniqueKey.replaceAll("^\\+1", "0");
-                    if (!added.containsKey(uniqueKey)) {
-                        added.put(uniqueKey, true);
+                    if (!added.containsKey(contact.phoneSimplified)) {
+                        added.put(contact.phoneSimplified, true);
                         contacts.add(contact);
                     }
                 }

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -144,10 +145,10 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
 
             // If no primary available, add all (excluding duplicates).
             if (!hasPrimary) {
-                Map<String, Boolean> added = new HashMap<>();
+                HashSet<String> added = new HashSet<>(phones.size());
                 for (ContactsPojo contact : phones) {
-                    if (!added.containsKey(contact.phoneSimplified)) {
-                        added.put(contact.phoneSimplified, true);
+                    if (!added.contains(contact.phoneSimplified)) {
+                        added.add(contact.phoneSimplified);
                         contacts.add(contact);
                     }
                 }

--- a/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/PhoneNormalizer.java
@@ -1,12 +1,19 @@
 package fr.neamar.kiss.normalizer;
 
-import java.util.regex.Pattern;
-
 public class PhoneNormalizer {
-
-    private static final Pattern ignorePattern = Pattern.compile("[-.():/ ]");
-
     public static String simplifyPhoneNumber(String phoneNumber) {
-        return ignorePattern.matcher(phoneNumber).replaceAll("");
+        // This is done manually for performance reason,
+        // But the algorithm is just a regexp replacement of "[-.():/ ]" with ""
+        StringBuilder sb = new StringBuilder();
+        int phoneLength = phoneNumber.length();
+        for(int i = 0; i < phoneLength; i++)
+        {
+            char c = phoneNumber.charAt(i);
+            if(c == ' ' || c == '-' || c == '.' || c == '(' || c == ')' || c == ':' || c == '/') {
+                continue;
+            }
+            sb.append(c);
+        }
+        return sb.toString();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
@@ -96,6 +96,7 @@ public class StringNormalizer {
 
                         case Character.DASH_PUNCTUATION:
                             // We skip dashes too
+                            // (standard HYPHEN-MINUS was skipped above, but dashes are a large family!)
                             // see http://www.fileformat.info/info/unicode/category/Pd/list.htm
                             break;
 


### PR DESCRIPTION
Recently, we spent a bunch of time optimising search.

But hey, another big area of KISS is startup time. For most of us, we only see it once when we boot the device, but on some device with low memory (or for gamers), the loading happens more frequently, and can benefit from some optimisations.

## Overview
![image](https://user-images.githubusercontent.com/536844/38178248-8f5757d2-3606-11e8-9ea0-caab71ddb6be.png)

AsyncTask#1 is app,
AsyncTask#2 is contact.

(might be interesting to try to make those calls in parallel to use multi-core when available)

## Flamegraph: app loading
![image](https://user-images.githubusercontent.com/536844/38178252-99ba632c-3606-11e8-97f8-38b38dbc8210.png)

A lot of time spent on system calls, not much to optimize here.
Notice the `normalizeWithResults` function, not a big drain but still here.

## Flamegraph: contact loading
![image](https://user-images.githubusercontent.com/536844/38178258-c41c38f2-3606-11e8-83a3-c2c85c51fa07.png)

And with details:
![image](https://user-images.githubusercontent.com/536844/38178259-c8d96842-3606-11e8-8bee-8ab5e669e150.png)

A bunch of things that got optimized here:

* No more regexp in `PhoneNormalizer`. Regexps are slow, and in this case, we don't need them. (from 9% to 2.7%)
* We had two different simplifying regexp, for no reason. Phone uniqueness is now defined with the `simplifiedPhoneNumber`. (from 4.3% to 0%)

Notice the `normalizeWithResults` function, which accounts for 47% of the time.

## Flamegraph: `normalizeWithResults()`
As noticed before, this function gets called a lot by both AppLoader and ContactLoader.

Here is a zoom on the flamegraph:
![image](https://user-images.githubusercontent.com/536844/38178635-dc0155f8-360e-11e8-8496-421574dcbd88.png)

Actual numbers:
![image](https://user-images.githubusercontent.com/536844/38178637-e4f98234-360e-11e8-9fec-9d7518db71fa.png)

The call to denormalize on NFKD is the most expensive one by far.

However, in most situations, we can assume that 80%+ of the characters will be basic latin characters (ascii code < 'z'). So I've introduced a small `if` that short circuit the normalizer whenever we're dealing with a basic latin character (see https://en.wikipedia.org/wiki/List_of_Unicode_characters).

The Normalizer is not an easy-to-understand piece of code, and Unicode is really tricky for me, so I wasn't able to come up with anything more than that. It did, however, move the needle, as for ContactLoader `setName()` went from 47% of the time spent loading to 22%. The impact on AppLoader is less important as most of the time is still spent in system calls anyway.

----
**tl;dr**: contact load time improved by roughly 20%, app load time improved by roughly 5%.