### PR TITLE
Disable suggestions automatically when swiftkey is detected as current input method

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -3,6 +3,7 @@ package fr.neamar.kiss.forwarder;
 import android.content.pm.ActivityInfo;
 import android.os.Build;
 import android.os.Handler;
+import android.provider.Settings;
 import android.text.InputType;
 import android.view.MotionEvent;
 import android.view.View;
@@ -180,10 +181,11 @@ class ExperienceTweaks extends Forwarder {
 
     /**
      * Should we force the keyboard not to display suggestions?
-     * (swiftkey)
+     * (swiftkey is broken, see https://github.com/Neamar/KISS/issues/44)
      */
     private boolean isNonCompliantKeyboard() {
-        return prefs.getBoolean("enable-keyboard-workaround", false);
+        String currentKeyboard = Settings.Secure.getString(mainActivity.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
+        return currentKeyboard.contains("swiftkey");
     }
 
     /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,9 +69,6 @@
     <string name="menu_contact_copy_phone">Telefonnummer kopieren</string>
     <string name="menu_app_hibernate">Schlafenlegen</string>
 
-    <string name="keyboard_workaround_name">Tastaturvorschlagsabhilfe</string>
-    <string name="keyboard_workaround_desc">Kaputte Soft-Tastaturen (wie SwiftKey™) zwingen keine Vorschläge anzuzeigen</string>
-
     <string name="portrait_title">Hochformat erzwingen</string>
 
     <string name="menu_phone_create">Kontakt erstellen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -119,8 +119,6 @@
     <string name="search_providers_title">Επιλέξτε μηχανές αναζήτησης</string>
     <string name="root_mode_desc">Αν διαθέσιμο, χρησιμοποιείστε το για αδρανοποίηση εφαρμογών</string>
     <string name="settings_tethering">Tethering</string>
-    <string name="keyboard_workaround_name">Διόρθωση προτάσεων πληκτρολογίου</string>
-    <string name="keyboard_workaround_desc">Παρεμπόδιση μη συμβατών πληκτρολογίων (όπως το SwiftKey™) να εμφανίζουν προτάσεις</string>
     <string name="alias_phone">κλήση,τηλέφωνο</string>
     <string name="alias_messaging">μήνυμα,μνμ,sms,mms</string>
     <string name="settings_storage">Αποθήκευση</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -46,7 +46,6 @@
     <string name="reset_favorites_name">Restarigi vian ŝatatoliston</string>
     <string name="reset_favorites_warn">Ĉu vi vere volas restarigi viajn ŝatatajn?</string>
     <string name="keyboard_name">Montri klavaron en komenco</string>
-    <string name="keyboard_workaround_name">Klavaraj sugestoj riparado</string>
     <string name="history_hide_desc">Kaŝi historion kaj komencan ekranon, ebligi widgets</string>
     <string name="history_onclick_name">Montri historion sur tuŝado</string>
     <string name="icons_hide_main">Kaŝi aplikaĵojn ikonojn</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -122,8 +122,6 @@
     <string name="items_title">%d elementos</string>
 
     <string name="ui_item_visit">Ir a «%1$s»</string>
-    <string name="keyboard_workaround_name">Reparar las sugerencias del teclado</string>
-    <string name="keyboard_workaround_desc">Evitar que algunos teclados en pantalla (como SwiftKey™) muestren sugerencias por error</string>
     <string name="settings_storage">Almacenamiento</string>
     <string name="settings_dev">Ajustes para desarrolladores</string>
     <string name="settings_accessibility">Accesibilidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,8 +104,6 @@
     <string name="ui_excluded_apps">Voir ou modifier les applications exclues</string>
     <string name="ui_excluded_apps_dialog_title">Désélectionnez les applis que vous souhaitez inclure</string>
     <string name="ui_excluded_apps_not_found">Aucune appli n’a été exclue</string>
-    <string name="keyboard_workaround_name">Débugger les suggestions clavier</string>
-    <string name="keyboard_workaround_desc">Empêche les claviers (comme SwiftKey™) d’afficher des suggestions</string>
     <string name="search_providers_title">Sélectionner les moteurs de recherche</string>
     <string name="history_mode_name">Mode historique</string>
     <string name="history_mode_desc">Choisir la manière selon laquelle est affiché l’historique</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -80,8 +80,6 @@
     <string name="reset_warn">Želite li obrisati povijest?</string>
     <string name="reset_favorites_name">Obriši favorite</string>
     <string name="reset_favorites_warn">Želite li obrisati favorite?</string>
-    <string name="keyboard_workaround_name">Zaobiđi prijedloge tipkovnice</string>
-    <string name="keyboard_workaround_desc">Onemogući tipkovnicama da pokazuju prijedloge</string>
     <string name="history_hide_desc">Sakrij povijest i uvodni sadržaj</string>
     <string name="history_hide_name">Minimalističko sučelje</string>
     <string name="history_onclick_name">Prikaži povijest na dodir</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -118,8 +118,6 @@
     <string name="settings_storage">Penyimpanan</string>
     <string name="settings_dev">Pengaturan pengembang</string>
     <string name="settings_accessibility">Aksesibilitas</string>
-    <string name="keyboard_workaround_name">Saran solusi keyboard</string>
-    <string name="keyboard_workaround_desc">Cegah soft-keyboards (seperti SwiftKey™) dari menampilkan sugesti</string>
     <string name="alternate_history_inputs">Alternatif masukan riwayat</string>
     <string name="keyboard_options">Opsi keyboard</string>
     <string name="misc">Dll</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -47,8 +47,6 @@
     <string name="reset_favorites_name">Azzera l\'elenco dei preferiti</string>
     <string name="reset_favorites_warn">Sei sicuro di voler azzerare l\'elenco dei preferiti?</string>
     <string name="keyboard_name">Visualizza la tastiera all\'avvio</string>
-    <string name="keyboard_workaround_name">Forza disabilitazione dei suggerimenti</string>
-    <string name="keyboard_workaround_desc">Disabilita la visualizzazione dei suggerimenti nelle tastiere con bug (come SwiftKey™)</string>
     <string name="history_hide_desc">Cronologia e schermata introduttiva saranno nascoste</string>
     <string name="history_hide_name">Interfaccia minimale</string>
     <string name="history_onclick_name">Visualizza la cronologia al tocco</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,8 +127,6 @@
     <string name="settings_storage">ストレージ</string>
     <string name="settings_dev">開発者向けの設定</string>
     <string name="settings_accessibility">アクセシビリティ</string>
-    <string name="keyboard_workaround_name">キーボード入力候補の修正</string>
-    <string name="keyboard_workaround_desc">(SwiftKey™ のような) 壊れたソフトキーボードが入力候補を表示するのを防止します</string>
     <string name="alternate_history_inputs">代替の履歴入力</string>
     <string name="keyboard_options">キーボード オプション</string>
     <string name="misc">その他</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -47,8 +47,6 @@
     <string name="reset_favorites_name">Nustatykite iš naujo mėgiamiausiųjų sąrašą</string>
     <string name="reset_favorites_warn">Ar Jūs tikrai norite nustatyti iš naujo mėgiamiausiuosius?</string>
     <string name="keyboard_name">Rodyti klaviatūrą pradžios ekrane</string>
-    <string name="keyboard_workaround_name">Klaviatūros nuspėjimo problemų sprendimas</string>
-    <string name="keyboard_workaround_desc">Neleisti neveikiančioms programinėms klaviatūroms (kaip SwiftKey™) rodyti nuspėjimus</string>
     <string name="history_hide_desc">Paslėpti istorijos ir intro ekraną, įgalinti valdiklius</string>
     <string name="history_hide_name">Minimalistinė vartotojo sąsaja</string>
     <string name="history_onclick_name">Rodyti istoriją palietus</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -138,8 +138,6 @@
     <string name="toast_favorites_removed">%s ble fjernet fra favoritter</string>
     <string name="menu_favorites_remove">Fjern favoritt</string>
 
-    <string name="keyboard_workaround_name">Tastaturforslagsfiks</string>
-    <string name="keyboard_workaround_desc">Forhindre feilaktige skjermtastatur (som SwiftKey™) fra å vise forslag</string>
     <string name="history_mode_name">Historikkmodus</string>
     <string name="history_mode_desc">Velg hvilken måte historikken skal oppføres</string>
     <string name="default_launcher_warn">Etter å ha valgt forvalgt oppstarter, vil du bli sendt til dens hjemmeskjerm. Vil du fortsette?

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -82,8 +82,6 @@
     <string name="reset_warn">Weet je zeker dat je jouw geschiedenis wil resetten?</string>
     <string name="reset_favorites_name">Reset lijst met favorieten</string>
     <string name="reset_favorites_warn">Weet je zeker dat je jouw favorieten wil resetten?</string>
-    <string name="keyboard_workaround_name">Workaround voor toetsenbordsuggesties</string>
-    <string name="keyboard_workaround_desc">Voorkom dat toetsenborden als Swiftkey suggesties tonen</string>
     <string name="history_hide_desc">Geschiedenis- en intro-scherm verbergen; widgets inschakelen</string>
     <string name="history_hide_name">Minimalistische UI</string>
     <string name="history_onclick_name">Toon geschiedenis bij aanraking</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -129,8 +129,6 @@
     <string name="color_picker_default_title" msgid="1248663997452044787">Selecione uma cor</string>
     <string name="color_swatch_description" msgid="2883438431173736180">Cor <xliff:g example="14" id="color_index">%1$d</xliff:g></string>
     <string name="color_swatch_description_selected" msgid="5020921249944943124">Cor <xliff:g example="14" id="color_index">%1$d</xliff:g> selecionada</string>
-    <string name="keyboard_workaround_name">Correção para sugestões do teclado</string>
-    <string name="keyboard_workaround_desc">Previne teclados quebrados (como o SwiftKey™) de mostrarem sugestões</string>
     <string name="settings_sound">Som e volume</string>
     <string name="settings_display">Tela</string>
     <string name="menu_tags_edit">Adicionar ou editar etiquetas</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -46,8 +46,6 @@
     <string name="reset_favorites_name">Limpar a sua lista de favoritos</string>
     <string name="reset_favorites_warn">Deseja realmente limpar os seus favoritos?</string>
     <string name="keyboard_name">Exibir teclado ao iniciar</string>
-    <string name="keyboard_workaround_name">Correção para sugestões do teclado</string>
-    <string name="keyboard_workaround_desc">Previne teclados virtuais defeituosos (como SwiftKey™) de apresentarem sugestões</string>
     <string name="history_hide_desc">Ocultar histórico e ecrã inicial, ativar widgets</string>
     <string name="history_hide_name">Interface minimalista</string>
     <string name="history_onclick_name">Mostrar histórico ao toque</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -122,8 +122,6 @@
     <string name="settings_storage">Stocare</string>
     <string name="settings_dev">Optiuni dezvoltator</string>
     <string name="settings_accessibility">Accesibilitate</string>
-    <string name="keyboard_workaround_name">Rezolvare sugestii tastatură</string>
-    <string name="keyboard_workaround_desc">Previne tastaturile problematice (precum SwiftKey™) să mai arate sugestii</string>
     <string name="alternate_history_inputs">Surse alternative istoric</string>
     <string name="keyboard_options">Opțiuni tastatură</string>
     <string name="misc">Diverse</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -129,8 +129,6 @@
     <string name="settings_dev">Для разработчиков</string>
     <string name="settings_accessibility">Специальные возможности</string>
     <string name="ui_item_visit">Открыть “%1$s”</string>
-    <string name="keyboard_workaround_desc">Блокировать варианты ввода в сторонних клавиатурах</string>
-    <string name="keyboard_workaround_name">Обход вариантов</string>
     <string name="settings_sound">Звук и громкость</string>
     <string name="settings_display">Дисплей</string>
     <string name="menu_tags_edit">Теги</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -46,8 +46,6 @@
     <string name="reset_favorites_name">Nollställ din lista av favoriter</string>
     <string name="reset_favorites_warn">Vill du verkligen nollställa din lista av favoriter?</string>
     <string name="keyboard_name">Visa tangentbord vid start</string>
-    <string name="keyboard_workaround_name">Fix för tangentbordsförslag</string>
-    <string name="keyboard_workaround_desc">Förhindrar "mjuka" tangentbord (som SwiftKey™) från att visa förslag</string>
     <string name="history_hide_desc">Dölj historik och introskärm</string>
     <string name="history_hide_name">Minimalistiskt användargränssnitt</string>
     <string name="history_onclick_name">Visa historik vid tryck</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -126,8 +126,6 @@
     <string name="settings_storage">Складиште</string>
     <string name="settings_dev">Опције за програмера</string>
     <string name="settings_accessibility">Приступачност</string>
-    <string name="keyboard_workaround_name">Поправка за предлоге тастатуре</string>
-    <string name="keyboard_workaround_desc">Спречава покварене софтверске тастатуре (нпр. SwiftKey™) да приказују предлоге</string>
     <string name="alternate_history_inputs">Мењај улазе историјата наизменице</string>
     <string name="keyboard_options">Опције тастатуре</string>
     <string name="misc">Разно</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -46,8 +46,6 @@
     <string name="reset_favorites_name">Återställa din lista över favoriter</string>
     <string name="reset_favorites_warn">Vill du verkligen återställa dina favoriter?</string>
     <string name="keyboard_name">Visa tangentbordet på start</string>
-    <string name="keyboard_workaround_name">Fix för tangentbordsförslag</string>
-    <string name="keyboard_workaround_desc">Förhindra trasiga mjuk-tangentbord (som SwiftKey™) från att visa förslag</string>
     <string name="history_hide_desc">Dölj historik och introskärm, aktivera widgets</string>
     <string name="history_hide_name">Minimalistisk UI</string>
     <string name="history_onclick_name">Visa historik vid beröring</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -127,8 +127,6 @@
 
     <string name="exclude_favorites">Sık kullanılanları geçmişe dahil etme</string>
     <string name="favorites_hide">Sık Kullanılanlar Çubuğunu Gizle</string>
-    <string name="keyboard_workaround_desc">Bozuk yazılım-klavyelerinin (SwiftKey™ gibi) öneri göstermelerini engelle</string>
-    <string name="keyboard_workaround_name">Klavye önerileri çözümü</string>
     <string name="misc">Diğer</string>
 
     <string name="keyboard_options">Klavye seçenekleri</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -77,8 +77,6 @@
     <string name="root_mode_name">Root режим</string>
     <string name="title_wallpaper">Живе інтерактивне тло</string>
     <string name="title_providers">Вибір постачальників</string>
-    <string name="keyboard_workaround_name">Виправлення клавіатурних пропозицій</string>
-    <string name="keyboard_workaround_desc">Перешкоджати зламаним програмним клавіатурам (наприклад, SwiftKey ™) від показу пропозицій</string>
     <string name="history_onclick_name">Показати історію при дотику</string>
     <string name="portrait_title">Примусовий портретний режим</string>
     <string name="lwp_touch">Надсилайте дотичні події на тло</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -123,8 +123,6 @@
     <string name="settings_storage">存储</string>
     <string name="settings_dev">开发者设置</string>
     <string name="settings_accessibility">无障碍功能</string>
-    <string name="keyboard_workaround_name">键盘建议修正</string>
-    <string name="keyboard_workaround_desc">显示建议时避免不能用的软键盘（如 SwiftKey™）</string>
     <string name="alternate_history_inputs">备用历史记录输入</string>
     <string name="keyboard_options">键盘选项</string>
     <string name="misc">杂项</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -47,8 +47,6 @@
     <string name="reset_favorites_name">重設您的收藏列表</string>
     <string name="reset_favorites_warn">您確定要重設收藏列表？</string>
     <string name="keyboard_name">啟動時彈出鍵盤</string>
-    <string name="keyboard_workaround_name">輸入法建議修正</string>
-    <string name="keyboard_workaround_desc">避免不相容的輸入法（如 SwiftKey™）顯示輸入建議</string>
     <string name="history_hide_desc">隱藏歷史紀錄和歡迎畫面，顯示主畫面小工具</string>
     <string name="history_hide_name">簡易模式</string>
     <string name="history_onclick_name">點擊時查看歷史紀錄</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,8 +54,6 @@
     <string name="reset_favorites_name">Reset your list of favorites</string>
     <string name="reset_favorites_warn">Do you really want to reset your favorites?</string>
     <string name="keyboard_name">Display keyboard on start</string>
-    <string name="keyboard_workaround_name">Keyboard suggestions fix</string>
-    <string name="keyboard_workaround_desc">Prevent broken soft-keyboards (like SwiftKey™) from showing suggestions</string>
     <string name="history_hide_desc">Hide history and intro screen, enable widgets</string>
     <string name="history_hide_name">Minimalistic UI</string>
     <string name="history_onclick_name">Show history on touch</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -122,11 +122,6 @@
                 android:defaultValue="false"
                 android:key="display-keyboard"
                 android:title="@string/keyboard_name" />
-            <fr.neamar.kiss.SwitchPreference
-                android:defaultValue="false"
-                android:key="enable-keyboard-workaround"
-                android:summary="@string/keyboard_workaround_desc"
-                android:title="@string/keyboard_workaround_name" />
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/history_hide_name">
             <fr.neamar.kiss.SwitchPreference


### PR DESCRIPTION
Removes the preference from the setting screen as this is now automatically detected.
