### PR TITLE
Enable fast scroll on app list

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -657,7 +657,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 searchEditText.setText("");
             }
 
-            // Do not display the alphabetical scrollbars (#926)
+            // Do not display the alphabetical scrollbar (#926)
+            // They only make sense when displaying apps alphabetically, not for searching
             list.setFastScrollEnabled(false);
         }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -628,6 +628,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 anim.start();
             }
             kissBar.setVisibility(View.VISIBLE);
+
+            // Display the alphabet on the scrollbar (#926)
+            list.setFastScrollEnabled(true);
         } else {
             isDisplayingKissBar = false;
             // Hide the bar
@@ -653,6 +656,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             if (clearSearchText) {
                 searchEditText.setText("");
             }
+
+            // Do not display the alphabetical scrollbars (#926)
+            list.setFastScrollEnabled(false);
         }
 
         forwarderManager.onDisplayKissBar(display);

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -293,12 +293,6 @@ public class SettingsActivity extends PreferenceActivity implements
             addCustomSearchProvidersPreferences(prefs);
         } else if (key.equalsIgnoreCase("icons-pack")) {
             KissApplication.getApplication(this).getIconsHandler().loadIconsPack(sharedPreferences.getString(key, "default"));
-        } else if (key.equalsIgnoreCase("sort-apps")) {
-            // Reload application list
-            final AppProvider provider = KissApplication.getApplication(this).getDataHandler().getAppProvider();
-            if (provider != null) {
-                provider.reload();
-            }
         } else if (key.equalsIgnoreCase("enable-sms-history")) {
             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && checkSelfPermission(Manifest.permission.RECEIVE_SMS)
                     != PackageManager.PERMISSION_GRANTED) {

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -1,18 +1,14 @@
 package fr.neamar.kiss.adapter;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Handler;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.SectionIndexer;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -170,22 +166,12 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         alphaIndexer.clear();
         int size = results.size();
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        // Apply app sorting preference
-        boolean isAlphabetical = prefs.getString("sort-apps", "alphabetical").equals("alphabetical");
-
         // Generate the mapping letter => number
         for (int x = 0; x < size; x++) {
             String s = results.get(x).getSection();
 
-            if(isAlphabetical) {
-                // Put the first one
-                if (!alphaIndexer.containsKey(s)) {
-                    alphaIndexer.put(s, x);
-                }
-            }
-            else {
-                // Put the last one
+            // Put the first one
+            if (!alphaIndexer.containsKey(s)) {
                 alphaIndexer.put(s, x);
             }
         }
@@ -194,45 +180,29 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         Set<String> sectionLetters = alphaIndexer.keySet();
         ArrayList<String> sectionList = new ArrayList<>(sectionLetters);
         Collections.sort(sectionList);
-        if (isAlphabetical) {
-            // When displaying from A to Z, everything needs to be reversed
-            Collections.reverse(sectionList);
-        }
+        // We're displaying from A to Z, everything needs to be reversed
+        Collections.reverse(sectionList);
         sections = new String[sectionList.size()];
         sectionList.toArray(sections);
     }
 
     @Override
     public Object[] getSections() {
-        Log.e("WTF", Arrays.toString(sections));
-        Log.e("WTF", alphaIndexer.toString());
-
         return sections;
     }
 
     @Override
     public int getPositionForSection(int sectionIndex) {
-        Log.e("WTF", "P4S" +  alphaIndexer.get(sections[sectionIndex]) + " " + sectionIndex + " " + sections[sectionIndex]);
         return alphaIndexer.get(sections[sectionIndex]);
     }
 
     @Override
     public int getSectionForPosition(int position) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        // Apply app sorting preference
-        boolean isAlphabetical = prefs.getString("sort-apps", "alphabetical").equals("alphabetical");
-
-        if(isAlphabetical) {
-            for (int i = 0; i < sections.length; i++) {
-                if (alphaIndexer.get(sections[i]) > position) {
-                    Log.e("WTF", "S4P" + i + "  " + position + " " + sections[i]);
-                    return i - 1;
-                }
+        for (int i = 0; i < sections.length; i++) {
+            if (alphaIndexer.get(sections[i]) > position) {
+                return i - 1;
             }
-            return sections.length - 1;
         }
-
-        // Non alphabetical doesn't need section
-        return 0;
+        return sections.length - 1;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -1,14 +1,18 @@
 package fr.neamar.kiss.adapter;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.SectionIndexer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -166,11 +170,22 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         alphaIndexer.clear();
         int size = results.size();
 
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        // Apply app sorting preference
+        boolean isAlphabetical = prefs.getString("sort-apps", "alphabetical").equals("alphabetical");
+
         // Generate the mapping letter => number
         for (int x = 0; x < size; x++) {
             String s = results.get(x).getSection();
 
-            if (!alphaIndexer.containsKey(s)) {
+            if(isAlphabetical) {
+                // Put the first one
+                if (!alphaIndexer.containsKey(s)) {
+                    alphaIndexer.put(s, x);
+                }
+            }
+            else {
+                // Put the last one
                 alphaIndexer.put(s, x);
             }
         }
@@ -179,22 +194,45 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         Set<String> sectionLetters = alphaIndexer.keySet();
         ArrayList<String> sectionList = new ArrayList<>(sectionLetters);
         Collections.sort(sectionList);
+        if (isAlphabetical) {
+            // When displaying from A to Z, everything needs to be reversed
+            Collections.reverse(sectionList);
+        }
         sections = new String[sectionList.size()];
         sectionList.toArray(sections);
     }
 
     @Override
     public Object[] getSections() {
+        Log.e("WTF", Arrays.toString(sections));
+        Log.e("WTF", alphaIndexer.toString());
+
         return sections;
     }
 
     @Override
     public int getPositionForSection(int sectionIndex) {
+        Log.e("WTF", "P4S" +  alphaIndexer.get(sections[sectionIndex]) + " " + sectionIndex + " " + sections[sectionIndex]);
         return alphaIndexer.get(sections[sectionIndex]);
     }
 
     @Override
     public int getSectionForPosition(int position) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        // Apply app sorting preference
+        boolean isAlphabetical = prefs.getString("sort-apps", "alphabetical").equals("alphabetical");
+
+        if(isAlphabetical) {
+            for (int i = 0; i < sections.length; i++) {
+                if (alphaIndexer.get(sections[i]) > position) {
+                    Log.e("WTF", "S4P" + i + "  " + position + " " + sections[i]);
+                    return i - 1;
+                }
+            }
+            return sections.length - 1;
+        }
+
+        // Non alphabetical doesn't need section
         return 0;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -106,7 +106,8 @@ public abstract class Result {
     public abstract View display(Context context, int position, View convertView);
 
     public String getSection() {
-        // get the first letter of the store
+        // get the normalized first letter of the pojo
+        // Ensure accented characters are never displayed. (É => E)
         String ch = Character.toString((char) pojo.normalizedName.codePoints[0]);
         // convert to uppercase otherwise lowercase a -z will be sorted
         // after upper A-Z

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -91,7 +91,6 @@ public abstract class Result {
         return enriched;
     }
 
-
     @Override
     public String toString() {
         return pojo.getName();
@@ -106,6 +105,13 @@ public abstract class Result {
      */
     public abstract View display(Context context, int position, View convertView);
 
+    public String getSection() {
+        // get the first letter of the store
+        String ch = Character.toString((char) pojo.normalizedName.codePoints[0]);
+        // convert to uppercase otherwise lowercase a -z will be sorted
+        // after upper A-Z
+        return ch.toUpperCase();
+    }
     /**
      * How to display the popup menu
      *

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -47,4 +47,11 @@ public class ApplicationsSearcher extends Searcher {
         this.addResult(pojos.toArray(new Pojo[0]));
         return null;
     }
+
+    @Override
+    protected void onPostExecute(Void param) {
+        super.onPostExecute(param);
+        // Build sections for fast scrolling
+        activityWeakReference.get().adapter.buildSections();
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -1,8 +1,6 @@
 package fr.neamar.kiss.searcher;
 
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,13 +21,8 @@ public class ApplicationsSearcher extends Searcher {
 
     @Override
     PriorityQueue<Pojo> getPojoProcessor(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        // Apply app sorting preference
-        if (prefs.getString("sort-apps", "alphabetical").equals("invertedAlphabetical")) {
-            return new PriorityQueue<>(DEFAULT_MAX_RESULTS, new PojoComparator());
-        } else {
-            return new PriorityQueue<>(DEFAULT_MAX_RESULTS, Collections.reverseOrder(new PojoComparator()));
-        }
+        // Sort from A to Z, so reverse (last item needs to be A, listview starts at the bottom)
+        return new PriorityQueue<>(DEFAULT_MAX_RESULTS, Collections.reverseOrder(new PojoComparator()));
     }
 
     @Override

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -88,7 +88,6 @@
 
     <string name="toast_favorites_added">تمت إضافة%s إلى المفضلة</string>
 
-    <string name="order_apps_name">التطبيق ترتيب القائمة</string>
     <string name="enable_sms">تجميع التاريخ من الرسائل النصية</string>
     <string name="enable_phone">تجميع التاريخ من المكالمات الهاتفية</string>
     <string name="enable_app">تجميع التاريخ من التطبيق تثبيت</string>

--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -48,8 +48,6 @@
     <string name="theme_name">Tema</string>
     <string name="menu_phone_create">Crear contautu</string>
 
-    <string name="order_apps_name">Orde del llistáu d\'aplicaciones</string>
-
     <string name="title_providers">Esbilla de fornidores</string>
     <string name="ui_empty_2">Mira siempres la to historia</string>
     <string name="ui_empty_2_sub">Pa un accesu rápidu</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -71,8 +71,6 @@
     <string name="portrait_title">Dikey rejimi zorla</string>
     <string name="menu_phone_create">Kontakt yarat</string>
 
-    <string name="order_apps_name">Proqram siyahı sırası</string>
-
     <string name="history_hide_desc">Keçmişi və daxil ekranını gizlət</string>
     <string name="history_hide_name">Minimalistik interfeys</string>
 </resources>

--- a/app/src/main/res/values-de/arrays.xml
+++ b/app/src/main/res/values-de/arrays.xml
@@ -8,8 +8,4 @@
         <item>Semi-transparent Dunkel</item>
         <item>Transparent Dunkel</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>Von A nach Z</item>
-        <item>Von Z nach A</item>
-    </string-array>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -73,8 +73,6 @@
 
     <string name="menu_phone_create">Kontakt erstellen</string>
 
-    <string name="order_apps_name">Sortierreihenfolge der Appliste</string>
-
     <string name="shortcuts_name">Verknüpfungen</string>
 
     <string name="reset_warn">Wollen Sie wirklich Ihren gesamten Verlauf leeren?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -86,7 +86,6 @@
 
     <string name="toast_favorites_added">%s προστέθηκε στα αγαπημένα</string>
 
-    <string name="order_apps_name">Ταξινόμηση λίστας εφαρμογών</string>
     <string name="shortcut_added">Η συντόμευση προστέθηκε στο KISS.</string>
 
     <string name="root_mode_error">Αποτυχία απόκτησης δικαιωμάτων διαχειριστή.</string>

--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -8,8 +8,4 @@
         <item>Tema semi-transparente oscuro</item>
         <item>Tema transparente oscuro</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>De la A a la Z</item>
-        <item>De la Z a la A</item>
-    </string-array>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -88,7 +88,6 @@
 
     <string name="toast_favorites_added">%s ha sido añadido a favoritos</string>
 
-    <string name="order_apps_name">Orden de la lista de aplis</string>
     <string name="enable_sms">Mostrar SMS entrantes en el historial</string>
     <string name="enable_phone">Incluir llamadas entrantes en el historial</string>
     <string name="enable_app">Incluir aplis instaladas recientemente en el historial</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -71,7 +71,6 @@
     <string name="toast_hibernate_completed">%s a été hibernée, relancez-la pour la réveiller.</string>
     <string name="toast_hibernate_error">%s n\'est pas hibernée.</string>
     <string name="menu_phone_create">Créer un contact</string>
-    <string name="order_apps_name">Ordre de tri de la liste d\'applications</string>
     <string name="portrait_title">Forcer le mode portrait</string>
     <string name="history_hide_name">Interface minimaliste</string>
     <string name="history_hide_desc">Cacher l\'historique et l\'écran d\'introduction, activer les widgets</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -71,8 +71,6 @@
     <string name="theme_name">Tema</string>
     <string name="menu_phone_create">Crear contacto</string>
 
-    <string name="order_apps_name">Orden da listaxe</string>
-
     <string name="shortcuts_name">Atallos</string>
 
     <string name="reset_warn">Realmente desexas reiniciar o teu historial?</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -112,7 +112,6 @@
 
     <string name="toast_favorites_added">%s dodan u favorite</string>
 
-    <string name="order_apps_name">Sortiranje aplikacija</string>
     <string name="enable_sms">Prikaži povijest dolaznih SMS poruka</string>
     <string name="enable_phone">Prikaži povijest dolaznih poziva</string>
     <string name="enable_app">Prikaži povijest novih aplikacija</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -97,7 +97,6 @@
 
     <string name="toast_favorites_added">a(z) %s hozzáadva a kedvencekhez</string>
 
-    <string name="order_apps_name">App lista rendezése</string>
     <string name="shortcut_added">Parancsikon hozzáadva.</string>
 
     <string name="enable_sms">Bejövő SMS-ek mutatása az előzmények között</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -89,7 +89,6 @@
 
     <string name="toast_favorites_added">%s telah ditambahkan ke favorit</string>
 
-    <string name="order_apps_name">Susunan urutan daftar app</string>
     <string name="enable_sms">Tampilkan SMS yang masuk diriwayat</string>
     <string name="enable_phone">Tampilkan panggilan masuk diriwayat</string>
     <string name="enable_app">Tampilkan app yang baru terinstal diriwayat</string>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -8,10 +8,6 @@
         <item>Semitrasparente scuro</item>
         <item>Trasparente scuro</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>Dalla A alla Z</item>
-        <item>Dalla Z alla A</item>
-    </string-array>
     <string-array name="historyModeEntries">
         <item>Più recente per primo</item>
         <item>Più utilizzato per primo</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -132,7 +132,6 @@
 
     <string name="toast_favorites_added">L\'elemento %s è stato aggiunto ai preferiti</string>
 
-    <string name="order_apps_name">Ordine dell\'elenco delle applicazioni</string>
     <string name="enable_sms">Visualizza gli SMS ricevuti</string>
     <string name="enable_phone">Visualizza le chiamate ricevute</string>
     <string name="enable_app">Visualizza le applicazioni appena installate</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -70,8 +70,6 @@
     <string name="portrait_title">強制的に縦向き</string>
     <string name="menu_phone_create">連絡先を作成</string>
 
-    <string name="order_apps_name">アプリ一覧の並び順</string>
-
     <string name="history_hide_desc">履歴と導入画面を非表示にして、ウィジェットを有効にします</string>
     <string name="history_hide_name">最小限の UI</string>
     <string name="history_onclick_name">タッチして履歴を表示</string>

--- a/app/src/main/res/values-lt/arrays.xml
+++ b/app/src/main/res/values-lt/arrays.xml
@@ -8,10 +8,6 @@
         <item>Tamsi pusiau permatoma tema</item>
         <item>Tamsi permatoma tema</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>Nuo A iki Z</item>
-        <item>Nuo Z iki A</item>
-    </string-array>
     <string-array name="historyModeEntries">
         <item>Paskiausias pirma</item>
         <item>Dažniausias pirma (dažnumas)</item>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -113,7 +113,6 @@
 
     <string name="toast_favorites_added">%s buvo įtraukta į megiamiausiuosius</string>
 
-    <string name="order_apps_name">Programėlių sąrašo rūšiavimo tvarka</string>
     <string name="enable_sms">Rodyti įeinančias teksto žinutes istorijoje</string>
     <string name="enable_phone">Rodyti įeinančius skambučius istorijoje</string>
     <string name="enable_app">Rodyti neseniai instaliuotas programėles istorijoje</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -65,8 +65,6 @@
     <string name="theme_name">Draktgrensesnitt</string>
     <string name="menu_phone_create">Opprett kontakt</string>
 
-    <string name="order_apps_name">Sortering for programliste</string>
-
     <string name="alias_contacts">kontakter,folk,relasjoner</string>
     <string name="alias_web" tools:ignore="Typos">internett,vev,browser</string>
     <string name="alias_mail">epost,e-post</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -119,7 +119,6 @@
 
     <string name="toast_favorites_added">%s toegevoegd aan favorieten</string>
 
-    <string name="order_apps_name">Volgorde applicatielijst</string>
     <string name="enable_sms">Inkomende sms-berichten weergeven in geschiedenis</string>
     <string name="enable_phone">Toon inkomende gesprekken in geschiedenis</string>
     <string name="enable_app">Laat laatst geïnstalleerde apps zien in geschiedenis</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -87,7 +87,6 @@
     <string name="menu_exclude">Wyklucz aplikację z KISS</string>
     <string name="toast_favorites_added">%s został dodany do ulubionych</string>
 
-    <string name="order_apps_name">Kolejność listy aplikacji</string>
     <string name="enable_sms">Wypełnij historię wiadomościami tekstowymi</string>
     <string name="enable_phone">Wypełnij historię połączeniami telefonicznymi</string>
     <string name="enable_app">Wypełnij historię z zainstalowanych aplikacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -70,8 +70,6 @@
     <string name="theme_name">Tema da interface</string>
     <string name="menu_phone_create">Criar contato</string>
 
-    <string name="order_apps_name">Ordem da lista de aplicativos</string>
-
     <string name="activity_setting">Configurações do KISS</string>
 
     <string name="app_name">Launcher KISS</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -112,7 +112,6 @@
 
     <string name="toast_favorites_added">%s foi adicionado aos favoritos</string>
 
-    <string name="order_apps_name">Ordem da lista de aplicações</string>
     <string name="enable_sms">Exibir SMS recebidas no histórico</string>
     <string name="enable_phone">Exibir chamadas recebidas no histórico</string>
     <string name="enable_app">Exibir aplicações instaladas recentemente no histórico</string>

--- a/app/src/main/res/values-ro/arrays.xml
+++ b/app/src/main/res/values-ro/arrays.xml
@@ -8,10 +8,6 @@
         <item>Tema intunecata semi-transparenta</item>
         <item>Tema intunecata transparenta</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>De la A la Z</item>
-        <item>De la Z la A</item>
-    </string-array>
     <string-array name="historyModeEntries">
         <item>Cele mai recente primele</item>
         <item>Cele mai frecvent utilizate primele</item>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -93,7 +93,6 @@
 
     <string name="toast_favorites_added">%s a fost adăugat la favorite</string>
 
-    <string name="order_apps_name">Ordine sortare listă aplicații</string>
     <string name="enable_sms">Arată mesajele SMS primite în istoric</string>
     <string name="enable_phone">Adaugă apelurile telefonice la istoric</string>
     <string name="enable_app">Adaugă aplicațiile noi instalate la istoric</string>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -8,10 +8,6 @@
         <item>Чёрная полупрозрачная</item>
         <item>Чёрная прозрачная</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>А–Я</item>
-        <item>Я–А</item>
-    </string-array>
     <string-array name="historyModeEntries">
         <item>Недавние</item>
         <item>Частые</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -71,8 +71,6 @@
     <string name="portrait_title">Портретный режим</string>
     <string name="menu_phone_create">Создать контакт</string>
 
-    <string name="order_apps_name">Сортировка приложений</string>
-
     <string name="history_hide_desc">Скрыть историю и приветствие, включить виджеты</string>
     <string name="history_hide_name">Лаконичный UI</string>
     <string name="history_onclick_name">История при нажатии</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -111,7 +111,6 @@
 
     <string name="toast_favorites_added">%s lades till bland favoriter</string>
 
-    <string name="order_apps_name">Sortering av applista</string>
     <string name="enable_sms">Visa inkommande SMS i historiken</string>
     <string name="enable_phone">Visa inkommande samtal i historiken</string>
     <string name="enable_app">Visa nyligen installerade appar i historiken</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -108,7 +108,6 @@
     <string name="menu_shortcut_remove">Уклони пречицу</string>
 
     <string name="theme_name">Тема сучеља</string>
-    <string name="order_apps_name">Ређање апликација</string>
     <string name="enable_sms">Прикажи долазни СМС у историјату</string>
     <string name="enable_phone">Приказуј долазне позиве у историјату</string>
     <string name="enable_app">Прикажи новоинсталиране апликације у историјату</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -71,8 +71,6 @@
     <string name="portrait_title">Dikey kipi zorla</string>
     <string name="menu_phone_create">Kişi oluştur</string>
 
-    <string name="order_apps_name">Uygulama listesi sıralaması</string>
-
     <string name="history_hide_desc">Geçmiş ve giriş ekranını gizle, widgetları etkinleştir</string>
     <string name="history_hide_name">Basit arayüz</string>
     <string name="shortcuts_name">Kısayollar</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -142,7 +142,6 @@
     <string name="theme_name">Тема інтерфейсу</string>
     <string name="toast_favorites_added">%s було додано до вподобань</string>
 
-    <string name="order_apps_name">Порядок сортування списку додатків</string>
     <string name="enable_sms">Показати вхідні SMS-повідомлення в історії</string>
     <string name="enable_phone">Показати вхідні дзвінки в історії</string>
     <string name="enable_app">Показати нещодавно встановлені додатки в історії</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -94,7 +94,6 @@
 
     <string name="toast_favorites_added">%s 已添加到收藏</string>
 
-    <string name="order_apps_name">应用列表排序方式</string>
     <string name="enable_sms">在历史记录中显示收到的短信</string>
     <string name="enable_phone">在历史记录中显示收到的来电</string>
     <string name="enable_app">在历史记录中显示新安装的应用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -131,7 +131,6 @@
 
     <string name="toast_favorites_added">%s 已添加到收藏</string>
 
-    <string name="order_apps_name">應用程式列表排序方式</string>
     <string name="enable_sms">在歷史紀錄中顯示收到的簡訊</string>
     <string name="enable_phone">在歷史紀錄中顯示來電紀錄</string>
     <string name="enable_app">在歷史紀錄中顯示新增的應用程式</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -16,14 +16,6 @@
         <item>semi-transparent-dark</item>
         <item>transparent-dark</item>
     </string-array>
-    <string-array name="sortAppListEntries">
-        <item>From A to Z</item>
-        <item>From Z to A</item>
-    </string-array>
-    <string-array name="sortAppListValues" translatable="false">
-        <item>alphabetical</item>
-        <item>invertedAlphabetical</item>
-    </string-array>
     <string-array name="historyModeEntries">
         <item>Most recent first</item>
         <item>Most frequent first (frecency)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,7 +140,6 @@
 
     <string name="toast_favorites_added">%s was added to favorites</string>
 
-    <string name="order_apps_name">App list sort order</string>
     <string name="enable_sms">Show incoming SMSes in history</string>
     <string name="enable_phone">Show incoming calls in history</string>
     <string name="enable_app">Show newly installed apps in history</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -156,12 +156,6 @@
                 android:defaultValue="false"
                 android:key="force-portrait"
                 android:title="@string/portrait_title" />
-            <ListPreference
-                android:defaultValue="alphabetical"
-                android:entries="@array/sortAppListEntries"
-                android:entryValues="@array/sortAppListValues"
-                android:key="sort-apps"
-                android:title="@string/order_apps_name" />
             <fr.neamar.kiss.SwitchPreference
                 android:defaultValue="true"
                 android:key="tags-visible"


### PR DESCRIPTION
Fix #926 by enabling fast-scroll (alphabet scrolling) on the app list.

It should work equally well with non-ascii character, as I'm using the normalized result name.

![2018-05-07 11 06 14](https://user-images.githubusercontent.com/536844/39697006-6337b8a2-51e7-11e8-8f13-8ec537e2e8bf.png)

This also removes the option to sort apps from Z to A, as the implementation got quite messy for not real value. See comment in 00f5f5f.

Documentation on fast scroll: https://developer.android.com/reference/android/widget/SectionIndexer