### PR TITLE
[DNM] Reporting of settings in use for KISS beta

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,14 +7,12 @@ android {
         applicationId 'fr.neamar.kiss'
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 127
-        versionName "3.2.0"
+        versionCode 129
+        versionName "3.2.2-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
-            minifyEnabled true
-            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId 'fr.neamar.kiss'
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 129
-        versionName "3.2.2-beta"
+        versionCode 130
+        versionName "3.2.3-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId 'fr.neamar.kiss'
         minSdkVersion 15
         targetSdkVersion 27
-        versionCode 130
-        versionName "3.2.3-beta"
+        versionCode 131
+        versionName "3.3.0-beta"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
     implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.amplitude:android-sdk:2.16.0'
 }
 
 buildscript {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -8,3 +8,5 @@
     public static int d(...);
     public static int e(...);
 }
+-keep class com.google.android.gms.ads.** { *; }
+-dontwarn okio.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
     <!-- Display notification drawer -->
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
 
+    <!-- Access Internet (for tracking purposes on the beta version only) -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -14,6 +14,11 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.amplitude.api.Amplitude;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -216,6 +221,14 @@ public class DataHandler extends BroadcastReceiver
 
         long time = System.currentTimeMillis() - start;
         Log.v(TAG, "Time to load all providers: " + time + "ms");
+
+        try {
+            JSONObject eventProperties = new JSONObject();
+            eventProperties.put("time", time);
+            Amplitude.getInstance().logEvent("All providers loaded", eventProperties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
 
         this.allProvidersHaveLoaded = true;
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -32,6 +32,8 @@ import android.widget.PopupWindow;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
+import com.amplitude.api.Amplitude;
+
 import java.util.ArrayList;
 
 import fr.neamar.kiss.adapter.RecordAdapter;
@@ -146,6 +148,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Amplitude.getInstance().initialize(this, "ce5704d98bb60331b30cce7dee138112").enableForegroundTracking(getApplication());
+
         Log.d(TAG, "onCreate()");
 
         KissApplication.getApplication(this).initDataHandler();

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.database.DataSetObserver;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -352,12 +353,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         if(!prefs.contains("informed-about-tracking-in-beta")) {
             AlertDialog.Builder alert = new AlertDialog.Builder(this);
             alert.setTitle("Important information");
-            Spannable text= new SpannableString(Html.fromHtml("Thanks for being part of KISS beta!<br>" +
+            Spannable text= new SpannableString(Html.fromHtml("Welcome to KISS beta!<br>" +
                     "This version anonymously reports which settings are currently in use.<br>" +
                     "<b>This will allow us to prioritize the most-used settings in our development</b>.<br>" +
-                    "This is <i>temporary</i>, for the next couple weeks at most. " +
-                    "For more details (including opting-out): <a href=https://github.com/Neamar/KISS/pull/979>https://github.com/Neamar/KISS/pull/979</a>.<br>" +
-                    "Sorry for the inconvenience!"));
+                    "For more details: <a href=https://github.com/Neamar/KISS/pull/979>https://github.com/Neamar/KISS/pull/979</a><br>" +
+                    "Thanks for your help in improving KISS!"));
             Linkify.addLinks(text, Linkify.WEB_URLS);
 
             alert.setMessage(text);
@@ -366,6 +366,16 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 public void onClick(DialogInterface dialog, int whichButton) {
                     trackSettings();
                     prefs.edit().putBoolean("informed-about-tracking-in-beta", true).apply();
+                }
+            });
+
+            alert.setNegativeButton("Leave the beta", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int whichButton) {
+                    String url = "https://play.google.com/apps/testing/fr.neamar.kiss";
+                    Intent i = new Intent(Intent.ACTION_VIEW);
+                    i.setData(Uri.parse(url));
+                    startActivity(i);
+                    finish();
                 }
             });
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -403,7 +403,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             else if(s.equals(("selected-search-provider-names"))) {
                 identify.set("search-provider-count", settings.get(s).toString().split(",").length);
             }
-            else if(!s.equals("excluded_apps_ui")) {
+            else if(!s.equals("excluded_apps_ui") && !s.equals("available-search-providers") && !s.equals("deleting-search-providers-names")) {
                 identify.set(s, settings.get(s).toString());
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -114,7 +114,7 @@ public class RecordAdapter extends BaseAdapter {
 
         try {
             result = results.get(position);
-            result.launch(context, v);
+            result.launch(context, v, position);
         } catch (ArrayIndexOutOfBoundsException ignored) {
             return;
         }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss.dataprovider;
 
 import android.app.Service;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
@@ -56,7 +57,7 @@ public abstract class Provider<T extends Pojo> extends Service implements IProvi
 
         loader.setProvider(this);
         this.pojoScheme = loader.getPojoScheme();
-        loader.execute();
+        loader.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     public void reload() {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
@@ -6,6 +6,11 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
 
+import com.amplitude.api.Amplitude;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,7 +66,16 @@ public abstract class Provider<T extends Pojo> extends Service implements IProvi
     }
 
     public void loadOver(ArrayList<T> results) {
-        Log.i(TAG, "Done loading provider: " + this.getClass().getSimpleName());
+        Log.i(TAG, "Done loading provider: " + getClass().getSimpleName());
+
+        try {
+            JSONObject eventProperties = new JSONObject();
+            eventProperties.put("type", getClass().getSimpleName());
+            eventProperties.put("pojo_count", pojos.size());
+            Amplitude.getInstance().logEvent("Provider loaded", eventProperties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
 
         // Store results
         this.pojos = results;

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/Provider.java
@@ -79,6 +79,7 @@ public abstract class Provider<T extends Pojo> extends Service implements IProvi
             JSONObject eventProperties = new JSONObject();
             eventProperties.put("type", getClass().getSimpleName());
             eventProperties.put("pojo_count", pojos.size());
+            eventProperties.put("time", time);
             Amplitude.getInstance().logEvent("Provider loaded", eventProperties);
         } catch (JSONException e) {
             e.printStackTrace();

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -16,6 +16,11 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageView;
 
+import com.amplitude.api.Amplitude;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 
 import fr.neamar.kiss.KissApplication;
@@ -271,6 +276,18 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
     public void onClick(View v) {
         int favNumber = Integer.parseInt((String) v.getTag());
         final Result result = getFavResult(favNumber);
+
+
+        try {
+            JSONObject eventProperties = new JSONObject();
+            eventProperties.put("type", result.getClass().getSimpleName());
+            eventProperties.put("favorite_id", favNumber);
+
+            Amplitude.getInstance().logEvent("Favorite clicked", eventProperties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
         result.fastLaunch(mainActivity, v);
         v.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -21,6 +21,11 @@ import android.widget.ImageView;
 import android.widget.ListAdapter;
 import android.widget.Toast;
 
+import com.amplitude.api.Amplitude;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.lang.ref.WeakReference;
 import java.util.List;
 
@@ -222,6 +227,15 @@ public abstract class Result {
 
     public final void launch(Context context, View v) {
         Log.i("log", "Launching " + pojo.id);
+
+        try {
+            JSONObject eventProperties = new JSONObject();
+            eventProperties.put("type", pojo.getClass().getSimpleName());
+            eventProperties.put("relevance", pojo.relevance);
+            Amplitude.getInstance().logEvent("Result clicked", eventProperties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
 
         recordLaunch(context);
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -225,13 +225,14 @@ public abstract class Result {
         parent.removeResult(this);
     }
 
-    public final void launch(Context context, View v) {
+    public final void launch(Context context, View v, int position) {
         Log.i("log", "Launching " + pojo.id);
 
         try {
             JSONObject eventProperties = new JSONObject();
             eventProperties.put("type", pojo.getClass().getSimpleName());
             eventProperties.put("relevance", pojo.relevance);
+            eventProperties.put("position", position);
             Amplitude.getInstance().logEvent("Result clicked", eventProperties);
         } catch (JSONException e) {
             e.printStackTrace();
@@ -258,7 +259,7 @@ public abstract class Result {
      * @param context android context
      */
     public void fastLaunch(Context context, View v) {
-        this.launch(context, v);
+        this.launch(context, v, -1);
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -6,6 +6,11 @@ import android.os.AsyncTask;
 import android.support.annotation.CallSuper;
 import android.util.Log;
 
+import com.amplitude.api.Amplitude;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -108,6 +113,17 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
 
         long time = System.currentTimeMillis() - start;
         Log.v("Timing", "Time to run query `" + query + "` to completion: " + time + "ms");
+
+        try {
+            JSONObject eventProperties = new JSONObject();
+            eventProperties.put("type", getClass().getSimpleName());
+            eventProperties.put("length", query.replace("<null>", "").length());
+            eventProperties.put("time", time);
+            eventProperties.put("allProvidersHaveLoaded", KissApplication.getApplication(activity).getDataHandler().allProvidersHaveLoaded);
+            Amplitude.getInstance().logEvent("Search", eventProperties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
     }
 
     public interface DataObserver {


### PR DESCRIPTION
**tl;dr**: the beta version of KISS will monitor a couple of metrics over the coming weeks, to provide opportunities to remove unused features, improve the onboarding experience by settings sensible defaults, and allow the developers to focus on the features most in-use.

## I'm not in the beta / I use f-droid, what is changing for me?
Nothing. KISS will not have access to the internet. Your data will stay on your device forever :heart: 

## I'm in the beta, can you start with why?!
Everyone hates tracking, and that includes me and the other KISS developers. 
Our [privacy policy is super clear](https://kisslauncher.com/privacy): the default version of KISS does not have access to the Internet, and your data is your data. Period.

However, with time, we've noticed that we had no visibility over which features were used, and which weren't. This led to slow development ([just look at everything that has to be tested for a release!](https://github.com/Neamar/KISS/blob/master/qa-suite.md)) and user frustration when we were unable to assess the real impact of a missing feature or bug.

To solve that, I'm starting an audit of the settings currently being used by the beta users on the Play Store ([want to join the beta?](https://play.google.com/apps/testing/fr.neamar.kiss)).

For the next couple of weeks, the beta version will report the settings currently enabled and a couple of metrics described below.

**If you do not want to be tracked, that's obviously perfectly fine and understandable! Just [opt-out of the beta](https://play.google.com/apps/testing/fr.neamar.kiss) to get the standard, internet-less KISS.**

## What is tracked?
If you want to get a complete list, you should check the changes [here](https://github.com/Neamar/KISS/pull/979/files), but here is the high-level recap of the events:

* Time to load KISS (includes the *number* of apps and contacts, to normalize the data; of course, no actual apps or contacts are sent)
* Time to load search results (include the *length* of the query, of course, no text query is sent)
* Click on a result (includes the type of result being clicked [app? contact? shortcut?], and the relevance of the result [score]. Of course the name of the result is never sent)
* Click on a favorite (includes the type of the favorite [app? contact?] and the favorite position (from 1 to 6)
* All apps button clicked

In addition to those events, the following properties are aggregated with a random user-id:

* device model
* Android version
* app version
* approximate geolocation (country)
* Locale being used (to improve translation effort)
* value for each boolean settings (e.g. "rounded bar enabled")
* value for each setting not containing user information (for instance, your search providers settings are not sent) (e.g. "theme being used")

## Who will have access to the data?
For now, that's only me.
The data will likely be shared with long-term developers on a need-to-know basis; this will probably include @sandoche @saveman71 @psykzz @TBog @licaon-kter.
Data will never be shared outside of those individuals, or sold, or anything. It will only be used to inform future developments.
Data is stored in Amplitude's server, more info about their privacy and security [here](https://amplitude.zendesk.com/hc/en-us/articles/206533238-Data-Security-Privacy).

Keep in mind that we all care about KISS. I've worked on this project for nearly 10 years, and I'm just trying to make it better. I have a job outside and don't need any money or rubbish "you're not the customer you're the product" mentality. I do *care* about this and will fight to the end to make sure this data is used (and discarded after use) correctly.

## I have more questions!
I understand this is a tricky topic, if you have any additional question or concern please send an email to contact@kisslauncher.com or even better, comment on this PR.

## Uh, I'm a dev and this is a very unusual PR!
Yup, I've hijacked the description field to add more info about this.
Feel free to review the PR, but *do not merge* it!