### PR TITLE
Support for dark notification icons

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -12,6 +12,7 @@ import android.preference.ListPreference;
 import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceCategory;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -86,6 +87,10 @@ public class SettingsActivity extends PreferenceActivity implements
         addExcludedAppSettings(prefs);
 
         addCustomSearchProvidersPreferences(prefs);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            removePreference("colors", "black-notification-icons");
+        }
     }
 
     @Override
@@ -104,6 +109,12 @@ public class SettingsActivity extends PreferenceActivity implements
             return true;
         }
         return super.onMenuItemSelected(featureId, item);
+    }
+
+    private void removePreference(String parent, String category) {
+        PreferenceCategory p = (PreferenceCategory) findPreference(parent);
+        Preference c = findPreference(category);
+        p.removePreference(c);
     }
 
     private void loadExcludedAppsToPreference(MultiSelectListPreference multiSelectList) {

--- a/app/src/main/java/fr/neamar/kiss/SwitchPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/SwitchPreference.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 // https://code.google.com/p/android/issues/detail?id=26194
-
+// Can be removed once we drop support for KitKat
 public class SwitchPreference extends android.preference.SwitchPreference {
 
     public SwitchPreference(Context context) {

--- a/app/src/main/java/fr/neamar/kiss/UIColors.java
+++ b/app/src/main/java/fr/neamar/kiss/UIColors.java
@@ -12,6 +12,7 @@ import android.view.WindowManager;
 
 public class UIColors {
     public static final int COLOR_DEFAULT = 0xFF4caf50;
+    // Source: https://material.io/guidelines/style/color.html#color-color-palette
     public static final int[] COLOR_LIST = new int[]{
             0xFF4CAF50, 0xFFD32F2F, 0xFFC2185B, 0xFF7B1FA2,
             0xFF512DA8, 0xFF303F9F, 0xFF1976D2, 0xFF0288D1,

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -5,6 +5,7 @@ import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Build;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 
@@ -64,6 +65,14 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.searchEditText.setShadowLayer(3, 1, 2, shadowColor);
             }
         }
+
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (prefs.getBoolean("black-notification-icons", false)) {
+                // Apply the flag to any view, so why not the edittext!
+                mainActivity.searchEditText.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+            }
+        }
     }
 
     void onResume() {
@@ -84,24 +93,21 @@ class InterfaceTweaks extends Forwarder {
     private void applyRoundedCorners(MainActivity mainActivity) {
         if (prefs.getBoolean("pref-rounded-bars", true)) {
             mainActivity.kissBar.setBackgroundResource(R.drawable.rounded_kiss_bar);
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar);
                 mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar);
-            }
-            else {
+            } else {
                 // Before API21, you can't access values from current theme using ?attr/
                 // So we made two different drawables (#931).
-                if(getSearchBackgroundColor() == Color.WHITE) {
+                if (getSearchBackgroundColor() == Color.WHITE) {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_light);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_light);
-                }
-                else {
+                } else {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_dark);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_dark);
                 }
             }
-        }
-        else if(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             // Tinting is not properly applied pre lollipop if there is no solid background, so we need to manually set the background color
             mainActivity.kissBar.setBackgroundColor(UIColors.getPrimaryColor(mainActivity));
         }
@@ -111,14 +117,12 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout);
                 // clip list content to rounded corners
                 mainActivity.listContainer.setClipToOutline(true);
-            }
-            else {
+            } else {
                 // Before API21, you can't access values from current theme using ?attr/
                 // So we made two different drawables (#931).
-                if(getSearchBackgroundColor() == Color.WHITE) {
+                if (getSearchBackgroundColor() == Color.WHITE) {
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_light);
-                }
-                else {
+                } else {
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_dark);
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,5 +207,7 @@
     <string name="enable_favorites_bar_summary_on">Display favorites above the search bar</string>
     <string name="get_help">Get help!</string>
     <string name="permission_denied">Permission has been denied</string>
+    <string name="colors">Colors</string>
+    <string name="black_notification_icons">Display notifications icons in black</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -26,8 +26,8 @@
             android:defaultValue="recency"
             android:entries="@array/historyModeEntries"
             android:entryValues="@array/historyModeValues"
-            android:order="46"
             android:key="history-mode"
+            android:order="46"
             android:summary="@string/history_mode_desc"
             android:title="@string/history_mode_name" />
         <fr.neamar.kiss.preference.FreezeHistorySwitch
@@ -86,19 +86,24 @@
             android:defaultValue="default"
             android:key="icons-pack"
             android:title="@string/icons_pack_name" />
-        <fr.neamar.kiss.preference.ColorPreference
-            android:key="notification-bar-color"
-            android:title="@string/notification_bar_color" />
-        <fr.neamar.kiss.preference.ColorPreference
-            android:key="primary-color"
-            android:title="@string/main_color" />
+        <PreferenceCategory android:title="@string/colors" android:key="colors">
+            <fr.neamar.kiss.preference.ColorPreference
+                android:key="notification-bar-color"
+                android:title="@string/notification_bar_color" />
+            <fr.neamar.kiss.preference.ColorPreference
+                android:key="primary-color"
+                android:title="@string/main_color" />
+            <fr.neamar.kiss.SwitchPreference
+                android:key="black-notification-icons"
+                android:title="@string/black_notification_icons" />
+        </PreferenceCategory>
         <PreferenceCategory android:title="@string/misc">
             <fr.neamar.kiss.SwitchPreference
                 android:key="transparent-search"
                 android:title="@string/transparent_search_bar" />
             <fr.neamar.kiss.SwitchPreference
-                android:key="transparent-favorites"
                 android:defaultValue="true"
+                android:key="transparent-favorites"
                 android:title="@string/transparent_favorites_bar" />
             <fr.neamar.kiss.SwitchPreference
                 android:defaultValue="false"


### PR DESCRIPTION
As requested in #962.

Added a setting to enable this option or not.

White:
![image](https://user-images.githubusercontent.com/536844/39707228-b32443b6-520b-11e8-93e6-802846f33a62.png)

Black:
![image](https://user-images.githubusercontent.com/536844/39707237-bb3c9daa-520b-11e8-9cf1-135af09b0254.png)
