### PR TITLE
Ensure tutorial can be read on all backgrounds

### DIFF
--- a/app/src/main/res/layout/main_empty.xml
+++ b/app/src/main/res/layout/main_empty.xml
@@ -36,6 +36,10 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:shadowColor="?attr/resultShadowColor"
+                android:shadowDx="1"
+                android:shadowDy="2"
+                android:shadowRadius="3"
                 android:text="@string/ui_empty_1"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="?attr/resultColor" />
@@ -43,6 +47,10 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:shadowColor="?attr/resultShadowColor"
+                android:shadowDx="1"
+                android:shadowDy="2"
+                android:shadowRadius="3"
                 android:text="@string/ui_empty_1_sub"
                 android:textColor="?android:attr/textColorTertiary" />
         </LinearLayout>
@@ -78,6 +86,10 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:shadowColor="?attr/resultShadowColor"
+                android:shadowDx="1"
+                android:shadowDy="2"
+                android:shadowRadius="3"
                 android:text="@string/ui_empty_2"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="?attr/resultColor" />
@@ -85,6 +97,10 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:shadowColor="?attr/resultShadowColor"
+                android:shadowDx="1"
+                android:shadowDy="2"
+                android:shadowRadius="3"
                 android:text="@string/ui_empty_2_sub"
                 android:textColor="?android:attr/textColorTertiary" />
         </LinearLayout>
@@ -120,6 +136,10 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:shadowColor="?attr/resultShadowColor"
+                android:shadowDx="1"
+                android:shadowDy="2"
+                android:shadowRadius="3"
                 android:text="@string/ui_empty_3"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="?attr/resultColor" />
@@ -127,6 +147,10 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:shadowColor="?attr/resultShadowColor"
+                android:shadowDx="1"
+                android:shadowDy="2"
+                android:shadowRadius="3"
                 android:text="@string/ui_empty_3_sub"
                 android:textColor="?android:attr/textColorTertiary" />
         </LinearLayout>


### PR DESCRIPTION
In the last version, we updated the theme to default to transparent. This commit ensures the tutorial is properly displayed too, by using the shadows already in effects on results.
Fix #984.

As an example, first section has the shadows applied on this screenshot:

![image](https://user-images.githubusercontent.com/536844/39989848-f9c0b3c0-5762-11e8-9eb6-8be1d3f672db.png)


Note: this should be temporary, as we're working on a completely rebranded on-boarding experience.