### PR TITLE
Force 10 max lines in summary

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SwitchPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/SwitchPreference.java
@@ -2,9 +2,12 @@ package fr.neamar.kiss;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
 
 // https://code.google.com/p/android/issues/detail?id=26194
 // Can be removed once we drop support for KitKat
+// Forced 10 max lines in summary (different Android versions have different values)
 public class SwitchPreference extends android.preference.SwitchPreference {
 
     public SwitchPreference(Context context) {
@@ -17,5 +20,14 @@ public class SwitchPreference extends android.preference.SwitchPreference {
 
     public SwitchPreference(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+    }
+
+    @Override
+    protected void onBindView(View view) {
+        super.onBindView(view);
+
+        View summary = view.findViewById(android.R.id.summary);
+        if (summary instanceof TextView)
+            ((TextView) summary).setMaxLines(10);
     }
 }


### PR DESCRIPTION
Quick fix for SwitchPreference to have a maximum of 10 lines in summary.
See #1033
This will only fix the toggle switches in the preferences. It was a very simple fix and a more complete one would require some refactoring that I don't have time to test.