### PR TITLE
Check app icon cache on UI thread

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/cache/MemoryCacheHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/cache/MemoryCacheHelper.java
@@ -65,6 +65,14 @@ public class MemoryCacheHelper {
         }
     }
 
+    @Nullable
+    public static Drawable getCachedAppIconDrawable(ComponentName className, UserHandle userHandle) {
+        AppIconHandle handle = new AppIconHandle(className, userHandle);
+        synchronized (sAppIconCache) {
+            return sAppIconCache.get(handle);
+        }
+    }
+
     private static class AsyncAppIconLoad extends AsyncTask<Void, Void, Drawable> {
         final WeakReference<Context> contextRef;
         final AppIconHandle handle;

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -73,8 +73,10 @@ public class AppResult extends Result {
         final ImageView appIcon = view.findViewById(R.id.item_app_icon);
         if (!prefs.getBoolean("icons-hide", false)) {
             if (appIcon.getTag() instanceof ComponentName && className.equals(appIcon.getTag())) {
-                icon = appIcon.getDrawable();
+                setDrawableCache(appIcon.getDrawable());
             }
+            if (!isDrawableCached())
+                setDrawableCache(MemoryCacheHelper.getCachedAppIconDrawable(className, this.appPojo.userHandle));
             this.setAsyncDrawable(appIcon);
         } else {
             appIcon.setImageDrawable(null);


### PR DESCRIPTION
Previously the AsyncAppIconLoad task was started prior to checking if the app had an icon already cached

This PR will first check if there is an app icon cached already and set it in the AppResult