### PR TITLE
AMOLED black theme

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
@@ -1,12 +1,12 @@
 package fr.neamar.kiss.forwarder;
 
 import android.content.Intent;
-import androidx.annotation.NonNull;
 import android.view.ContextMenu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import fr.neamar.kiss.MainActivity;
 
 public class ForwarderManager extends Forwarder {
@@ -24,8 +24,8 @@ public class ForwarderManager extends Forwarder {
         super(mainActivity);
 
         this.widgetForwarder = new Widget(mainActivity);
-        this.liveWallpaperForwarder = new LiveWallpaper(mainActivity);
         this.interfaceTweaks = new InterfaceTweaks(mainActivity);
+        this.liveWallpaperForwarder = new LiveWallpaper(mainActivity);
         this.experienceTweaks = new ExperienceTweaks(mainActivity);
         this.favoritesForwarder = new Favorites(mainActivity);
         this.permissionForwarder = new Permission(mainActivity);

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -36,6 +36,9 @@ class InterfaceTweaks extends Forwarder {
             case "transparent-dark":
                 mainActivity.setTheme(R.style.AppThemeTransparentDark);
                 break;
+            case "amoled-dark":
+                mainActivity.setTheme(R.style.AppThemeAmoledDark);
+                break;
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/LiveWallpaper.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/LiveWallpaper.java
@@ -2,7 +2,9 @@ package fr.neamar.kiss.forwarder;
 
 import android.app.WallpaperManager;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Point;
+import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
@@ -12,17 +14,28 @@ import android.view.animation.Transformation;
 import fr.neamar.kiss.MainActivity;
 
 class LiveWallpaper extends Forwarder {
-    private final WallpaperManager mWallpaperManager;
-    private final Point mWindowSize;
+    private final boolean wallpaperIsVisible;
+
+    private WallpaperManager mWallpaperManager;
+    private Point mWindowSize;
     private android.os.IBinder mWindowToken;
-    private final View mContentView;
+    private View mContentView;
     private float mLastTouchPos;
     private float mWallpaperOffset;
-    private final LiveWallpaper.Anim mAnimation;
+    private LiveWallpaper.Anim mAnimation;
     private VelocityTracker mVelocityTracker;
 
     LiveWallpaper(MainActivity mainActivity) {
         super(mainActivity);
+        TypedValue typedValue = new TypedValue();
+        mainActivity.getTheme().resolveAttribute(android.R.attr.windowShowWallpaper, typedValue, true);
+        TypedArray a = mainActivity.obtainStyledAttributes(typedValue.resourceId, new int[]{android.R.attr.windowShowWallpaper});
+        wallpaperIsVisible = a.getBoolean(0, true);
+        a.recycle();
+
+        if(!wallpaperIsVisible) {
+            return;
+        }
 
         mWallpaperManager = (WallpaperManager) mainActivity.getSystemService(Context.WALLPAPER_SERVICE);
         assert mWallpaperManager != null;
@@ -36,6 +49,10 @@ class LiveWallpaper extends Forwarder {
     }
 
     boolean onTouch(View view, MotionEvent event) {
+        if(!wallpaperIsVisible) {
+            return false;
+        }
+
         int actionMasked = event.getActionMasked();
         switch (actionMasked) {
             case MotionEvent.ACTION_DOWN:

--- a/app/src/main/res/drawable/rounded_search_bar.xml
+++ b/app/src/main/res/drawable/rounded_search_bar.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="?attr/searchBackgroundOutline" />
     <solid android:color="?attr/searchBackgroundColor" />
     <corners android:radius="@dimen/corner_radius" />
 </shape>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -125,6 +125,7 @@
             android:layout_toLeftOf="@+id/clearButton"
             android:layout_toEndOf="@+id/launcherButton"
             android:layout_toRightOf="@+id/launcherButton"
+            android:layout_margin="1dp"
             android:background="?attr/searchBackgroundColor"
             android:hint="@string/ui_search_hint"
             android:imeOptions="flagNoExtractUi|actionSearch"

--- a/app/src/main/res/values-de/arrays.xml
+++ b/app/src/main/res/values-de/arrays.xml
@@ -7,5 +7,6 @@
         <item>Dunkel</item>
         <item>Semi-transparent Dunkel</item>
         <item>Transparent Dunkel</item>
+        <item>AMOLED dark theme</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -7,5 +7,6 @@
         <item>Tema oscuro</item>
         <item>Tema semi-transparente oscuro</item>
         <item>Tema transparente oscuro</item>
+        <item>AMOLED dark theme</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -7,5 +7,6 @@
         <item>Scuro</item>
         <item>Semitrasparente scuro</item>
         <item>Trasparente scuro</item>
+        <item>AMOLED dark theme</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-lt/arrays.xml
+++ b/app/src/main/res/values-lt/arrays.xml
@@ -7,5 +7,6 @@
         <item>Tamsi tema</item>
         <item>Tamsi pusiau permatoma tema</item>
         <item>Tamsi permatoma tema</item>
+        <item>AMOLED dark theme</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ro/arrays.xml
+++ b/app/src/main/res/values-ro/arrays.xml
@@ -7,6 +7,7 @@
         <item>Temă întunecata</item>
         <item>Temă întunecată semi-transparentă</item>
         <item>Temă întunecată transparentă</item>
+        <item>AMOLED dark theme</item>
     </string-array>
     <string-array name="historyModeEntries">
         <item>Cele mai recent accesate primele</item>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -7,6 +7,7 @@
         <item>Чёрная</item>
         <item>Чёрная полупрозрачная</item>
         <item>Чёрная прозрачная</item>
+        <item>AMOLED dark theme</item>
     </string-array>
     <string-array name="defaultSearchProviders" tools:ignore="InconsistentArrays">
         <item>Bing|https://www.bing.com/search?q=%s</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -7,6 +7,7 @@
         <item>Dark theme</item>
         <item>Dark semi-transparent theme</item>
         <item>Dark transparent theme</item>
+        <item>AMOLED dark theme</item>
     </string-array>
     <string-array name="themesValues" translatable="false">
         <item>light</item>
@@ -15,6 +16,7 @@
         <item>dark</item>
         <item>semi-transparent-dark</item>
         <item>transparent-dark</item>
+        <item>amoled-dark</item>
     </string-array>
     <string-array name="historyModeEntries">
         <item>Accessed recently first</item>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -5,6 +5,7 @@
     <attr name="resultShadowColor" format="reference|color" />
     <attr name="searchColor" format="reference|color" />
     <attr name="searchBackgroundColor" format="reference|color" />
+    <attr name="searchBackgroundOutline" format="reference|color" />
     <attr name="dividerDrawable" format="reference" />
     <attr name="appSelectableItemBackground" format="reference" />
     <attr name="textShadowRadius" format="reference|float" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,6 +22,7 @@
         <item name="resultShadowColor">#3f000000</item>
         <item name="listBackgroundColor">@android:color/white</item>
         <item name="searchBackgroundColor">@android:color/white</item>
+        <item name="searchBackgroundOutline">@android:color/transparent</item>
         <item name="dividerDrawable">@drawable/list_separator_light</item>
         <item name="textShadowRadius">0</item>
     </style>
@@ -36,7 +37,9 @@
         <item name="resultColor">@color/kiss_text_on_dark</item>
         <item name="resultShadowColor">@android:color/black</item>
         <item name="listBackgroundColor">@color/kiss_list_background_inverse</item>
+
         <item name="searchBackgroundColor">@color/kiss_list_background_inverse</item>
+        <item name="searchBackgroundOutline">@android:color/transparent</item>
         <item name="dividerDrawable">@drawable/list_separator_dark</item>
         <item name="textShadowRadius">0</item>
     </style>
@@ -52,6 +55,7 @@
         <item name="resultColor">@color/kiss_text_on_dark</item>
         <item name="resultShadowColor">@android:color/black</item>
         <item name="listBackgroundColor">@android:color/black</item>
+        <item name="searchBackgroundOutline">@color/kiss_list_background_inverse</item>
         <item name="searchBackgroundColor">@android:color/black</item>
         <item name="dividerDrawable">@android:color/transparent</item>
         <item name="textShadowRadius">0</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -41,6 +41,23 @@
         <item name="textShadowRadius">0</item>
     </style>
 
+
+    <style name="AppThemeAmoledDark" parent="BaseThemeDark">
+        <item name="android:windowShowWallpaper">false</item>
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:textColor">@color/kiss_text_on_dark</item>
+        <item name="android:textColorSecondary">#7f7f7f</item>
+
+        <item name="searchColor">@color/kiss_text_on_dark</item>
+        <item name="resultColor">@color/kiss_text_on_dark</item>
+        <item name="resultShadowColor">@android:color/black</item>
+        <item name="listBackgroundColor">@android:color/black</item>
+        <item name="searchBackgroundColor">@android:color/black</item>
+        <item name="dividerDrawable">@android:color/transparent</item>
+        <item name="textShadowRadius">0</item>
+    </style>
+
+
     <style name="AppThemeTransparent" parent="AppThemeLight">
         <item name="resultColor">@color/kiss_text_on_light</item>
         <item name="resultShadowColor">@android:color/black</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -51,12 +51,13 @@
         <item name="android:textColor">@color/kiss_text_on_dark</item>
         <item name="android:textColorSecondary">#7f7f7f</item>
 
-        <item name="searchColor">@color/kiss_text_on_dark</item>
-        <item name="resultColor">@color/kiss_text_on_dark</item>
+        <item name="searchColor">@android:color/white</item>
+        <item name="resultColor">@android:color/white</item>
         <item name="resultShadowColor">@android:color/black</item>
         <item name="listBackgroundColor">@android:color/black</item>
-        <item name="searchBackgroundOutline">@color/kiss_list_background_inverse</item>
+        <item name="searchBackgroundOutline">@android:color/white</item>
         <item name="searchBackgroundColor">@android:color/black</item>
+
         <item name="dividerDrawable">@android:color/transparent</item>
         <item name="textShadowRadius">0</item>
     </style>


### PR DESCRIPTION
This has been a common request over the past months.

Seems that multiple studies found out that a black pixel on an Amoled screen uses up to 40% less battery.

This is an attempt at creating a theme that is mostly black.

![2018-12-28 12 06 47](https://user-images.githubusercontent.com/536844/50528373-405f6a80-0aee-11e9-92f6-39880406bd04.png)

Using an icon pack:

![2018-12-28 22 14 18](https://user-images.githubusercontent.com/536844/50528374-405f6a80-0aee-11e9-87a9-e41b9c4d292f.png)
