### PR TITLE
Sort history entries alphabetically

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -326,6 +326,19 @@ public class DataHandler extends BroadcastReceiver
         return DBHelper.getHistoryLength(this.context);
     }
 
+    /**
+     * Query database for item and return its name
+     *
+     * @param id      globally unique ID, usually starts with provider scheme, e.g. "app://" or "contact://"
+     * @return name of item (i.e. app name)
+     */
+    public String getItemName(String id) {
+        // Ask all providers if they know this id
+        Pojo pojo = getPojo(id);
+
+        return (pojo != null) ? pojo.getName() : "???";
+    }
+
     public boolean addShortcut(ShortcutsPojo shortcut) {
         boolean success = false;//this is here to know what info is being returned
 

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -287,16 +287,17 @@ public class DataHandler extends BroadcastReceiver
      * @param context        android context
      * @param itemCount      max number of items to retrieve, total number may be less (search or calls are not returned for instance)
      * @param historyMode    Recency vs Frecency vs Frequency
+     * @param sortHistory sort history entries alphabetically
      * @param itemsToExclude Items to exclude from history
      * @return pojos in recent history
      */
-    public ArrayList<Pojo> getHistory(Context context, int itemCount, String historyMode, ArrayList<Pojo> itemsToExclude) {
+    public ArrayList<Pojo> getHistory(Context context, int itemCount, String historyMode, boolean sortHistory, ArrayList<Pojo> itemsToExclude) {
         // Pre-allocate array slots that are likely to be used based on the current maximum item
         // count
         ArrayList<Pojo> history = new ArrayList<>(Math.min(itemCount, 256));
 
         // Read history
-        List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount, historyMode);
+        List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount, historyMode, sortHistory);
 
         // Find associated items
         for (int i = 0; i < ids.size(); i++) {

--- a/app/src/main/java/fr/neamar/kiss/db/ValuedHistoryRecord.java
+++ b/app/src/main/java/fr/neamar/kiss/db/ValuedHistoryRecord.java
@@ -7,6 +7,11 @@ public class ValuedHistoryRecord {
     public String record;
 
     /**
+     * Name for the record
+     */
+    public String name;
+
+    /**
      * Context dependant value, e.g. number of access
      */
     public int value;

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -36,6 +36,7 @@ public class HistorySearcher extends Searcher {
     protected Void doInBackground(Void... voids) {
         // Ask for records
         String historyMode = prefs.getString("history-mode", "recency");
+        boolean sortHistory = prefs.getBoolean("sort-history", false);
         boolean excludeFavorites = prefs.getBoolean("exclude-favorites", false);
 
         MainActivity activity = activityWeakReference.get();
@@ -48,7 +49,7 @@ public class HistorySearcher extends Searcher {
             favoritesPojo = KissApplication.getApplication(activity).getDataHandler().getFavorites();
         }
 
-        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler().getHistory(activity, getMaxResultCount(), historyMode, favoritesPojo);
+        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler().getHistory(activity, getMaxResultCount(), historyMode, sortHistory, favoritesPojo);
 
         int size = pojos.size();
         for(int i = 0; i < size; i += 1) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,8 @@
     <string name="root_mode_desc">If available use it to hibernate apps</string>
     <string name="root_mode_name">Root mode</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>
+    <string name="history_sort_name">Sort history</string>
+    <string name="history_sort_desc">Sort history entries alphabetically</string>
     <string name="freeze_history_name">Freeze history</string>
     <string name="freeze_history_warn">Are you sure you want to freeze history and turn off further updates? Your history will not change anymore.</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,10 +25,16 @@
             android:order="46"
             android:summary="@string/history_mode_desc"
             android:title="@string/history_mode_name" />
+        <fr.neamar.kiss.SwitchPreference
+            android:defaultValue="false"
+            android:key="sort-history"
+            android:order="47"
+            android:summary="@string/history_sort_desc"
+            android:title="@string/history_sort_name" />
         <fr.neamar.kiss.preference.FreezeHistorySwitch
             android:defaultValue="false"
             android:key="freeze-history"
-            android:order="47"
+            android:order="48"
             android:summary="@string/freeze_history_summary"
             android:title="@string/freeze_history_name" />
         <PreferenceCategory


### PR DESCRIPTION
Hi!

I like the way KISS's history adapts to the apps I use most. However, the changing order of the app entries keeps me from using KISS effectively.

Thus I have added an option which simply sorts the history after it has been compiled. This means that the history still adapts to the user, but the apps stay in the same order (unless an app is added, of course).

BTW, today is **I Love Free Software Day**, so thanks a lot for KISS! :)

Martin

---

Unsorted history:

![kiss unsorted](https://user-images.githubusercontent.com/316423/52812655-45757a80-3098-11e9-8afe-9b2de0a41abc.png)

---

Sorted history:

![kiss sorted](https://user-images.githubusercontent.com/316423/52812672-53c39680-3098-11e9-8f64-14f6543239e8.png)