### PR TITLE
Fix maximum number of history results on exclusion

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -295,15 +295,18 @@ public class DataHandler extends BroadcastReceiver
         // count
         ArrayList<Pojo> history = new ArrayList<>(Math.min(itemCount, 256));
 
+        // Max sure that we get enough items, regardless of how many may be excluded
+        int extendedItemCount = itemCount + itemsToExclude.size();
+
         // Read history
-        List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, itemCount, historyMode);
+        List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, extendedItemCount, historyMode);
 
         // Find associated items
         for (int i = 0; i < ids.size(); i++) {
             // Ask all providers if they know this id
             Pojo pojo = getPojo(ids.get(i).record);
             if (pojo != null) {
-                //Look if the pojo should get excluded
+                // Look if the pojo should get excluded
                 boolean exclude = false;
                 for (int j = 0; j < itemsToExclude.size(); j++) {
                     if (itemsToExclude.get(j).id.equals(pojo.id)) {
@@ -314,6 +317,11 @@ public class DataHandler extends BroadcastReceiver
 
                 if (!exclude) {
                     history.add(pojo);
+                }
+
+                // Break if maximum number of items have been retrieved
+                if (history.size() >= itemCount) {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Hi!

I have thought a bit about correctly filtering the maximum number of history results when some of them might be excluded. There are quite a few possibilities, but the fix I propose changes only 4 LOC. I also think that it strikes a nice balance between processor and memory use.

The fix is easy: increase the limit of items that are retrieved from the database by the number of items in the exclusion list. This way, too many items will be retrieved, but still much less than the whole history. In the filtering loop, we'll then break at the time the history contains the correct number of items.

Works on my phone (Samsung Galaxy S5 with Android Oreo) and the Android emulator (Nexus 5X with Android Nougat). :)

Martin

---

Settings for the screenshots:
* History mode: Accessed recently first
* Max number of results in search and history: 5
* Exclude favorites from history: true

![screenshot_1551292958](https://user-images.githubusercontent.com/316423/53514576-4e1e7580-3ac8-11e9-8a9a-73707981e88a.png)
