### PR TITLE
Add option to swap the KISS button with the menu button

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -29,7 +29,6 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.PopupWindow;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
@@ -102,7 +101,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     /**
      * The ViewGroup that wraps the buttons at the right hand side of the searchEditText
      */
-    public RelativeLayout rightHandSideButtonsWrapper;
+    public ViewGroup rightHandSideButtonsWrapper;
     /**
      * Menu button
      */

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -12,7 +12,6 @@ import android.content.SharedPreferences;
 import android.database.DataSetObserver;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -26,9 +25,11 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewAnimationUtils;
+import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.PopupWindow;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
@@ -97,6 +98,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      * Utility for automatically hiding the keyboard when scrolling down
      */
     private KeyboardScrollHider hider;
+
+    /**
+     * The ViewGroup that wraps the buttons at the right hand side of the searchEditText
+     */
+    public RelativeLayout rightHandSideButtonsWrapper;
     /**
      * Menu button
      */
@@ -114,10 +120,20 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      * Progress bar displayed when loading
      */
     private View loaderSpinner;
+
+    /**
+     * The ViewGroup that wraps the buttons at the left hand side of the searchEditText
+     */
+    public ViewGroup leftHandSideButtonsWrapper;
     /**
      * Launcher button, can be clicked to display all apps
      */
     public View launcherButton;
+
+    /**
+     * Launcher button's white counterpart, which appears when launcher button is clicked
+     */
+    public View whiteLauncherButton;
     /**
      * "X" button to empty the search field
      */
@@ -202,10 +218,13 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.listContainer = (View) this.list.getParent();
         this.emptyListView = this.findViewById(android.R.id.empty);
         this.kissBar = findViewById(R.id.mainKissbar);
+        this.rightHandSideButtonsWrapper = findViewById(R.id.rightHandSideButtonsWrapper);
         this.menuButton = findViewById(R.id.menuButton);
         this.searchEditText = findViewById(R.id.searchEditText);
         this.loaderSpinner = findViewById(R.id.loaderBar);
+        this.leftHandSideButtonsWrapper = findViewById(R.id.leftHandSideButtonsWrapper);
         this.launcherButton = findViewById(R.id.launcherButton);
+        this.whiteLauncherButton = findViewById(R.id.whiteLauncherButton);
         this.clearButton = findViewById(R.id.clearButton);
 
         /*
@@ -606,8 +625,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     private void displayKissBar(boolean display, boolean clearSearchText) {
         dismissPopup();
         // get the center for the clipping circle
-        int cx = (launcherButton.getLeft() + launcherButton.getRight()) / 2;
-        int cy = (launcherButton.getTop() + launcherButton.getBottom()) / 2;
+        ViewGroup launcherButtonWrapper = (ViewGroup) launcherButton.getParent();
+        int cx = (launcherButtonWrapper.getLeft() + launcherButtonWrapper.getRight()) / 2;
+        int cy = (launcherButtonWrapper.getTop() + launcherButtonWrapper.getBottom()) / 2;
 
         // get the final radius for the clipping circle
         int finalRadius = Math.max(kissBar.getWidth(), kissBar.getHeight());

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -41,7 +41,7 @@ public class SettingsActivity extends PreferenceActivity implements
     private static final int PERMISSION_READ_PHONE_STATE = 1;
 
     // Those settings require the app to restart
-    final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites pref-rounded-list pref-rounded-bars pref-hide-circle history-hide enable-favorites-bar notification-bar-color black-notification-icons";
+    final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide enable-favorites-bar notification-bar-color black-notification-icons";
     final static private String settingsRequiringRestartForSettingsActivity = "theme force-portrait require-settings-update";
     private boolean requireFullRestart = false;
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -6,12 +6,18 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Build;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.UIColors;
+import fr.neamar.kiss.utils.ViewGroupUtils;
 
 // Deals with any settings in the "User Interface" setting sub-screen
 class InterfaceTweaks extends Forwarder {
@@ -45,6 +51,7 @@ class InterfaceTweaks extends Forwarder {
     void onCreate() {
         UIColors.updateThemePrimaryColor(mainActivity);
         applyRoundedCorners(mainActivity);
+        swapKissButtonWithMenu(mainActivity);
         tintResources(mainActivity);
 
         // Transparent Search and Favorites bar
@@ -128,6 +135,22 @@ class InterfaceTweaks extends Forwarder {
                 } else {
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_dark);
                 }
+            }
+        }
+    }
+
+    private void swapKissButtonWithMenu(MainActivity mainActivity) {
+        if (prefs.getBoolean("pref-swap-kiss-button-with-menu", false)) {
+            List<View> leftHandSideViews = ViewGroupUtils.removeAndGetDirectChildren(mainActivity.rightHandSideButtonsWrapper);
+            List<View> rightHandSideViews = ViewGroupUtils.removeAndGetDirectChildren(mainActivity.leftHandSideButtonsWrapper);
+            ViewGroupUtils.addAllViews(mainActivity.rightHandSideButtonsWrapper, rightHandSideViews);
+            ViewGroupUtils.addAllViews(mainActivity.leftHandSideButtonsWrapper, leftHandSideViews);
+            RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mainActivity.whiteLauncherButton.getLayoutParams();
+            layoutParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT, 1);
+            layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT, 0);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                layoutParams.addRule(RelativeLayout.ALIGN_PARENT_END, 1);
+                layoutParams.addRule(RelativeLayout.ALIGN_PARENT_START, 0);
             }
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/utils/ViewGroupUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ViewGroupUtils.java
@@ -1,0 +1,26 @@
+package fr.neamar.kiss.utils;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ViewGroupUtils {
+
+    public static List<View> removeAndGetDirectChildren(ViewGroup viewGroup) {
+        List<View> result = new ArrayList<>();
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            result.add(viewGroup.getChildAt(i));
+        }
+        viewGroup.removeAllViews();
+        return result;
+    }
+
+    public static void addAllViews(ViewGroup viewGroup, List<View> views) {
+        for (View view : views) {
+            viewGroup.addView(view);
+        }
+    }
+
+}

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -88,43 +88,48 @@
         android:elevation="2dp"
         tools:ignore="UnusedAttribute">
 
-        <ImageView
-            android:id="@+id/launcherButton"
+        <RelativeLayout
+            android:id="@+id/leftHandSideButtonsWrapper"
             android:layout_width="@dimen/launcher_button_width"
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:background="?attr/appSelectableItemBackground"
-            android:contentDescription="@string/main_kiss"
-            android:focusable="true"
-            android:onClick="onLauncherButtonClicked"
             android:paddingLeft="@dimen/launcher_button_padding"
             android:paddingRight="@dimen/launcher_button_padding"
-            android:src="@drawable/ic_launcher"
-            android:tag="showMenu" />
+            android:layout_centerVertical="true">
 
-        <ProgressBar
-            android:id="@+id/loaderBar"
-            android:layout_width="@dimen/launcher_button_width"
-            android:layout_height="match_parent"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:indeterminate="true"
-            android:paddingLeft="@dimen/launcher_button_padding"
-            android:paddingRight="@dimen/launcher_button_padding"
-            android:visibility="invisible" />
+
+            <ImageView
+                android:id="@+id/launcherButton"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/appSelectableItemBackground"
+                android:contentDescription="@string/main_kiss"
+                android:focusable="true"
+                android:onClick="onLauncherButtonClicked"
+                android:src="@drawable/ic_launcher"
+                android:tag="showMenu" />
+
+            <ProgressBar
+                android:id="@+id/loaderBar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:indeterminate="true"
+                android:paddingLeft="@dimen/launcher_button_padding"
+                android:paddingRight="@dimen/launcher_button_padding"
+                android:visibility="invisible" />
+
+        </RelativeLayout>
 
         <fr.neamar.kiss.ui.SearchEditText
             android:id="@+id/searchEditText"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_centerVertical="true"
-            android:layout_toStartOf="@+id/clearButton"
-            android:layout_toLeftOf="@+id/clearButton"
-            android:layout_toEndOf="@+id/launcherButton"
-            android:layout_toRightOf="@+id/launcherButton"
+            android:layout_toStartOf="@+id/rightHandSideButtonsWrapper"
+            android:layout_toLeftOf="@+id/rightHandSideButtonsWrapper"
+            android:layout_toEndOf="@+id/leftHandSideButtonsWrapper"
+            android:layout_toRightOf="@+id/leftHandSideButtonsWrapper"
             android:layout_margin="1dp"
             android:background="?attr/searchBackgroundColor"
             android:hint="@string/ui_search_hint"
@@ -137,38 +142,41 @@
             android:textCursorDrawable="@null"
             android:textSize="16sp" />
 
-        <ImageView
-            android:id="@+id/menuButton"
+        <RelativeLayout
+            android:id="@+id/rightHandSideButtonsWrapper"
             android:layout_width="@dimen/launcher_button_width"
             android:layout_height="match_parent"
             android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
-            android:background="?attr/appSelectableItemBackground"
-            android:contentDescription="@string/main_menu"
-            android:focusable="true"
-            android:onClick="onMenuButtonClicked"
             android:paddingLeft="@dimen/launcher_button_padding"
             android:paddingRight="@dimen/launcher_button_padding"
-            android:src="@drawable/dots"
-            android:tint="?attr/searchColor" />
+            >
 
-        <ImageView
-            android:id="@+id/clearButton"
-            android:layout_width="@dimen/launcher_button_width"
-            android:layout_height="match_parent"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:background="?attr/appSelectableItemBackground"
-            android:contentDescription="@string/main_clear"
-            android:focusable="true"
-            android:onClick="onClearButtonClicked"
-            android:paddingLeft="@dimen/launcher_button_padding"
-            android:paddingRight="@dimen/launcher_button_padding"
-            android:src="@drawable/clear_dark"
-            android:tint="?attr/searchColor"
-            android:visibility="visible" />
+            <ImageView
+                android:id="@+id/menuButton"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/appSelectableItemBackground"
+                android:contentDescription="@string/main_menu"
+                android:focusable="true"
+                android:onClick="onMenuButtonClicked"
+                android:src="@drawable/dots"
+                android:tint="?attr/searchColor" />
+
+            <ImageView
+                android:id="@+id/clearButton"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="?attr/appSelectableItemBackground"
+                android:contentDescription="@string/main_clear"
+                android:focusable="true"
+                android:onClick="onClearButtonClicked"
+                android:src="@drawable/clear_dark"
+                android:tint="?attr/searchColor"
+                android:visibility="visible" />
+        </RelativeLayout>
+
     </RelativeLayout>
 
     <ScrollView

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -88,15 +88,15 @@
         android:elevation="2dp"
         tools:ignore="UnusedAttribute">
 
-        <RelativeLayout
+        <FrameLayout
             android:id="@+id/leftHandSideButtonsWrapper"
             android:layout_width="@dimen/launcher_button_width"
             android:layout_height="match_parent"
-            android:layout_alignParentStart="true"
             android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
             android:paddingLeft="@dimen/launcher_button_padding"
-            android:paddingRight="@dimen/launcher_button_padding"
-            android:layout_centerVertical="true">
+            android:paddingRight="@dimen/launcher_button_padding">
 
 
             <ImageView
@@ -119,7 +119,7 @@
                 android:paddingRight="@dimen/launcher_button_padding"
                 android:visibility="invisible" />
 
-        </RelativeLayout>
+        </FrameLayout>
 
         <fr.neamar.kiss.ui.SearchEditText
             android:id="@+id/searchEditText"
@@ -142,7 +142,7 @@
             android:textCursorDrawable="@null"
             android:textSize="16sp" />
 
-        <RelativeLayout
+        <FrameLayout
             android:id="@+id/rightHandSideButtonsWrapper"
             android:layout_width="@dimen/launcher_button_width"
             android:layout_height="match_parent"
@@ -150,8 +150,7 @@
             android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
             android:paddingLeft="@dimen/launcher_button_padding"
-            android:paddingRight="@dimen/launcher_button_padding"
-            >
+            android:paddingRight="@dimen/launcher_button_padding">
 
             <ImageView
                 android:id="@+id/menuButton"
@@ -175,7 +174,7 @@
                 android:src="@drawable/clear_dark"
                 android:tint="?attr/searchColor"
                 android:visibility="visible" />
-        </RelativeLayout>
+        </FrameLayout>
 
     </RelativeLayout>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -182,6 +182,7 @@
     <string name="large_search_bar">Większy pasek wyszukiwania</string>
     <string name="rounded_list">Zaokrąglone rogi listy</string>
     <string name="rounded_bars">Zaokrąglone rogi paska</string>
+    <string name="swap_kiss_button_with_menu">Logo KISS po prawej stronie</string>
     <string name="menu_widget_add">(beta) Dodaj widżet</string>
     <string name="menu_widget_remove">Usuń widżet</string>
     <string name="rate_the_app">Oceń aplikację</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 
-    <string name="app_name">KISS launcher DEV</string>
+    <string name="app_name">KISS launcher</string>
     <string name="activity_setting">KISS settings</string>
     <string name="ui_search_hint">Search apps, contacts, …</string>
     <string name="ui_item_search">Search %1$s for “%2$s”</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 
-    <string name="app_name">KISS launcher</string>
+    <string name="app_name">KISS launcher DEV</string>
     <string name="activity_setting">KISS settings</string>
     <string name="ui_search_hint">Search apps, contacts, …</string>
     <string name="ui_item_search">Search %1$s for “%2$s”</string>
@@ -201,6 +201,7 @@
     <string name="large_search_bar">Bigger search bar</string>
     <string name="rounded_list">Rounded list corners</string>
     <string name="rounded_bars">Rounded bar corners</string>
+    <string name="swap_kiss_button_with_menu">KISS button on the right</string>
     <!-- Widget strings, preference ID should not be translated -->
     <string name="menu_widget_add">(beta) Add widget</string>
     <string name="menu_widget_remove">Remove widget</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -130,6 +130,10 @@
                 android:defaultValue="true"
                 android:key="pref-rounded-bars"
                 android:title="@string/rounded_bars" />
+            <fr.neamar.kiss.SwitchPreference
+                android:defaultValue="false"
+                android:key="pref-swap-kiss-button-with-menu"
+                android:title="@string/swap_kiss_button_with_menu" />
         </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen


### PR DESCRIPTION
Resolves #1161 

**Before**
![Before](https://user-images.githubusercontent.com/1756419/55670320-2b2f7000-5883-11e9-971a-9c6d30db7a62.png)

**Settings**
![Settings](https://user-images.githubusercontent.com/1756419/55670322-3bdfe600-5883-11e9-86ed-f589c4340a73.png)

**After**
![After](https://user-images.githubusercontent.com/1756419/55670327-56b25a80-5883-11e9-84a9-fa4dabd67403.png)

Since each side of the bar has two buttons, I've decided to wrap them in RelativeLayouts and exchange their children based on settings. Since the white KISS button is in a different view I've treated it separately.
