### PR TITLE
Add an option to disable gestures

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -91,13 +91,16 @@ class ExperienceTweaks extends Forwarder {
             public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
                 float directionY = e2.getY() - e1.getY();
                 float directionX = e2.getX() - e1.getX();
-                if ( Math.abs(directionX) > Math.abs(directionY) )
+                if (Math.abs(directionX) > Math.abs(directionY)) {
                     return false;
-                if(directionY > 0) {
+                }
+                if (!isGesturesEnabled()) {
+                    return false;
+                }
+                if (directionY > 0) {
                     // Fling down: display notifications
                     displayNotificationDrawer();
-                }
-                else {
+                } else {
                     // Fling up: display keyboard
                     mainActivity.showKeyboard();
                 }
@@ -211,11 +214,10 @@ class ExperienceTweaks extends Forwarder {
             Method showStatusBar;
             if (Build.VERSION.SDK_INT >= 17) {
                 showStatusBar = statusbarManager.getMethod("expandNotificationsPanel");
-            }
-            else {
+            } else {
                 showStatusBar = statusbarManager.getMethod("expand");
             }
-            showStatusBar.invoke( sbservice );
+            showStatusBar.invoke(sbservice);
         } catch (ClassNotFoundException e1) {
             e1.printStackTrace();
         } catch (NoSuchMethodException e1) {
@@ -250,4 +252,9 @@ class ExperienceTweaks extends Forwarder {
     private boolean isKeyboardOnStartEnabled() {
         return prefs.getBoolean("display-keyboard", false);
     }
+
+    private boolean isGesturesEnabled() {
+        return prefs.getBoolean("enable-gestures", true);
+    }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,4 +236,6 @@
     <string name="pref_show_untagged">Show untagged action</string>
 
     <string name="unable_to_initialize_shortcuts">Unable to initialize shortcuts. Is KISS your default launcher?</string>
+    <string name="enable_gestures">Enable gestures on empty areas</string>
+    <string name="enable_gestures_desc">(up for keyboard, down for notifications)</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -188,6 +188,11 @@
                 android:key="icons-hide"
                 android:summary="@string/icons_hide_desc"
                 android:title="@string/icons_hide_main" />
+            <fr.neamar.kiss.SwitchPreference
+                android:defaultValue="true"
+                android:key="enable-gestures"
+                android:summary="@string/enable_gestures_desc"
+                android:title="@string/enable_gestures" />
         </PreferenceCategory>
         <PreferenceScreen
             android:key="wallpaper-holder"

--- a/docs/_posts/2018-03-25-gestures.md
+++ b/docs/_posts/2018-03-25-gestures.md
@@ -27,3 +27,6 @@ Note that in this mode, a third gesture can be supported if you enable `⋮, KIS
 If you're not using minimalistic, gestures are still supported but are harder to access, as you need to swipe up or down on the very thin margin between the list and the side of your screen (red rectangles):
 
 ![Gestures on non-minimalistic mode in KISS](/screenshots/gestures-non-minimalistic.png)
+
+## Disable gestures
+If, for any reason, you don't like the gestures, you can disable them from `⋮, KISS Settings, Misc, Enable gestures`.


### PR DESCRIPTION
(based on feedback from #1009)

This is pretty straightforward: whenever it is unchecked, the up and down gestures will stop working.