### PR TITLE
Fix backbutton

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,7 +99,12 @@
         <activity
             android:name=".SettingsActivity"
             android:label="@string/activity_setting"
-            android:theme="@style/SettingTheme" />
+            android:theme="@style/SettingTheme"
+            android:parentActivityName=".MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
         <activity
             android:name=".kustomsupport.AutoFinishTransparentActivity"
             android:theme="@style/Theme.Transparent" />

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -47,7 +47,6 @@ public class SettingsActivity extends PreferenceActivity implements
 
     private SharedPreferences prefs;
 
-    @SuppressWarnings("deprecation")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         prefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -154,7 +153,6 @@ public class SettingsActivity extends PreferenceActivity implements
         return excludedAppList.isEmpty();
     }
 
-    @SuppressWarnings("deprecation")
     private void addExcludedAppSettings(final SharedPreferences prefs) {
         final MultiSelectListPreference multiPreference = new MultiSelectListPreference(this);
         multiPreference.setTitle(R.string.ui_excluded_apps);
@@ -192,7 +190,6 @@ public class SettingsActivity extends PreferenceActivity implements
         }
     }
 
-    @SuppressWarnings("deprecation")
     private void addExcludedFromHistoryAppSettings(final SharedPreferences prefs) {
         final MultiSelectListPreference multiPreference = new MultiSelectListPreference(this);
         multiPreference.setTitle(R.string.ui_excluded_from_history_apps);
@@ -404,7 +401,6 @@ public class SettingsActivity extends PreferenceActivity implements
         }
     }
 
-    @SuppressWarnings("deprecation")
     private void fixSummaries() {
         int historyLength = KissApplication.getApplication(this).getDataHandler().getHistoryLength();
         if (historyLength > 5) {

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -58,6 +58,8 @@
     </style>
 
     <style name="SettingTheme" parent="AppThemeLight">
+        <item name="android:actionBarStyle">@style/SettingsActionBar</item>
+
         <item name="android:windowActionBar">true</item>
         <item name="android:windowNoTitle">false</item>
         <item name="android:windowBackground">@color/kiss_background</item>
@@ -65,6 +67,10 @@
         <item name="android:colorPrimaryDark">@color/kiss_green</item>
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+
+    <style name="SettingsActionBar" parent="@android:style/Widget.Material.Light.ActionBar.Solid">
+        <item name="android:displayOptions">homeAsUp|showTitle</item>
     </style>
 
     <style name="SettingThemeDark" parent="AppThemeDark">


### PR DESCRIPTION
This adds back buttons for each ```PreferenceScreen``` in ```SettingsActivity``` for API >= 21, and back button for only the root ```PreferenceScreen``` for older versions:
<img width="250px" src="https://user-images.githubusercontent.com/10991116/57586981-2a1dde00-74d4-11e9-9f26-6b5e2747985c.png"/> <img width="250px" src="https://user-images.githubusercontent.com/10991116/57586980-2a1dde00-74d4-11e9-924b-c18d04c303fe.png"/>

<img width="250px" src="https://user-images.githubusercontent.com/10991116/57586950-d0b5af00-74d3-11e9-9baa-69730898f2a0.png"/> <img width="250px" src="https://user-images.githubusercontent.com/10991116/57586949-d0b5af00-74d3-11e9-8c53-cb7af7a6b627.png"/>

Fixes #1178.

----
<a class="imgpatreon" href="https://www.patreon.com/emmanuelmess" target="_blank">
<img alt="Become a patreon" src="https://user-images.githubusercontent.com/10991116/56376378-07065400-61de-11e9-9583-8ff2148aa41c.png" width=150px></a>