### PR TITLE
make loaderBar the same size as launcherButton

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -115,8 +115,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:indeterminate="true"
-                android:paddingLeft="@dimen/launcher_button_padding"
-                android:paddingRight="@dimen/launcher_button_padding"
                 android:visibility="invisible" />
 
         </FrameLayout>


### PR DESCRIPTION
The loading circle is too small, even invisible, because of the padding. I think it was an error added by the swapping feature and the wrappers.