### PR TITLE
Fix back button missing for dark themes

### DIFF
--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -69,15 +69,17 @@
         <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
-    <style name="SettingsActionBar" parent="@android:style/Widget.Material.Light.ActionBar.Solid">
-        <item name="android:displayOptions">homeAsUp|showTitle</item>
-    </style>
-
     <style name="SettingThemeDark" parent="AppThemeDark">
+        <item name="android:actionBarStyle">@style/SettingsActionBar</item>
+
         <item name="android:windowActionBar">true</item>
         <item name="android:windowNoTitle">false</item>
         <item name="android:windowBackground">@color/kiss_list_background_inverse</item>
         <item name="android:colorPrimaryDark">@color/kiss_green</item>
         <item name="android:navigationBarColor">@android:color/black</item>
+    </style>
+
+    <style name="SettingsActionBar" parent="@android:style/Widget.Material.Light.ActionBar.Solid">
+        <item name="android:displayOptions">homeAsUp|showTitle</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixes no back button for dark themes:

![Screenshot_1558279383](https://user-images.githubusercontent.com/10991116/57984302-e9bce380-7a30-11e9-9de9-66ff40216e3a.png)

----
<a class="imgpatreon" href="https://www.patreon.com/emmanuelmess" target="_blank">
<img alt="Become a patreon" src="https://user-images.githubusercontent.com/10991116/56376378-07065400-61de-11e9-9583-8ff2148aa41c.png" width=150px></a>