### PR TITLE
Ensure calendar icon is not changed when a custom icon pack is used

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -86,7 +86,7 @@ public class IconsHandler {
      *
      * @param packageName Android package ID of the package to parse
      */
-    public void loadIconsPack(String packageName) {
+    void loadIconsPack(String packageName) {
 
         //clear icons pack
         iconsPackPackageName = packageName;
@@ -174,7 +174,6 @@ public class IconsHandler {
     private Bitmap loadBitmap(String drawableName) {
         int id = iconPackres.getIdentifier(drawableName, "drawable", iconsPackPackageName);
         if (id > 0) {
-            //noinspection deprecation: Resources.getDrawable(int, Theme) requires SDK 21+
             Drawable bitmap = iconPackres.getDrawable(id);
             if (bitmap instanceof BitmapDrawable) {
                 return ((BitmapDrawable) bitmap).getBitmap();
@@ -214,10 +213,9 @@ public class IconsHandler {
         if (drawable != null) { //there is a custom icon
             int id = iconPackres.getIdentifier(drawable, "drawable", iconsPackPackageName);
             if (id > 0) {
-                //noinspection deprecation: Resources.getDrawable(int, Theme) requires SDK 21+
                 try {
                     return iconPackres.getDrawable(id);
-                } catch(Resources.NotFoundException e) {
+                } catch (Resources.NotFoundException e) {
                     // Unable to load icon, keep going.
                     e.printStackTrace();
                 }
@@ -309,7 +307,7 @@ public class IconsHandler {
         }
     }
 
-    public HashMap<String, String> getIconsPacks() {
+    HashMap<String, String> getIconsPacks() {
         return iconsPacks;
     }
 

--- a/app/src/main/java/fr/neamar/kiss/ui/GoogleCalendarIcon.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/GoogleCalendarIcon.java
@@ -2,11 +2,13 @@ package fr.neamar.kiss.ui;
 
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 
 import androidx.annotation.Nullable;
 
@@ -22,6 +24,14 @@ public class GoogleCalendarIcon {
 
     @Nullable
     public static Drawable getDrawable(Context context, String activityName) {
+        // Do nothing if using a custom icon pack
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String currentIconPack = prefs.getString("icons-pack", "default");
+        if (!"default".equals(currentIconPack)) {
+            return null;
+        }
+
+        // Otherwise, retrieve today's icon
         PackageManager pm = context.getPackageManager();
         try {
             ComponentName cn = new ComponentName(GOOGLE_CALENDAR, activityName);


### PR DESCRIPTION
The new system that displays today's icon for the calendar #1183  should be disabled when a custom icon pack is used, otherwise it leads to ugly results.

![Screenshot_20190523-125943](https://user-images.githubusercontent.com/536844/58408256-b9e39080-806d-11e9-80e3-ae553d98fc69.jpg)
