### PR TITLE
For excluding apps from KISS converted dialog to ScreenPreference

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -529,7 +529,7 @@ public class DataHandler extends BroadcastReceiver
      * @return pojos for all applications
      */
     @Nullable
-    public List<Pojo> getApplications() {
+    public List<AppPojo> getApplications() {
         AppProvider appProvider = getAppProvider();
         return appProvider != null ? appProvider.getAllApps() : null;
     }

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -494,6 +494,14 @@ public class DataHandler extends BroadcastReceiver
         PreferenceManager.getDefaultSharedPreferences(context).edit().putStringSet("excluded-apps", excluded).apply();
     }
 
+    public void removeFromExcluded(AppPojo app) {
+        // The set needs to be cloned and then edited,
+        // modifying in place is not supported by putStringSet()
+        Set<String> excluded = new HashSet<>(getExcluded());
+        excluded.remove(app.getComponentName());
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putStringSet("excluded-apps", excluded).apply();
+    }
+
     public void removeFromExcluded(String packageName) {
         Set<String> excluded = getExcluded();
         Set<String> newExcluded = new HashSet<String>();
@@ -523,15 +531,26 @@ public class DataHandler extends BroadcastReceiver
         PreferenceManager.getDefaultSharedPreferences(context).edit().putStringSet("excluded-apps", newExcluded).apply();
     }
 
+	/**
+	 * Return all applications (including excluded)
+	 *
+	 * @return pojos for all applications
+	 */
+	@Nullable
+	public List<AppPojo> getApplications() {
+		AppProvider appProvider = getAppProvider();
+		return appProvider != null ? appProvider.getAllApps() : null;
+	}
+
     /**
      * Return all applications
      *
      * @return pojos for all applications
      */
     @Nullable
-    public List<AppPojo> getApplications() {
+    public List<AppPojo> getApplicationsNoExcluded() {
         AppProvider appProvider = getAppProvider();
-        return appProvider != null ? appProvider.getAllApps() : null;
+        return appProvider != null ? appProvider.getAllAppsNoExcluded() : null;
     }
 
     @Nullable

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -54,6 +54,7 @@ public class SettingsActivity extends PreferenceActivity implements
     final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide enable-favorites-bar notification-bar-color black-notification-icons";
     final static private String settingsRequiringRestartForSettingsActivity = "theme force-portrait require-settings-update";
     private boolean requireFullRestart = false;
+    private boolean requireReloadApps = false;
 
     private SharedPreferences prefs;
 
@@ -239,6 +240,8 @@ public class SettingsActivity extends PreferenceActivity implements
                 } else {
                     dataHandler.removeFromExcluded(app);
                 }
+
+                requireReloadApps = true;
 
                 return true;
             }
@@ -436,6 +439,9 @@ public class SettingsActivity extends PreferenceActivity implements
         // Flag this, so that MainActivity get the information onResume().
         if (requireFullRestart) {
             prefs.edit().putBoolean("require-layout-update", true).apply();
+        }
+        if(requireReloadApps) {
+            KissApplication.getApplication(this).getDataHandler().getAppProvider().reload();
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -36,6 +36,7 @@ import fr.neamar.kiss.broadcast.IncomingCallHandler;
 import fr.neamar.kiss.dataprovider.AppProvider;
 import fr.neamar.kiss.dataprovider.SearchProvider;
 import fr.neamar.kiss.forwarder.TagsMenu;
+import fr.neamar.kiss.preference.SwitchPreference;
 import fr.neamar.kiss.searcher.QuerySearcher;
 import fr.neamar.kiss.utils.PackageManagerUtils;
 

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss;
 
 import android.Manifest;
+import android.app.ActionBar;
 import android.app.Dialog;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -223,7 +224,10 @@ public class SettingsActivity extends PreferenceActivity implements
         final SwitchPreference switchPreference = new SwitchPreference(this);
         switchPreference.setIcon(icon);
         switchPreference.setTitle(appName);
-        switchPreference.setSummary(mainActivityName);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                || getResources().getConfiguration().screenWidthDp > 420) {
+            switchPreference.setSummary(mainActivityName);
+        }
         switchPreference.setChecked(isExcluded);
         switchPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -196,6 +196,18 @@ public class AppProvider extends Provider<AppPojo> {
         return records;
     }
 
+    public ArrayList<AppPojo> getAllAppsNoExcluded() {
+        ArrayList<AppPojo> records = new ArrayList<>(pojos.size());
+
+        for (AppPojo pojo : pojos) {
+            if(pojo.excluded) continue;
+
+            pojo.relevance = 0;
+            records.add(pojo);
+        }
+        return records;
+    }
+
     public void removeApp(AppPojo appPojo) {
         pojos.remove(appPojo);
     }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -186,8 +186,8 @@ public class AppProvider extends Provider<AppPojo> {
         return null;
     }
 
-    public ArrayList<Pojo> getAllApps() {
-        ArrayList<Pojo> records = new ArrayList<>(pojos.size());
+    public ArrayList<AppPojo> getAllApps() {
+        ArrayList<AppPojo> records = new ArrayList<>(pojos.size());
 
         for (AppPojo pojo : pojos) {
             pojo.relevance = 0;

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -53,15 +53,16 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 
                     String id = user.addUserSuffixToString(pojoScheme + appInfo.packageName + "/" + activityInfo.getName(), '/');
 
-                    AppPojo app = new AppPojo(id, appInfo.packageName, activityInfo.getName(), user);
+                    boolean isExcluded = excludedAppList.contains(AppPojo.getComponentName(appInfo.packageName, activityInfo.getName(), user));
+
+                    AppPojo app = new AppPojo(id, appInfo.packageName, activityInfo.getName(), user,
+                            isExcluded);
 
                     app.setName(activityInfo.getLabel().toString());
 
                     app.setTags(tagsHandler.getTags(app.id));
 
-                    if (!excludedAppList.contains(app.getComponentName())) {
-                        apps.add(app);
-                    }
+                    apps.add(app);
                 }
             }
         } else {
@@ -73,14 +74,18 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
             for (ResolveInfo info : manager.queryIntentActivities(mainIntent, 0)) {
                 ApplicationInfo appInfo = info.activityInfo.applicationInfo;
                 String id = pojoScheme + appInfo.packageName + "/" + info.activityInfo.name;
-                AppPojo app = new AppPojo(id, appInfo.packageName, info.activityInfo.name, new UserHandle());
+                boolean isExcluded = excludedAppList.contains(
+                        AppPojo.getComponentName(appInfo.packageName, info.activityInfo.name, new UserHandle())
+                );
+
+                AppPojo app = new AppPojo(id, appInfo.packageName, info.activityInfo.name, new UserHandle(),
+                        isExcluded);
 
                 app.setName(info.loadLabel(manager).toString());
 
                 app.setTags(tagsHandler.getTags(app.id));
-                if (!excludedAppList.contains(app.getComponentName())) {
-                    apps.add(app);
-                }
+
+                apps.add(app);
             }
         }
 

--- a/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
@@ -3,19 +3,27 @@ package fr.neamar.kiss.pojo;
 import fr.neamar.kiss.utils.UserHandle;
 
 public class AppPojo extends PojoWithTags {
+    public static String getComponentName(String packageName, String activityName,
+                                          UserHandle userHandle) {
+        return userHandle.addUserSuffixToString(packageName + "/" + activityName, '#');
+    }
+
     public final String packageName;
     public final String activityName;
     public final UserHandle userHandle;
+    public final boolean excluded;
 
-    public AppPojo(String id, String packageName, String activityName, UserHandle userHandle) {
+    public AppPojo(String id, String packageName, String activityName, UserHandle userHandle,
+                   boolean isExcluded) {
         super(id);
 
         this.packageName = packageName;
         this.activityName = activityName;
         this.userHandle = userHandle;
+        this.excluded = isExcluded;
     }
 
     public String getComponentName() {
-        return userHandle.addUserSuffixToString(packageName + "/" + activityName, '#');
+        return getComponentName(packageName, activityName, userHandle);
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/preference/PreferenceScreenHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/PreferenceScreenHelper.java
@@ -1,0 +1,44 @@
+package fr.neamar.kiss.preference;
+
+import android.app.ActionBar;
+import android.app.Dialog;
+import android.os.Build;
+import android.preference.PreferenceScreen;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toolbar;
+
+import java.util.ArrayDeque;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+public final class PreferenceScreenHelper {
+	@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+	public static @Nullable Toolbar findToolbar(PreferenceScreen preference) {
+		final Dialog dialog = preference.getDialog();
+		ViewGroup root = (ViewGroup) dialog.getWindow().getDecorView();
+
+		ArrayDeque<ViewGroup> viewGroups = new ArrayDeque<>();
+		viewGroups.push(root);
+
+		while (!viewGroups.isEmpty()) {
+			ViewGroup e = viewGroups.removeFirst();
+
+			for (int i = 0; i < e.getChildCount(); i++) {
+				View child = e.getChildAt(i);
+
+				if (child instanceof Toolbar) {//Only in LOLIPOP or higher you're going to find a Toolbar
+					return (Toolbar) child;
+				}
+
+				if (child instanceof ViewGroup) {
+					viewGroups.addFirst((ViewGroup) child);
+				}
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/app/src/main/java/fr/neamar/kiss/preference/SwitchPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/SwitchPreference.java
@@ -1,4 +1,4 @@
-package fr.neamar.kiss;
+package fr.neamar.kiss.preference;
 
 import android.content.Context;
 import android.util.AttributeSet;

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -8,6 +8,7 @@ import java.util.PriorityQueue;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
+import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoComparator;
 
@@ -36,7 +37,7 @@ public class ApplicationsSearcher extends Searcher {
         if (activity == null)
             return null;
 
-        List<Pojo> pojos = KissApplication.getApplication(activity).getDataHandler().getApplications();
+        List<AppPojo> pojos = KissApplication.getApplication(activity).getDataHandler().getApplications();
         if (pojos != null)
            this.addResult(pojos.toArray(new Pojo[0]));
         return null;

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -37,7 +37,7 @@ public class ApplicationsSearcher extends Searcher {
         if (activity == null)
             return null;
 
-        List<AppPojo> pojos = KissApplication.getApplication(activity).getDataHandler().getApplications();
+        List<AppPojo> pojos = KissApplication.getApplication(activity).getDataHandler().getApplicationsNoExcluded();
         if (pojos != null)
            this.addResult(pojos.toArray(new Pojo[0]));
         return null;

--- a/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
@@ -21,7 +21,7 @@ public class UntaggedSearcher extends Searcher {
         MainActivity activity = activityWeakReference.get();
         if ( activity == null )
             return null;
-        List<AppPojo> results = KissApplication.getApplication(activity).getDataHandler().getApplications();
+        List<AppPojo> results = KissApplication.getApplication(activity).getDataHandler().getApplicationsNoExcluded();
         if (results == null)
             return null;
         for(Iterator<AppPojo> iterator = results.iterator(); iterator.hasNext(); ) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
+import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoWithTags;
 
@@ -20,10 +21,10 @@ public class UntaggedSearcher extends Searcher {
         MainActivity activity = activityWeakReference.get();
         if ( activity == null )
             return null;
-        List<Pojo> results = KissApplication.getApplication(activity).getDataHandler().getApplications();
+        List<AppPojo> results = KissApplication.getApplication(activity).getDataHandler().getApplications();
         if (results == null)
             return null;
-        for(Iterator<Pojo> iterator = results.iterator(); iterator.hasNext(); ) {
+        for(Iterator<AppPojo> iterator = results.iterator(); iterator.hasNext(); ) {
             Pojo pojo = iterator.next();
             if (!(pojo instanceof PojoWithTags)) {
                 iterator.remove();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="settings_excluded_apps">Excluded apps</string>
     <string name="ui_excluded_apps">View or edit apps excluded from KISS</string>
     <string name="ui_excluded_from_history_apps">View or edit apps excluded from history</string>
-    <string name="ui_excluded_apps_dialog_title">Deselect the apps you would like to include</string>
+    <string name="ui_excluded_apps_dialog_title">Select apps to exclude</string>
     <string name="ui_excluded_apps_not_found">No apps have been excluded</string>
     <string name="reset_warn">Do you really want to reset your history?</string>
     <string name="reset_favorites_name">Reset your list of favorites</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,7 +25,7 @@
             android:order="46"
             android:summary="@string/history_mode_desc"
             android:title="@string/history_mode_name" />
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="false"
             android:key="sort-history"
             android:order="47"
@@ -40,11 +40,11 @@
         <PreferenceCategory
             android:order="50"
             android:title="@string/alternate_history_inputs">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="enable-phone-history"
                 android:title="@string/enable_phone" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="enable-app-history"
                 android:title="@string/enable_app" />
@@ -74,13 +74,13 @@
             android:dialogMessage="@string/reset_favorites_warn"
             android:key="reset"
             android:title="@string/reset_favorites_name" />
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="true"
             android:key="enable-favorites-bar"
             android:summaryOff="@string/enable_favorites_bar_summary_off"
             android:summaryOn="@string/enable_favorites_bar_summary_on"
             android:title="@string/enable_favorites_bar" />
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="false"
             android:key="exclude-favorites"
             android:title="@string/exclude_favorites" />
@@ -106,31 +106,31 @@
             <fr.neamar.kiss.preference.ColorPreference
                 android:key="primary-color"
                 android:title="@string/main_color" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:key="black-notification-icons"
                 android:title="@string/black_notification_icons" />
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/misc">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:key="transparent-search"
                 android:title="@string/transparent_search_bar" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="transparent-favorites"
                 android:title="@string/transparent_favorites_bar" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="large-search-bar"
                 android:title="@string/large_search_bar" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-rounded-list"
                 android:title="@string/rounded_list" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="pref-rounded-bars"
                 android:title="@string/rounded_bars" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-swap-kiss-button-with-menu"
                 android:title="@string/swap_kiss_button_with_menu" />
@@ -141,66 +141,66 @@
         android:summary="@string/user_experience_summary"
         android:title="@string/title_ux">
         <PreferenceCategory android:title="@string/keyboard_options">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="display-keyboard"
                 android:title="@string/keyboard_name" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="enable-suggestions-keyboard"
                 android:title="@string/keyboard_suggestions" />
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/history_hide_name" android:key="history-hide-section">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="history-hide"
                 android:summary="@string/history_hide_desc"
                 android:title="@string/history_hide_name" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:dependency="history-hide"
                 android:key="history-onclick"
                 android:title="@string/history_onclick_name" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:dependency="history-hide"
                 android:key="favorites-hide"
                 android:title="@string/favorites_hide" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-hide-navbar"
                 android:summary="@string/pref_hide_navbar_desc"
                 android:title="@string/pref_hide_navbar" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-hide-statusbar"
                 android:summary="@string/pref_hide_statusbar_desc"
                 android:title="@string/pref_hide_statusbar" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-hide-circle"
                 android:summary="@string/pref_hide_circle_desc"
                 android:title="@string/pref_hide_circle" />
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/misc">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="force-portrait"
                 android:title="@string/portrait_title" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="tags-visible"
                 android:title="@string/tags_visible" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="icons-hide"
                 android:summary="@string/icons_hide_desc"
                 android:title="@string/icons_hide_main" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="call-contact-on-click"
                 android:title="@string/contacts_call_on_click" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="enable-gestures"
                 android:summary="@string/enable_gestures_desc"
@@ -209,27 +209,27 @@
         <PreferenceScreen
             android:key="wallpaper-holder"
             android:title="@string/title_wallpaper">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="lwp-touch"
                 android:title="@string/lwp_touch" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="lwp-drag"
                 android:summary="@string/lwp_drag_desc"
                 android:title="@string/lwp_drag" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="wp-drag-animate"
                 android:summary="@string/wp_drag_animate_desc"
                 android:title="@string/wp_drag_animate" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:dependency="wp-drag-animate"
                 android:key="wp-animate-center"
                 android:summary="@string/wp_animate_center_desc"
                 android:title="@string/wp_animate_center" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:dependency="wp-drag-animate"
                 android:key="wp-animate-sides"
@@ -237,15 +237,15 @@
                 android:title="@string/wp_animate_sides" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/screen_toggle_tags">
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-tags-menu"
                 android:title="@string/pref_tags_menu" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-show-untagged"
                 android:title="@string/pref_show_untagged" />
-            <fr.neamar.kiss.SwitchPreference
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="pref-tags-menu-dismiss"
                 android:title="@string/pref_tags_menu_dismiss" />
@@ -261,19 +261,19 @@
         android:key="providers"
         android:summary="@string/providers_summary"
         android:title="@string/title_providers">
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="true"
             android:key="enable-contacts"
             android:title="@string/contacts_name" />
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="true"
             android:key="enable-settings"
             android:title="@string/settings_name" />
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="true"
             android:key="enable-shortcuts"
             android:title="@string/shortcuts_name" />
-        <fr.neamar.kiss.SwitchPreference
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="true"
             android:key="enable-search"
             android:title="@string/search_name" />


### PR DESCRIPTION
The current problem is that on older Android versions the Switch widget is too big,  and it would make each item PreferenceSwitch too tall if it had the sumary.

<img width="250px" src="https://user-images.githubusercontent.com/10991116/58494543-b45c7800-814b-11e9-84ac-5fe4d3accdd3.png"/> <img width="250px" src="https://user-images.githubusercontent.com/10991116/58494542-b3c3e180-814b-11e9-9683-a9c3689152fb.png"/>
<img width="250px" src="https://user-images.githubusercontent.com/10991116/58496081-7c573400-814f-11e9-92e6-e28c102389a3.png"/>


Fixes #1132.
----
<a class="imgpatreon" href="https://www.patreon.com/emmanuelmess" target="_blank">
<img alt="Become a patreon" src="https://user-images.githubusercontent.com/10991116/56376378-07065400-61de-11e9-9583-8ff2148aa41c.png" width=150px></a>
