### PR TITLE
Ignore low priority notifications

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
+++ b/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
@@ -38,7 +38,7 @@ public class NotificationListener extends NotificationListenerService {
         StatusBarNotification[] sbns = getActiveNotifications();
         Map<String, Set<String>> notificationsByPackage = new HashMap<>();
         for (StatusBarNotification sbn : sbns) {
-            if(notificationIsTrivial(sbn.getNotification())) {
+            if(isNotificationTrivial(sbn.getNotification())) {
                 continue;
             }
 
@@ -87,7 +87,7 @@ public class NotificationListener extends NotificationListenerService {
 
     @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
-        if(notificationIsTrivial(sbn.getNotification())) {
+        if(isNotificationTrivial(sbn.getNotification())) {
             return;
         }
 
@@ -101,7 +101,7 @@ public class NotificationListener extends NotificationListenerService {
 
     @Override
     public void onNotificationRemoved(StatusBarNotification sbn) {
-        if(notificationIsTrivial(sbn.getNotification())) {
+        if(isNotificationTrivial(sbn.getNotification())) {
             return;
         }
 
@@ -133,7 +133,7 @@ public class NotificationListener extends NotificationListenerService {
     }
 
     // Low priority notifications should not be displayed
-    public boolean notificationIsTrivial(Notification notification) {
+    public boolean isNotificationTrivial(Notification notification) {
         return notification.priority <= Notification.PRIORITY_MIN;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
+++ b/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.notification;
 
+import android.app.Notification;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -37,6 +38,10 @@ public class NotificationListener extends NotificationListenerService {
         StatusBarNotification[] sbns = getActiveNotifications();
         Map<String, Set<String>> notificationsByPackage = new HashMap<>();
         for (StatusBarNotification sbn : sbns) {
+            if(notificationIsTrivial(sbn.getNotification())) {
+                continue;
+            }
+
             String packageName = sbn.getPackageName();
             if (!notificationsByPackage.containsKey(packageName)) {
                 notificationsByPackage.put(packageName, new HashSet<String>());
@@ -82,6 +87,10 @@ public class NotificationListener extends NotificationListenerService {
 
     @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
+        if(notificationIsTrivial(sbn.getNotification())) {
+            return;
+        }
+
         Set<String> currentNotifications = getCurrentNotificationsForPackage(sbn.getPackageName());
 
         currentNotifications.add(Integer.toString(sbn.getId()));
@@ -92,6 +101,10 @@ public class NotificationListener extends NotificationListenerService {
 
     @Override
     public void onNotificationRemoved(StatusBarNotification sbn) {
+        if(notificationIsTrivial(sbn.getNotification())) {
+            return;
+        }
+
         Set<String> currentNotifications = getCurrentNotificationsForPackage(sbn.getPackageName());
 
         currentNotifications.remove(Integer.toString(sbn.getId()));
@@ -117,5 +130,10 @@ public class NotificationListener extends NotificationListenerService {
             // see https://developer.android.com/reference/android/content/SharedPreferences.html#getStringSet(java.lang.String,%2520java.util.Set%3Cjava.lang.String%3E)
             return new HashSet<>(currentNotifications);
         }
+    }
+
+    // Low priority notifications should not be displayed
+    public boolean notificationIsTrivial(Notification notification) {
+        return notification.priority <= Notification.PRIORITY_MIN;
     }
 }


### PR DESCRIPTION
Potential fix for #1206

Low priority notifications are ignored.
I had to use a deprecated field to get this to work. Newer SDKs use `NotificationChannel`, but this is not available to KISS without asking for more permission.

Luckily, most apps use the support library and `NotificationCompat`, ensuring the deprecated field is still filled.