### PR TITLE
Calculator: shunting yard, added exponentiation and parentheses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,9 @@ jobs:
           path: app/build/reports
           destination: reports
       - run:
+          name: Run unit tests
+          command: ./gradlew testDebugUnitTest
+      - run:
           name: Generate debug APK
           command: ./gradlew assembleDebug assembleDebugAndroidTest
       - store_artifacts:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
 }
 
 dependencies {
@@ -38,6 +42,10 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.2.0'
 
     implementation 'androidx.annotation:annotation:1.0.2'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
+    testImplementation 'org.hamcrest:hamcrest-library:2.1'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
     errorprone ("com.google.errorprone:error_prone_core:2.3.3")

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
@@ -1,10 +1,15 @@
 package fr.neamar.kiss.dataprovider.simpleprovider;
 
+import java.math.BigDecimal;
+import java.util.ArrayDeque;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import fr.neamar.kiss.pojo.SearchPojo;
 import fr.neamar.kiss.searcher.Searcher;
+import fr.neamar.kiss.utils.calculator.Calculator;
+import fr.neamar.kiss.utils.calculator.ShuntingYard;
+import fr.neamar.kiss.utils.calculator.Tokenizer;
 
 public class CalculatorProvider extends SimpleProvider {
     private Pattern p;
@@ -18,56 +23,17 @@ public class CalculatorProvider extends SimpleProvider {
         // Now create matcher object.
         Matcher m = p.matcher(query);
         if (m.find()) {
-            String operator = m.group(3);
+            String operation = m.group();
 
-            // let's go for floating point arithmetic
-            // we need to add a "0" on top of it to support ".2" => 0.2
-            // For every other case, this doesn't change the number "01" => 1
-            float lhs = Float.parseFloat("0" + m.group(2));
-            lhs = m.group(1).equals("-") ? -lhs : lhs;
-            float rhs = Float.parseFloat("0" + m.group(5));
-            rhs = m.group(4).equals("-") ? -rhs : rhs;
+            ArrayDeque<Tokenizer.Token> tokenized = Tokenizer.tokenize(operation);
+            ArrayDeque<Tokenizer.Token> posfixed = ShuntingYard.infixToPostfix(tokenized);
+            BigDecimal result = Calculator.calculateExpression(posfixed);
 
-            float floatResult = 0;
-            switch (operator) {
-                case "+":
-                    floatResult = lhs + rhs;
-                    break;
-                case "-":
-                    floatResult = lhs - rhs;
-                    break;
-                case "*":
-                case "×":
-                case "x":
-                    floatResult = lhs * rhs;
-                    operator = "×";
-                    break;
-                case "/":
-                case "÷":
-                    floatResult = lhs / rhs;
-                    operator = "÷";
-                    break;
-                default:
-                    floatResult = Float.POSITIVE_INFINITY;
-            }
-
-            String queryProcessed = floatToString(lhs) + " " + operator + " "
-                    + floatToString(rhs) + " = " + floatToString(floatResult);
+            String queryProcessed = operation + " = " + result.toPlainString();
             SearchPojo pojo = new SearchPojo("calculator://", queryProcessed, "", SearchPojo.CALCULATOR_QUERY);
 
             pojo.relevance = 100;
             searcher.addResult(pojo);
-        }
-    }
-
-    private String floatToString(float f) {
-        // If f is an int, we don't want to display 9.0: cast to int
-        if (f == Math.round(f)) {
-            return Integer.toString(Math.round(f));
-        } else {
-            // otherwise, keep it as float, knowing that some floating-point issues can happen
-            // (try for instance 0.3 - 0.2)
-            return Float.toString(f);
         }
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 import fr.neamar.kiss.pojo.SearchPojo;
 import fr.neamar.kiss.searcher.Searcher;
 import fr.neamar.kiss.utils.calculator.Calculator;
+import fr.neamar.kiss.utils.calculator.Result;
 import fr.neamar.kiss.utils.calculator.ShuntingYard;
 import fr.neamar.kiss.utils.calculator.Tokenizer;
 
@@ -15,21 +16,40 @@ public class CalculatorProvider extends SimpleProvider {
     private Pattern p;
 
     public CalculatorProvider() {
-        p = Pattern.compile("^(-?)([0-9.]+)\\s?([+\\-*/×x÷^])\\s?(-?)([0-9.]+)$");
+        //This should try to match as much as possible without going out of the expression,
+        //even if the expression is not actually a computable operation.
+        p = Pattern.compile("\\(*[+\\-]?\\d*\\.?\\d+[()\\d.+\\-*/^]*\\d*\\.?\\d+\\)*");
     }
 
     @Override
     public void requestResults(String query, Searcher searcher) {
         // Now create matcher object.
-        Matcher m = p.matcher(query);
+        Matcher m = p.matcher(query.trim());
         if (m.find()) {
             String operation = m.group();
 
             ArrayDeque<Tokenizer.Token> tokenized = Tokenizer.tokenize(operation);
-            ArrayDeque<Tokenizer.Token> posfixed = ShuntingYard.infixToPostfix(tokenized);
-            BigDecimal result = Calculator.calculateExpression(posfixed);
+            Result<ArrayDeque<Tokenizer.Token>> posfixed = ShuntingYard.infixToPostfix(tokenized);
 
-            String queryProcessed = operation + " = " + result.toPlainString();
+            String readableResult;
+
+            if(posfixed.syntacticalError) {
+                return;
+            } else if(posfixed.arithmeticalError) {
+                readableResult = "ARITHMETIC ERROR";
+            } else {
+                Result<BigDecimal> result = Calculator.calculateExpression(posfixed.result);
+
+                if(result.syntacticalError) {
+                    return;
+                } else if(result.arithmeticalError) {
+                    readableResult = "ARITHMETIC ERROR";
+                } else {
+                    readableResult = " = " + result.result.toPlainString();
+                }
+            }
+
+            String queryProcessed = operation + readableResult;
             SearchPojo pojo = new SearchPojo("calculator://", queryProcessed, "", SearchPojo.CALCULATOR_QUERY);
 
             pojo.relevance = 100;

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
@@ -15,7 +15,7 @@ public class CalculatorProvider extends SimpleProvider {
     private Pattern p;
 
     public CalculatorProvider() {
-        p = Pattern.compile("^(-?)([0-9.]+)\\s?([+\\-*/×x÷])\\s?(-?)([0-9.]+)$");
+        p = Pattern.compile("^(-?)([0-9.]+)\\s?([+\\-*/×x÷^])\\s?(-?)([0-9.]+)$");
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
@@ -5,6 +5,7 @@ import java.util.ArrayDeque;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.annotation.VisibleForTesting;
 import fr.neamar.kiss.pojo.SearchPojo;
 import fr.neamar.kiss.searcher.Searcher;
 import fr.neamar.kiss.utils.calculator.Calculator;
@@ -13,7 +14,8 @@ import fr.neamar.kiss.utils.calculator.ShuntingYard;
 import fr.neamar.kiss.utils.calculator.Tokenizer;
 
 public class CalculatorProvider extends SimpleProvider {
-    private Pattern p;
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    Pattern p;
 
     public CalculatorProvider() {
         //This should try to match as much as possible without going out of the expression,

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
@@ -1,6 +1,9 @@
 package fr.neamar.kiss.utils.calculator;
 
+import android.os.Build;
+
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 
@@ -76,7 +79,7 @@ public class Calculator {
 
 					operand2 = stack.pop();
 					operand1 = stack.pop();
-					stack.push(operand1.divide(operand2));
+					stack.push(operand1.divide(operand2, MathContext.DECIMAL32));
 					break;
 				case Tokenizer.Token.EXP_TOKEN:
 					if (errorInExpression(false, stack)) {
@@ -85,7 +88,15 @@ public class Calculator {
 
 					operand2 = stack.pop();
 					operand1 = stack.pop();
-					stack.push(new BigDecimal(StrictMath.pow(operand1.doubleValue(), operand2.doubleValue())));
+
+					double pow = StrictMath.pow(operand1.doubleValue(), operand2.doubleValue());
+
+					if(!isFinite(pow)) {
+						throw new ArithmeticException("Not finite result: "
+								+ operand1.toString() + "^" + operand2.toString() + " = " + pow);
+					}
+
+					stack.push(new BigDecimal(pow));
 					break;
 			}
 		}
@@ -105,5 +116,22 @@ public class Calculator {
 			error = error || stack.size() < 2;
 		}
 		return error;
+	}
+
+	/**
+	 * Returns {@code true} if the argument is a finite floating-point
+	 * value; returns {@code false} otherwise (for NaN and infinity
+	 * arguments).
+	 *
+	 * @param d the {@code double} value to be tested
+	 * @return {@code true} if the argument is a finite
+	 * floating-point value, {@code false} otherwise.
+	 */
+	public static boolean isFinite(double d) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+		    return Double.isFinite(d);
+		} else {
+			return Math.abs(d) <= Double.MAX_VALUE;
+		}
 	}
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
@@ -1,0 +1,55 @@
+package fr.neamar.kiss.utils.calculator;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayDeque;
+import java.util.Iterator;
+
+public class Calculator {
+	public static BigDecimal calculateExpression(ArrayDeque<Tokenizer.Token> expression) throws ArithmeticException {
+		ArrayDeque<BigDecimal> stack = new ArrayDeque<>();
+		Iterator<Tokenizer.Token> iterator = expression.descendingIterator();
+
+
+		while (iterator.hasNext()) {
+			Tokenizer.Token token = iterator.next();
+
+			BigDecimal operand2 = null;
+			BigDecimal operand1 = null;
+
+			switch (token.type) {
+				case Tokenizer.Token.NUMBER_TOKEN:
+					stack.push(token.number);
+					break;
+
+				case Tokenizer.Token.SUM_TOKEN:
+					operand2 = stack.pop();
+					operand1 = stack.pop();
+					stack.push(operand1.add(operand2));
+					break;
+				case Tokenizer.Token.SUBTRACT_TOKEN:
+					operand2 = stack.pop();
+					operand1 = stack.pop();
+					stack.push(operand1.subtract(operand2));
+					break;
+				case Tokenizer.Token.MULTIPLY_TOKEN:
+					operand2 = stack.pop();
+					operand1 = stack.pop();
+					stack.push(operand1.multiply(operand2));
+					break;
+				case Tokenizer.Token.DIVIDE_TOKEN:
+					operand2 = stack.pop();
+					operand1 = stack.pop();
+					stack.push(operand1.divide(operand2));
+					break;
+				case Tokenizer.Token.EXP_TOKEN:
+					operand2 = stack.pop();
+					operand1 = stack.pop();
+					stack.push(operand1.pow(operand2.intValueExact()));
+					break;
+			}
+		}
+
+		return stack.pop();
+	}
+}

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
@@ -17,12 +17,8 @@ public class Calculator {
 	private static Result<BigDecimal> calculateExpressionThrowing(ArrayDeque<Tokenizer.Token> expression)
 			throws ArithmeticException {
 		ArrayDeque<BigDecimal> stack = new ArrayDeque<>();
-		Iterator<Tokenizer.Token> iterator = expression.descendingIterator();
 
-
-		while (iterator.hasNext()) {
-			Tokenizer.Token token = iterator.next();
-
+		for (Tokenizer.Token token : expression) {
 			BigDecimal operand2 = null;
 			BigDecimal operand1 = null;
 
@@ -32,14 +28,14 @@ public class Calculator {
 					break;
 
 				case Tokenizer.Token.UNARY_PLUS_TOKEN:
-					if(errorInExpression(true, stack)) {
+					if (errorInExpression(true, stack)) {
 						return Result.syntacticalError();
 					}
 
 					//redundant: stack.push(stack.pop());
 					break;
 				case Tokenizer.Token.UNARY_MINUS_TOKEN:
-					if(errorInExpression(true, stack)) {
+					if (errorInExpression(true, stack)) {
 						return Result.syntacticalError();
 					}
 
@@ -47,7 +43,7 @@ public class Calculator {
 					break;
 
 				case Tokenizer.Token.SUM_TOKEN:
-					if(errorInExpression(false, stack)) {
+					if (errorInExpression(false, stack)) {
 						return Result.syntacticalError();
 					}
 
@@ -56,7 +52,7 @@ public class Calculator {
 					stack.push(operand1.add(operand2));
 					break;
 				case Tokenizer.Token.SUBTRACT_TOKEN:
-					if(errorInExpression(false, stack)) {
+					if (errorInExpression(false, stack)) {
 						return Result.syntacticalError();
 					}
 
@@ -65,7 +61,7 @@ public class Calculator {
 					stack.push(operand1.subtract(operand2));
 					break;
 				case Tokenizer.Token.MULTIPLY_TOKEN:
-					if(errorInExpression(false, stack)) {
+					if (errorInExpression(false, stack)) {
 						return Result.syntacticalError();
 					}
 
@@ -74,7 +70,7 @@ public class Calculator {
 					stack.push(operand1.multiply(operand2));
 					break;
 				case Tokenizer.Token.DIVIDE_TOKEN:
-					if(errorInExpression(false, stack)) {
+					if (errorInExpression(false, stack)) {
 						return Result.syntacticalError();
 					}
 
@@ -83,7 +79,7 @@ public class Calculator {
 					stack.push(operand1.divide(operand2));
 					break;
 				case Tokenizer.Token.EXP_TOKEN:
-					if(errorInExpression(false, stack)) {
+					if (errorInExpression(false, stack)) {
 						return Result.syntacticalError();
 					}
 

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
@@ -52,7 +52,7 @@ public class Calculator {
 				case Tokenizer.Token.EXP_TOKEN:
 					operand2 = stack.pop();
 					operand1 = stack.pop();
-					stack.push(operand1.pow(operand2.intValueExact()));
+					stack.push(new BigDecimal(StrictMath.pow(operand1.doubleValue(), operand2.doubleValue())));
 					break;
 			}
 		}

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
@@ -22,6 +22,13 @@ public class Calculator {
 					stack.push(token.number);
 					break;
 
+				case Tokenizer.Token.UNARY_PLUS_TOKEN:
+					//redundant: stack.push(stack.pop());
+					break;
+				case Tokenizer.Token.UNARY_MINUS_TOKEN:
+					stack.push(stack.pop().negate());
+					break;
+
 				case Tokenizer.Token.SUM_TOKEN:
 					operand2 = stack.pop();
 					operand1 = stack.pop();

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Calculator.java
@@ -1,12 +1,21 @@
 package fr.neamar.kiss.utils.calculator;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 
 public class Calculator {
-	public static BigDecimal calculateExpression(ArrayDeque<Tokenizer.Token> expression) throws ArithmeticException {
+
+	public static Result<BigDecimal> calculateExpression(ArrayDeque<Tokenizer.Token> expression) {
+		try {
+			return calculateExpressionThrowing(expression);
+		} catch (ArithmeticException e) {
+			return Result.arithmeticalError();
+		}
+	}
+
+	private static Result<BigDecimal> calculateExpressionThrowing(ArrayDeque<Tokenizer.Token> expression)
+			throws ArithmeticException {
 		ArrayDeque<BigDecimal> stack = new ArrayDeque<>();
 		Iterator<Tokenizer.Token> iterator = expression.descendingIterator();
 
@@ -23,33 +32,61 @@ public class Calculator {
 					break;
 
 				case Tokenizer.Token.UNARY_PLUS_TOKEN:
+					if(errorInExpression(true, stack)) {
+						return Result.syntacticalError();
+					}
+
 					//redundant: stack.push(stack.pop());
 					break;
 				case Tokenizer.Token.UNARY_MINUS_TOKEN:
+					if(errorInExpression(true, stack)) {
+						return Result.syntacticalError();
+					}
+
 					stack.push(stack.pop().negate());
 					break;
 
 				case Tokenizer.Token.SUM_TOKEN:
+					if(errorInExpression(false, stack)) {
+						return Result.syntacticalError();
+					}
+
 					operand2 = stack.pop();
 					operand1 = stack.pop();
 					stack.push(operand1.add(operand2));
 					break;
 				case Tokenizer.Token.SUBTRACT_TOKEN:
+					if(errorInExpression(false, stack)) {
+						return Result.syntacticalError();
+					}
+
 					operand2 = stack.pop();
 					operand1 = stack.pop();
 					stack.push(operand1.subtract(operand2));
 					break;
 				case Tokenizer.Token.MULTIPLY_TOKEN:
+					if(errorInExpression(false, stack)) {
+						return Result.syntacticalError();
+					}
+
 					operand2 = stack.pop();
 					operand1 = stack.pop();
 					stack.push(operand1.multiply(operand2));
 					break;
 				case Tokenizer.Token.DIVIDE_TOKEN:
+					if(errorInExpression(false, stack)) {
+						return Result.syntacticalError();
+					}
+
 					operand2 = stack.pop();
 					operand1 = stack.pop();
 					stack.push(operand1.divide(operand2));
 					break;
 				case Tokenizer.Token.EXP_TOKEN:
+					if(errorInExpression(false, stack)) {
+						return Result.syntacticalError();
+					}
+
 					operand2 = stack.pop();
 					operand1 = stack.pop();
 					stack.push(new BigDecimal(StrictMath.pow(operand1.doubleValue(), operand2.doubleValue())));
@@ -57,6 +94,20 @@ public class Calculator {
 			}
 		}
 
-		return stack.pop();
+		if(stack.size() != 1) {
+			return Result.syntacticalError();
+		}
+
+		return Result.result(stack.pop());
+	}
+
+	private static boolean errorInExpression(boolean isUnary, final ArrayDeque<BigDecimal> stack) {
+		boolean error = false;
+		if(isUnary) {
+			error = error || stack.size() < 1;
+		} else {
+			error = error || stack.size() < 2;
+		}
+		return error;
 	}
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Result.java
@@ -1,0 +1,33 @@
+package fr.neamar.kiss.utils.calculator;
+
+import androidx.annotation.NonNull;
+
+public final class Result<T> {
+	static <T> Result<T> syntacticalError() {
+		return new Result<>(true);
+	}
+
+	static <T> Result<T> arithmeticalError() {
+		return new Result<>(false);
+	}
+
+	static <T> Result<T> result(@NonNull T result) {
+		return new Result<>(result);
+	}
+
+
+	public final T result;
+	public final boolean syntacticalError;
+	public final boolean arithmeticalError;
+
+	private Result(boolean isSyntactical) {
+		this.syntacticalError = isSyntactical;
+		this.arithmeticalError = !isSyntactical;
+		this.result = null;
+	}
+
+	private Result(@NonNull T result) {
+		this.result = result;
+		this.syntacticalError = this.arithmeticalError = false;
+	}
+}

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/ShuntingYard.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/ShuntingYard.java
@@ -4,7 +4,7 @@ import java.util.ArrayDeque;
 
 public class ShuntingYard {
 
-	public static ArrayDeque<Tokenizer.Token> infixToPostfix(ArrayDeque<Tokenizer.Token> infix) {
+	public static Result<ArrayDeque<Tokenizer.Token>> infixToPostfix(ArrayDeque<Tokenizer.Token> infix) {
 		ArrayDeque<Tokenizer.Token> sb = new ArrayDeque<>();
 		ArrayDeque<Tokenizer.Token> s = new ArrayDeque<>();
 
@@ -14,6 +14,10 @@ public class ShuntingYard {
 					s.push(token);
 					break;
 				case Tokenizer.Token.PARENTHESIS_CLOSE_TOKEN:
+					if(s.isEmpty()) {
+						return Result.syntacticalError();
+					}
+
 					// until '(' on stack, pop operators.
 					while (s.peek().type != Tokenizer.Token.PARENTHESIS_OPEN_TOKEN) {
 						sb.addLast(s.pop());
@@ -44,7 +48,7 @@ public class ShuntingYard {
 			sb.addLast(s.pop());
 		}
 
-		return sb;
+		return Result.result(sb);
 	}
 
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/ShuntingYard.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/ShuntingYard.java
@@ -27,7 +27,7 @@ public class ShuntingYard {
 							int prec1 = token.getPrecedence();
 							int prec2 = operatorStack.peek().getPrecedence();
 
-							if (prec1 <= prec2) {
+							if ((token.isLeftAssociative() && prec1 <= prec2) || (token.isRightAssociative() && prec1 < prec2)) {
 								outQueue.add(operatorStack.pop());
 							} else {
 								break;
@@ -47,6 +47,10 @@ public class ShuntingYard {
 					// until '(' on stack, pop operators.
 					while (operatorStack.peek().type != Tokenizer.Token.PARENTHESIS_OPEN_TOKEN) {
 						outQueue.add(operatorStack.pop());
+
+						if(operatorStack.isEmpty()) {
+							return Result.syntacticalError();
+						}
 					}
 					operatorStack.pop();
 					break;

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/ShuntingYard.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/ShuntingYard.java
@@ -1,0 +1,50 @@
+package fr.neamar.kiss.utils.calculator;
+
+import java.util.ArrayDeque;
+
+public class ShuntingYard {
+
+	public static ArrayDeque<Tokenizer.Token> infixToPostfix(ArrayDeque<Tokenizer.Token> infix) {
+		ArrayDeque<Tokenizer.Token> sb = new ArrayDeque<>();
+		ArrayDeque<Tokenizer.Token> s = new ArrayDeque<>();
+
+		for (Tokenizer.Token token : infix) {
+			switch (token.type) {
+				case Tokenizer.Token.PARENTHESIS_OPEN_TOKEN:
+					s.push(token);
+					break;
+				case Tokenizer.Token.PARENTHESIS_CLOSE_TOKEN:
+					// until '(' on stack, pop operators.
+					while (s.peek().type != Tokenizer.Token.PARENTHESIS_OPEN_TOKEN) {
+						sb.addLast(s.pop());
+					}
+					s.pop();
+					break;
+				default:
+					if (s.isEmpty()) {
+						s.push(token);
+					} else {
+						while (!s.isEmpty()) {
+							int prec2 = s.peek().getPrecedence();
+							int prec1 = token.getPrecedence();
+
+							if (prec2 > prec1 || (prec2 == prec1 && token.type == Tokenizer.Token.EXP_TOKEN)) {
+								sb.addLast(s.pop());
+							} else {
+								break;
+							}
+						}
+						s.push(token);
+					}
+					break;
+			}
+		}
+
+		while (!s.isEmpty()) {
+			sb.addLast(s.pop());
+		}
+
+		return sb;
+	}
+
+}

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
@@ -1,0 +1,123 @@
+package fr.neamar.kiss.utils.calculator;
+
+import android.view.inputmethod.InputConnection;
+
+import java.math.BigDecimal;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Stack;
+
+import androidx.annotation.NonNull;
+
+public class Tokenizer {
+	public static final class Token {
+		public static final int SUM_TOKEN = 0;
+		public static final int SUBTRACT_TOKEN = 1;
+		public static final int MULTIPLY_TOKEN = 2;
+		public static final int DIVIDE_TOKEN = 3;
+		public static final int EXP_TOKEN = 4;
+
+		public static final int NUMBER_TOKEN = 16;
+		public static final int PARENTHESIS_OPEN_TOKEN = 17;
+		public static final int PARENTHESIS_CLOSE_TOKEN = 18;
+
+
+		public final int type;
+		public final BigDecimal number;
+
+		public Token(int type) {
+			if(type != SUM_TOKEN && type != SUBTRACT_TOKEN && type != MULTIPLY_TOKEN && type != DIVIDE_TOKEN) {
+				throw new IllegalArgumentException("Wrong constructor!");
+			}
+			this.type = type;
+			number = null;
+		}
+
+		public Token(@NonNull BigDecimal number) {
+			this.type = NUMBER_TOKEN;
+			this.number = number;
+		}
+
+		public Token(boolean isParenthesisOpen) {
+			this.type = isParenthesisOpen? PARENTHESIS_OPEN_TOKEN : PARENTHESIS_CLOSE_TOKEN;
+			this.number = null;
+		}
+
+		public final int getPrecedence() {
+			switch (type) {
+				case SUM_TOKEN:
+				case SUBTRACT_TOKEN:
+					return 0;
+				case MULTIPLY_TOKEN:
+				case DIVIDE_TOKEN:
+					return 1;
+				case EXP_TOKEN:
+					return 2;
+				default:
+					return -1;
+			}
+		}
+	}
+
+	public static final ArrayDeque<Token> tokenize(String expression) {
+		ArrayDeque<Token> tokens = new ArrayDeque<>();
+
+		for (int i = 0; i < expression.length(); i++) {
+			char operator = expression.charAt(i);
+
+			Token token = null;
+
+			switch (operator) {
+				case '+':
+					token = new Token(Token.SUM_TOKEN);
+					break;
+				case '-':
+					token = new Token(Token.SUBTRACT_TOKEN);
+					break;
+				case '*':
+				case '×':
+				case 'x':
+					token = new Token(Token.MULTIPLY_TOKEN);
+					break;
+				case '/':
+				case '÷':
+					token = new Token(Token.DIVIDE_TOKEN);
+					break;
+				case '(':
+					token = new Token(true);
+					break;
+				case ')':
+					token = new Token(false);
+					break;
+				default:
+					StringBuilder number = new StringBuilder();
+
+					if(Character.isDigit(operator) || operator == '.' || operator == ',') {
+						number.append(operator);
+
+						while (i+1 < expression.length()) {
+							operator = expression.charAt(i+1);
+							if(Character.isDigit(operator) || operator == '.' || operator == ',') {
+								number.append(operator);
+								i++;
+							} else {
+								break;
+							}
+						}
+					}
+
+					if(number.length() != 0) {
+						token = new Token(new BigDecimal(number.toString()));
+					}
+			}
+
+			if(token == null) {
+				continue;
+			}
+
+			tokens.addLast(token);
+		}
+
+		return tokens;
+	}
+}

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
@@ -30,6 +30,7 @@ public class Tokenizer {
 
 		public Token(int type) {
 			if(type != SUM_TOKEN && type != SUBTRACT_TOKEN && type != MULTIPLY_TOKEN && type != DIVIDE_TOKEN
+					&& type != EXP_TOKEN
 					&& type != UNARY_PLUS_TOKEN && type != UNARY_MINUS_TOKEN) {
 				throw new IllegalArgumentException("Wrong constructor!");
 			}
@@ -90,6 +91,13 @@ public class Tokenizer {
 					}
 					break;
 				case '*':
+					if(expression.charAt(i+1) != '*') {
+						token = new Token(Token.MULTIPLY_TOKEN);
+					} else {// '**'
+						i++;
+						token = new Token(Token.EXP_TOKEN);
+					}
+					break;
 				case '×':
 				case 'x':
 					token = new Token(Token.MULTIPLY_TOKEN);
@@ -98,6 +106,9 @@ public class Tokenizer {
 				case '÷':
 					token = new Token(Token.DIVIDE_TOKEN);
 					break;
+				case '^':
+					token = new Token(Token.EXP_TOKEN);
+					break;
 				case '(':
 					token = new Token(true);
 					break;
@@ -105,6 +116,7 @@ public class Tokenizer {
 					token = new Token(false);
 					break;
 				default:
+					//Numbers
 					StringBuilder number = new StringBuilder();
 
 					if(Character.isDigit(operator) || operator == '.' || operator == ',') {

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
@@ -17,6 +17,9 @@ public class Tokenizer {
 		public static final int DIVIDE_TOKEN = 3;
 		public static final int EXP_TOKEN = 4;
 
+		public static final int UNARY_PLUS_TOKEN = 8;
+		public static final int UNARY_MINUS_TOKEN = 9;
+
 		public static final int NUMBER_TOKEN = 16;
 		public static final int PARENTHESIS_OPEN_TOKEN = 17;
 		public static final int PARENTHESIS_CLOSE_TOKEN = 18;
@@ -26,7 +29,8 @@ public class Tokenizer {
 		public final BigDecimal number;
 
 		public Token(int type) {
-			if(type != SUM_TOKEN && type != SUBTRACT_TOKEN && type != MULTIPLY_TOKEN && type != DIVIDE_TOKEN) {
+			if(type != SUM_TOKEN && type != SUBTRACT_TOKEN && type != MULTIPLY_TOKEN && type != DIVIDE_TOKEN
+					&& type != UNARY_PLUS_TOKEN && type != UNARY_MINUS_TOKEN) {
 				throw new IllegalArgumentException("Wrong constructor!");
 			}
 			this.type = type;
@@ -45,21 +49,24 @@ public class Tokenizer {
 
 		public final int getPrecedence() {
 			switch (type) {
+				case UNARY_PLUS_TOKEN:
+				case UNARY_MINUS_TOKEN:
+					return 0;
 				case SUM_TOKEN:
 				case SUBTRACT_TOKEN:
-					return 0;
+					return 1;
 				case MULTIPLY_TOKEN:
 				case DIVIDE_TOKEN:
-					return 1;
-				case EXP_TOKEN:
 					return 2;
+				case EXP_TOKEN:
+					return 3;
 				default:
 					return -1;
 			}
 		}
 	}
 
-	public static final ArrayDeque<Token> tokenize(String expression) {
+	public static ArrayDeque<Token> tokenize(String expression) {
 		ArrayDeque<Token> tokens = new ArrayDeque<>();
 
 		for (int i = 0; i < expression.length(); i++) {
@@ -69,10 +76,18 @@ public class Tokenizer {
 
 			switch (operator) {
 				case '+':
-					token = new Token(Token.SUM_TOKEN);
+					if(tokens.isEmpty() || tokens.peekLast().type != Token.NUMBER_TOKEN) {
+						token = new Token(Token.UNARY_PLUS_TOKEN);
+					} else {
+						token = new Token(Token.SUM_TOKEN);
+					}
 					break;
 				case '-':
-					token = new Token(Token.SUBTRACT_TOKEN);
+					if(tokens.isEmpty() || tokens.peekLast().type != Token.NUMBER_TOKEN) {
+						token = new Token(Token.UNARY_MINUS_TOKEN);
+					} else {
+						token = new Token(Token.SUBTRACT_TOKEN);
+					}
 					break;
 				case '*':
 				case '×':

--- a/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/calculator/Tokenizer.java
@@ -52,7 +52,7 @@ public class Tokenizer {
 			switch (type) {
 				case UNARY_PLUS_TOKEN:
 				case UNARY_MINUS_TOKEN:
-					return 0;
+					return 3;
 				case SUM_TOKEN:
 				case SUBTRACT_TOKEN:
 					return 1;
@@ -60,7 +60,7 @@ public class Tokenizer {
 				case DIVIDE_TOKEN:
 					return 2;
 				case EXP_TOKEN:
-					return 3;
+					return 4;
 				default:
 					return -1;
 			}

--- a/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
+++ b/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
@@ -1,0 +1,47 @@
+package fr.neamar.kiss.dataprovider.simpleprovider;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CalculatorProviderTest {
+	private static final Pattern pattern = new CalculatorProvider().p;
+
+	@ParameterizedTest
+	@MethodSource("expressionProvider")
+	public void testOperations(String expression, String operation) {
+		Matcher matcher = pattern.matcher(expression.trim());
+		matcher.find();
+		assertThat(matcher.group(), is(operation));
+	}
+
+	private static Stream<Arguments> expressionProvider() {
+		return Stream.of(
+				Arguments.of("(1+1)", "(1+1)"),
+				Arguments.of("(1 + 1)", "(1+1)"),
+
+				Arguments.of("afsdfsds(1+1)dfsdfsd", "(1+1)"),
+				Arguments.of("aadf8-100fs", "8-100"),
+
+				Arguments.of("+1-1", "+1-1"),
+				Arguments.of("-1-1", "-1-1"),
+				Arguments.of("1*1", "1*1"),
+				Arguments.of("1/1", "1/1"),
+
+				Arguments.of("(1)/1", "(1)/1"),
+				Arguments.of("( 1 )/1", "(1)/1"),
+				Arguments.of("(1+1)/1", "(1+1)/1"),
+				Arguments.of("(1*1)/1", "(1*1)/1"),
+
+				Arguments.of("(1+1)/2.", "(1+1)/2."),
+				Arguments.of("89.*(1+1)/2.", "89.*(1+1)/2.")
+		);
+	}
+}

--- a/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
+++ b/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
@@ -12,12 +12,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class CalculatorProviderTest {
-	private static final Pattern pattern = new CalculatorProvider().p;
+	private static final Pattern pattern = new CalculatorProvider().P;
 
 	@ParameterizedTest
 	@MethodSource("expressionProvider")
 	public void testOperations(String expression, String operation) {
-		Matcher matcher = pattern.matcher(expression.trim());
+		Matcher matcher = pattern.matcher(expression.replaceAll("\\s+", ""));
 		matcher.find();
 		assertThat(matcher.group(), is(operation));
 	}
@@ -27,13 +27,11 @@ public class CalculatorProviderTest {
 				Arguments.of("(1+1)", "(1+1)"),
 				Arguments.of("(1 + 1)", "(1+1)"),
 
-				Arguments.of("afsdfsds(1+1)dfsdfsd", "(1+1)"),
-				Arguments.of("aadf8-100fs", "8-100"),
-
 				Arguments.of("+1-1", "+1-1"),
 				Arguments.of("-1-1", "-1-1"),
 				Arguments.of("1*1", "1*1"),
 				Arguments.of("1/1", "1/1"),
+				Arguments.of("1**1", "1**1"),
 
 				Arguments.of("(1)/1", "(1)/1"),
 				Arguments.of("( 1 )/1", "(1)/1"),
@@ -41,7 +39,9 @@ public class CalculatorProviderTest {
 				Arguments.of("(1*1)/1", "(1*1)/1"),
 
 				Arguments.of("(1+1)/2.", "(1+1)/2."),
-				Arguments.of("89.*(1+1)/2.", "89.*(1+1)/2.")
+				Arguments.of("89.*(1+1)/2.", "89.*(1+1)/2."),
+
+				Arguments.of("8,009.*(1+1)/2.", "8,009.*(1+1)/2.")
 		);
 	}
 }

--- a/app/src/test/java/fr/neamar/kiss/utils/calculator/CalculatorTest.java
+++ b/app/src/test/java/fr/neamar/kiss/utils/calculator/CalculatorTest.java
@@ -1,0 +1,93 @@
+package fr.neamar.kiss.utils.calculator;
+
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CalculatorTest {
+	@ParameterizedTest
+	@MethodSource("operationsProvider")
+	public void testOperations(String operation, BigDecimal result) {
+		assertThat(operate(operation).result, is(result));
+	}
+
+	private static Stream<Arguments> operationsProvider() {
+		return Stream.of(
+				Arguments.of("+1", new BigDecimal(1)),
+				Arguments.of("-1", new BigDecimal(-1)),
+				Arguments.of("--1", new BigDecimal(1)),
+
+				Arguments.of("--1.", new BigDecimal(1)),
+
+				Arguments.of("+1+1", new BigDecimal(2)),
+				Arguments.of("-1+1+1+1", new BigDecimal(2)),
+				Arguments.of("2+0", new BigDecimal(2)),
+				Arguments.of("0+2", new BigDecimal(2)),
+
+				Arguments.of("0+2.", new BigDecimal(2)),
+
+				Arguments.of("(1+1)", new BigDecimal(2)),
+				Arguments.of("(1)+1", new BigDecimal(2)),
+				Arguments.of("(--1)+1", new BigDecimal(2)),
+				Arguments.of("--1+1", new BigDecimal(2)),
+				Arguments.of("-(-1)+1", new BigDecimal(2)),
+				Arguments.of("(--1)+1", new BigDecimal(2)),
+
+				Arguments.of("(1+1.)", new BigDecimal(2)),
+
+				Arguments.of("2*2+1", new BigDecimal(5)),
+				Arguments.of("1+2*2", new BigDecimal(5)),
+				Arguments.of("(1+2)*2", new BigDecimal(6)),
+
+				Arguments.of("(1+2.)*2", new BigDecimal(6)),
+
+				Arguments.of("2/2/2", new BigDecimal(0.5)),
+				Arguments.of("2/1/1", new BigDecimal(2)),
+				Arguments.of("2/(1/2)", new BigDecimal(4)),
+
+				Arguments.of("2/2/2.", new BigDecimal(0.5)),
+				Arguments.of("2/(1./2)", new BigDecimal(4)),
+
+				Arguments.of("-2**2", new BigDecimal(-4)),
+				Arguments.of("(-2)**2", new BigDecimal(4)),
+				Arguments.of("1+1**2", new BigDecimal(2)),
+				Arguments.of("1+1^2", new BigDecimal(2)),
+
+				Arguments.of("1+1^2.", new BigDecimal(2)),
+
+				Arguments.of("(1/3)+(1/3)", new BigDecimal(2).divide(new BigDecimal(3), MathContext.DECIMAL32)),
+
+				Arguments.of("(1/10)", new BigDecimal(1).divide(new BigDecimal(10)))
+		);
+	}
+
+	private Result<BigDecimal> operate(String operation) {
+		ArrayDeque<Tokenizer.Token> tokenized = Tokenizer.tokenize(operation);
+		Result<ArrayDeque<Tokenizer.Token>> posfixed = ShuntingYard.infixToPostfix(tokenized);
+
+		if(posfixed.syntacticalError) {
+			return Result.syntacticalError();
+		} else if(posfixed.arithmeticalError) {
+			return Result.arithmeticalError();
+		} else {
+			return Calculator.calculateExpression(posfixed.result);
+		}
+	}
+}


### PR DESCRIPTION
The functionality is more or less the same as before but:

* Fixed underflow? (fixed `1 + 1.11111 = 1.1111112`)
* Added exponentiation (`-1^2 = -1` or `-1**2 = -1`)
* Added parentheses (`(1+1) = 2`)
* Added unary + (`+1*2 = 2`)

## Help needed
* To find operations that break this implementation, be it a crash or incorrect answer.
* To fix the current RegEx so that any expression can be found.
* To find expressions that every iteration of RegEx can't parse correctly (find false positives or false negatives).

Fixes #1217
Fixes point 3 of #1151
Fixed #1221

----
<a class="imgpatreon" href="https://www.patreon.com/emmanuelmess" target="_blank">
<img alt="Become a patreon" src="https://user-images.githubusercontent.com/10991116/56376378-07065400-61de-11e9-9583-8ff2148aa41c.png" width=150px></a>