### PR TITLE
use start.duckduckgo.com instead of duckduckgo.com

### DIFF
--- a/app/src/main/res/values-ro/arrays.xml
+++ b/app/src/main/res/values-ro/arrays.xml
@@ -16,7 +16,7 @@
     </string-array>
     <string-array name="defaultSearchProviders">
         <item>Bing|https://www.bing.com/search?q={q}</item>
-        <item>DuckDuckGo|https://duckduckgo.com/?q={q}</item>
+        <item>DuckDuckGo|https://start.duckduckgo.com/?q={q}</item>
         <item>Google|https://encrypted.google.com/search?q={q}</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -16,7 +16,7 @@
     </string-array>
     <string-array name="defaultSearchProviders" tools:ignore="InconsistentArrays">
         <item>Bing|https://www.bing.com/search?q=%s</item>
-        <item>DuckDuckGo|https://duckduckgo.com/?q=%s</item>
+        <item>DuckDuckGo|https://start.duckduckgo.com/?q=%s</item>
         <item>Google|https://encrypted.google.com/search?q=%s</item>
         <item>Википедия|https://ru.m.wikipedia.org/w/index.php?search=%s</item>
         <item>Яндекс|https://yandex.ru/touchsearch?text=%s</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,7 +30,7 @@
     </string-array>
     <string-array name="defaultSearchProviders" tools:ignore="InconsistentArrays">
         <item>Bing|https://www.bing.com/search?q=%s</item>
-        <item>DuckDuckGo|https://duckduckgo.com/?q=%s</item>
+        <item>DuckDuckGo|https://start.duckduckgo.com/?q=%s</item>
         <item>Google|https://encrypted.google.com/search?q=%s</item>
     </string-array>
     <string-array name="toggleTagsDefault">


### PR DESCRIPTION
Start.duckduckgo.com is suggested for users who clear their cookies
often as it doesn't suggest adding DDG to your browser. I think this may
decrease how much users of KISS + some cookie clearing browser will see
that prompt and I think the prompt isn't very useful to users who are
already using DDG by default through KISS.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
