### PR TITLE
Fix animations on launch

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -321,18 +321,20 @@ public class AppResult extends Result {
                 LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
                 assert launcher != null;
                 Rect sourceBounds = null;
-                Bundle opts =null;
+                Bundle opts = null;
 
                 if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     // We're on a modern Android and can display activity animations
                     // If AppResult, find the icon
                     View potentialIcon = v.findViewById(R.id.item_app_icon);
-                    if(potentialIcon == null) {
+                    if (potentialIcon == null) {
                         // If favorite, find the icon
                         potentialIcon = v.findViewById(R.id.favorite);
                     }
 
                     if (potentialIcon != null) {
+                        sourceBounds = getViewBounds(potentialIcon);
+
                         // If we got an icon, we create options to get a nice animation
                         opts = ActivityOptions.makeClipRevealAnimation(potentialIcon, 0, 0, potentialIcon.getMeasuredWidth(), potentialIcon.getMeasuredHeight()).toBundle();
                     }
@@ -346,7 +348,7 @@ public class AppResult extends Result {
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
 
                 if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                    intent.setSourceBounds(v.getClipBounds());
+                    intent.setSourceBounds(getViewBounds(v));
                 }
 
                 context.startActivity(intent);
@@ -356,5 +358,15 @@ public class AppResult extends Result {
             // (null pointer exception can be thrown on Lollipop+ when app is missing)
             Toast.makeText(context, R.string.application_not_found, Toast.LENGTH_LONG).show();
         }
+    }
+
+    private Rect getViewBounds(View v) {
+        if (v == null) {
+            return null;
+        }
+
+        int[] l = new int[2];
+        v.getLocationOnScreen(l);
+        return new Rect(l[0], l[1], l[0] + v.getWidth(), l[1] + v.getHeight());
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.result;
 
+import android.app.ActivityOptions;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
@@ -11,9 +12,11 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.view.Menu;
@@ -317,7 +320,25 @@ public class AppResult extends Result {
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 LauncherApps launcher = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
                 assert launcher != null;
-                launcher.startMainActivity(className, appPojo.userHandle.getRealHandle(), v.getClipBounds(), null);
+                Rect sourceBounds = null;
+                Bundle opts =null;
+
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    // We're on a modern Android and can display activity animations
+                    // If AppResult, find the icon
+                    View potentialIcon = v.findViewById(R.id.item_app_icon);
+                    if(potentialIcon == null) {
+                        // If favorite, find the icon
+                        potentialIcon = v.findViewById(R.id.favorite);
+                    }
+
+                    if (potentialIcon != null) {
+                        // If we got an icon, we create options to get a nice animation
+                        opts = ActivityOptions.makeClipRevealAnimation(potentialIcon, 0, 0, potentialIcon.getMeasuredWidth(), potentialIcon.getMeasuredHeight()).toBundle();
+                    }
+                }
+
+                launcher.startMainActivity(className, appPojo.userHandle.getRealHandle(), sourceBounds, opts);
             } else {
                 Intent intent = new Intent(Intent.ACTION_MAIN);
                 intent.addCategory(Intent.CATEGORY_LAUNCHER);


### PR DESCRIPTION
This Pull Request fixes the code that was supposed to display an animation on launch.

Right now, when you exit KISS, you get the default system animation -- an activity that eases in from the bottom of the screen.

This PR fixes the transition to instead start from the app icon.

Speed is the same in both cases, but the overall result seems more natural and more in line with what other launchers are doing.