### PR TITLE
Accessibility fix in favorites

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -71,6 +71,7 @@
         android:focusableInTouchMode="true"
         android:gravity="center_vertical"
         android:orientation="horizontal"
+        android:importantForAccessibility="no"
         tools:ignore="UnusedAttribute"
         tools:layout="@layout/favorite_item" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="stub_app_tag" translatable="false">Tag example</string>
     <string name="main_menu">Menu</string>
     <string name="main_clear">Clear search bar</string>
-    <string name="main_kiss">Display favorites and app list</string>
+    <string name="main_kiss">Display app list</string>
     <string name="main_kiss_back">Display history</string>
     <string name="reset_name">Reset history</string>
     <string name="reset_excluded_apps_name">Reset list of apps excluded from KISS</string>


### PR DESCRIPTION
Talkback was only allowing the user to select 'all favorites'. Marking the layout as not important ensure individual items are available for description and touch.