### PR TITLE
Add more search providers to default set

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,8 +30,12 @@
     </string-array>
     <string-array name="defaultSearchProviders" tools:ignore="InconsistentArrays">
         <item>Bing|https://www.bing.com/search?q=%s</item>
+        <item>Ecosia|https://www.ecosia.org/search?q=%s</item>
         <item>DuckDuckGo|https://start.duckduckgo.com/?q=%s</item>
         <item>Google|https://encrypted.google.com/search?q=%s</item>
+        <item>Google Maps|https://www.google.com/maps/search/?api=1&amp;query=%s</item>
+        <item>Google Play Store|https://play.google.com/store/search?q=%s</item>
+        <item>YouTube|https://www.youtube.com/results?search_query=%s</item>
     </string-array>
     <string-array name="toggleTagsDefault">
     </string-array>


### PR DESCRIPTION
### Changes
Added the following new search engines to the default set:
- Google Maps
- Google Play Store
- YouTube
- Ecosia

When installed (which all except Ecosia typically are), these apps open automatically into the app's search results page, making for a very convenient search option.
I made sure that these providers have good web fallbacks should the apps not be installed. All of them work with HTTPS.
Also fixes #696 .

### Motivation
The idea is to make it easier for inexperienced users to choose from a wide range of search providers and to discover this feature.
I think that it is great that users can jump directly into apps' search results pages, and this PR makes it easier for newbies to experience that, without having to search for the relevant URL scheme which some may find difficult to find.
Also, I think there is no downside considering they can pick and choose to enable these providers or not.