### PR TITLE
Bugfixes for shortcuts (#1275)

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -457,7 +457,7 @@ public class DataHandler extends BroadcastReceiver
 
         for (ShortcutInfo shortcutInfo : shortcuts) {
             // Create Pojo
-            ShortcutsPojo pojo = ShortcutUtil.createShortcutPojo(context, shortcutInfo);
+            ShortcutsPojo pojo = ShortcutUtil.createShortcutPojo(context, shortcutInfo, true);
             if (pojo == null) {
                 continue;
             }

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -434,10 +434,8 @@ public class DataHandler extends BroadcastReceiver
             record.icon_blob = baos.toByteArray();
         }
 
-        DBHelper.insertShortcut(this.context, record);
-
-        Log.d(TAG, "Shortcut " + shortcut.id + " added.");
-        return true;
+        Log.d(TAG, "Shortcut " + shortcut.id);
+        return DBHelper.insertShortcut(this.context, record);
     }
 
     @TargetApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -478,7 +478,7 @@ public class DataHandler extends BroadcastReceiver
     public void removeShortcut(ShortcutsPojo shortcut) {
         // Also remove shortcut from favorites
         removeFromFavorites(shortcut.id);
-        DBHelper.removeShortcut(this.context, shortcut.intentUri);
+        DBHelper.removeShortcut(this.context, shortcut);
 
         if (this.getShortcutsProvider() != null) {
             this.getShortcutsProvider().reload();

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -203,8 +203,8 @@ public class DBHelper {
         SQLiteDatabase db = getDatabase(context);
 
         // Do not add duplicate shortcuts
-        Cursor cursor = db.query("shortcuts", new String[]{"intent_uri"},
-                "intent_uri = ?", new String[]{shortcut.intentUri}, null, null, null, null);
+        Cursor cursor = db.query("shortcuts", new String[]{"package", "intent_uri"},
+                "package = ? AND intent_uri = ?", new String[]{shortcut.packageName, shortcut.intentUri}, null, null, null, null);
         if (cursor.moveToFirst()) {
             return false;
         }
@@ -221,9 +221,9 @@ public class DBHelper {
         return true;
     }
 
-    public static void removeShortcut(Context context, String intentUri) {
+    public static void removeShortcut(Context context, ShortcutsPojo shortcut) {
         SQLiteDatabase db = getDatabase(context);
-        db.delete("shortcuts", "intent_uri = ?", new String[]{intentUri});
+        db.delete("shortcuts", "package = ? AND intent_uri = ?", new String[]{shortcut.packageName, shortcut.intentUri});
     }
 
     public static ArrayList<ShortcutRecord> getShortcuts(Context context, String packageName) {

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -199,8 +199,16 @@ public class DBHelper {
         return records;
     }
 
-    public static void insertShortcut(Context context, ShortcutRecord shortcut) {
+    public static boolean insertShortcut(Context context, ShortcutRecord shortcut) {
         SQLiteDatabase db = getDatabase(context);
+
+        // Do not add duplicate shortcuts
+        Cursor cursor = db.query("shortcuts", new String[]{"intent_uri"},
+                "intent_uri = ?", new String[]{shortcut.intentUri}, null, null, null, null);
+        if (cursor.moveToFirst()) {
+            return false;
+        }
+        cursor.close();
 
         ContentValues values = new ContentValues();
         values.put("name", shortcut.name);
@@ -209,7 +217,8 @@ public class DBHelper {
         values.put("intent_uri", shortcut.intentUri);
         values.put("icon_blob", shortcut.icon_blob);
 
-        db.insert("shortcuts", null, values);
+        db.insertWithOnConflict("shortcuts", null, values, SQLiteDatabase.CONFLICT_REPLACE);
+        return true;
     }
 
     public static void removeShortcut(Context context, String intentUri) {

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -217,7 +217,7 @@ public class DBHelper {
         values.put("intent_uri", shortcut.intentUri);
         values.put("icon_blob", shortcut.icon_blob);
 
-        db.insertWithOnConflict("shortcuts", null, values, SQLiteDatabase.CONFLICT_REPLACE);
+        db.insert("shortcuts", null, values);
         return true;
     }
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/OreoShortcuts.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/OreoShortcuts.java
@@ -18,7 +18,7 @@ public class OreoShortcuts extends Forwarder {
             // On first run save all shortcuts
             if (prefs.getBoolean("first-run-shortcuts", true)) {
                 // Save all shortcuts
-                ShortcutUtil.addShortcuts(mainActivity);
+                ShortcutUtil.addAllShortcuts(mainActivity);
                 // Set flag to false
                 prefs.edit().putBoolean("first-run-shortcuts", false).apply();
             }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/OreoShortcuts.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/OreoShortcuts.java
@@ -1,5 +1,8 @@
 package fr.neamar.kiss.forwarder;
 
+import android.content.Intent;
+import android.content.pm.LauncherApps;
+
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.utils.ShortcutUtil;
 
@@ -10,13 +13,26 @@ public class OreoShortcuts extends Forwarder {
 
     void onCreate() {
         // Shortcuts in Android O
-        if (prefs.getBoolean("first-run-shortcuts", true) &&
-                ShortcutUtil.areShortcutsEnabled(mainActivity)) {
+        if (ShortcutUtil.areShortcutsEnabled(mainActivity)) {
 
-            ShortcutUtil.rebuildShortcuts(mainActivity);
-            // Set flag to false
-            prefs.edit().putBoolean("first-run-shortcuts", false).apply();
+            // On first run save all shortcuts
+            if (prefs.getBoolean("first-run-shortcuts", true)) {
+                // Save all shortcuts
+                ShortcutUtil.addShortcuts(mainActivity);
+                // Set flag to false
+                prefs.edit().putBoolean("first-run-shortcuts", false).apply();
+            }
+
+            Intent intent = mainActivity.getIntent();
+            if (intent != null) {
+                final String action = intent.getAction();
+                if (LauncherApps.ACTION_CONFIRM_PIN_SHORTCUT.equals(action)) {
+                    // Save single shortcut via a pin request
+                    ShortcutUtil.addShortcut(mainActivity, intent);
+                }
+            }
         }
+
     }
 
 }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetShortcutsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetShortcutsPreference.java
@@ -22,7 +22,12 @@ public class ResetShortcutsPreference extends DialogPreference {
         if (which == DialogInterface.BUTTON_POSITIVE &&
                 android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 
-            ShortcutUtil.rebuildShortcuts(getContext());
+            // Remove all shortcuts
+            ShortcutUtil.removeAllShortcuts(getContext());
+
+            // Build all shortcuts
+            ShortcutUtil.addShortcuts(getContext());
+
             Toast.makeText(getContext(), R.string.shortcuts_reset_done_desc, Toast.LENGTH_LONG).show();
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetShortcutsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetShortcutsPreference.java
@@ -26,7 +26,7 @@ public class ResetShortcutsPreference extends DialogPreference {
             ShortcutUtil.removeAllShortcuts(getContext());
 
             // Build all shortcuts
-            ShortcutUtil.addShortcuts(getContext());
+            ShortcutUtil.addAllShortcuts(getContext());
 
             Toast.makeText(getContext(), R.string.shortcuts_reset_done_desc, Toast.LENGTH_LONG).show();
         }

--- a/app/src/main/java/fr/neamar/kiss/shortcut/SaveAllOreoShortcutsAsync.java
+++ b/app/src/main/java/fr/neamar/kiss/shortcut/SaveAllOreoShortcutsAsync.java
@@ -20,30 +20,21 @@ import java.util.Set;
 import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
-import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.ShortcutsPojo;
 import fr.neamar.kiss.utils.ShortcutUtil;
 import fr.neamar.kiss.utils.UserHandle;
 
 @TargetApi(Build.VERSION_CODES.O)
-public class SaveOreoShortcutAsync extends AsyncTask<Void, Integer, Boolean> {
+public class SaveAllOreoShortcutsAsync extends AsyncTask<Void, Integer, Boolean> {
 
-    private static String TAG = "SaveOreoShortcutAsync";
+    private static String TAG = "SaveAllOreoShortcutsAsync";
     private final WeakReference<Context> context;
     private final WeakReference<DataHandler> dataHandler;
 
-    public SaveOreoShortcutAsync(@NonNull Context context) {
+    public SaveAllOreoShortcutsAsync(@NonNull Context context) {
         this.context = new WeakReference<>(context);
         this.dataHandler = new WeakReference<>(KissApplication.getApplication(context).getDataHandler());
-    }
-
-    @Override
-    protected void onPreExecute() {
-        Context context = this.context.get();
-        if (context != null) {
-            DBHelper.removeAllShortcuts(context);
-        }
     }
 
     @Override
@@ -95,7 +86,7 @@ public class SaveOreoShortcutAsync extends AsyncTask<Void, Integer, Boolean> {
             }
 
             // Create Pojo
-            ShortcutsPojo pojo = ShortcutUtil.createShortcutPojo(context, shortcutInfo);
+            ShortcutsPojo pojo = ShortcutUtil.createShortcutPojo(context, shortcutInfo, !shortcutInfo.isPinned());
             if (pojo == null) {
                 continue;
             }
@@ -110,7 +101,7 @@ public class SaveOreoShortcutAsync extends AsyncTask<Void, Integer, Boolean> {
     @Override
     protected void onProgressUpdate(Integer... progress) {
         if (progress[0] == -1) {
-            Toast.makeText(context.get(), R.string.cant_pin_shortcut, Toast.LENGTH_LONG).show();
+            Toast.makeText(context.get(), R.string.cant_save_shortcuts, Toast.LENGTH_LONG).show();
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/shortcut/SaveSingleOreoShortcutAsync.java
+++ b/app/src/main/java/fr/neamar/kiss/shortcut/SaveSingleOreoShortcutAsync.java
@@ -1,0 +1,92 @@
+package fr.neamar.kiss.shortcut;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+
+import java.lang.ref.WeakReference;
+
+import fr.neamar.kiss.DataHandler;
+import fr.neamar.kiss.KissApplication;
+import fr.neamar.kiss.R;
+import fr.neamar.kiss.pojo.ShortcutsPojo;
+import fr.neamar.kiss.utils.ShortcutUtil;
+
+@TargetApi(Build.VERSION_CODES.O)
+public class SaveSingleOreoShortcutAsync extends AsyncTask<Void, Integer, Boolean> {
+
+    private static String TAG = "SaveAllOreoShortcutsAsync";
+    private final WeakReference<Context> context;
+    private final WeakReference<DataHandler> dataHandler;
+    private Intent intent;
+
+    public SaveSingleOreoShortcutAsync(@NonNull Context context, @NonNull Intent intent) {
+        this.context = new WeakReference<>(context);
+        this.dataHandler = new WeakReference<>(KissApplication.getApplication(context).getDataHandler());
+        this.intent = intent;
+    }
+
+
+    @Override
+    protected Boolean doInBackground(Void... voids) {
+
+        final LauncherApps.PinItemRequest pinItemRequest = intent.getParcelableExtra(LauncherApps.EXTRA_PIN_ITEM_REQUEST);
+        final ShortcutInfo shortcutInfo = pinItemRequest.getShortcutInfo();
+
+        if (shortcutInfo == null) {
+            cancel(true);
+            return null;
+        }
+
+        Context context = this.context.get();
+        if (context == null) {
+            cancel(true);
+            return null;
+        }
+
+        // Create Pojo
+        ShortcutsPojo pojo = ShortcutUtil.createShortcutPojo(context, shortcutInfo, false);
+        if (pojo == null) {
+            return false;
+        }
+
+        final DataHandler dataHandler = this.dataHandler.get();
+        if (dataHandler == null) {
+            cancel(true);
+            return null;
+        }
+
+        // Add shortcut to the DataHandler
+        if(dataHandler.addShortcut(pojo)){
+            pinItemRequest.accept();
+        }
+        return true;
+    }
+
+    @Override
+    protected void onProgressUpdate(Integer... progress) {
+        if (progress[0] == -1) {
+            Toast.makeText(context.get(), R.string.cant_pin_shortcut, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    @Override
+    protected void onPostExecute(@NonNull Boolean success) {
+        if (success) {
+            Log.i(TAG, "Shortcut added to KISS");
+
+            if (this.dataHandler.get().getShortcutsProvider() != null) {
+                this.dataHandler.get().getShortcutsProvider().reload();
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/fr/neamar/kiss/shortcut/SaveSingleOreoShortcutAsync.java
+++ b/app/src/main/java/fr/neamar/kiss/shortcut/SaveSingleOreoShortcutAsync.java
@@ -67,8 +67,9 @@ public class SaveSingleOreoShortcutAsync extends AsyncTask<Void, Integer, Boolea
         // Add shortcut to the DataHandler
         if(dataHandler.addShortcut(pojo)){
             pinItemRequest.accept();
+            return true;
         }
-        return true;
+        return false;
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
@@ -52,7 +52,7 @@ public class ShortcutUtil {
     /**
      * Save all oreo shortcuts to DB
      */
-    public static void addShortcuts(Context context){
+    public static void addAllShortcuts(Context context){
         new SaveAllOreoShortcutsAsync(context).execute();
     }
 

--- a/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss.utils;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.LauncherApps;
@@ -18,8 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.pojo.ShortcutsPojo;
-import fr.neamar.kiss.shortcut.SaveOreoShortcutAsync;
+import fr.neamar.kiss.shortcut.SaveAllOreoShortcutsAsync;
+import fr.neamar.kiss.shortcut.SaveSingleOreoShortcutAsync;
 
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
@@ -49,8 +52,23 @@ public class ShortcutUtil {
     /**
      * Save all oreo shortcuts to DB
      */
-    public static void rebuildShortcuts(Context context){
-        new SaveOreoShortcutAsync(context).execute();
+    public static void addShortcuts(Context context){
+        new SaveAllOreoShortcutsAsync(context).execute();
+    }
+
+    /**
+     * Save single shortcut to DB via pin request
+     */
+    @TargetApi(Build.VERSION_CODES.O)
+    public static void addShortcut(Context context, Intent intent){
+        new SaveSingleOreoShortcutAsync(context, intent).execute();
+    }
+
+    /**
+     * Remove all shortcuts saved in the database
+     */
+    public static void removeAllShortcuts(Context context){
+        DBHelper.removeAllShortcuts(context);
     }
 
     /**
@@ -89,7 +107,7 @@ public class ShortcutUtil {
      * Create ShortcutPojo from ShortcutInfo
      */
     @TargetApi(Build.VERSION_CODES.O)
-    public static ShortcutsPojo createShortcutPojo(Context context, ShortcutInfo shortcutInfo){
+    public static ShortcutsPojo createShortcutPojo(Context context, ShortcutInfo shortcutInfo, boolean includePackageName){
 
         LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
         // id isn't used after being saved in the DB.
@@ -102,13 +120,13 @@ public class ShortcutUtil {
         String appName = getAppNameFromPackageName(context, shortcutInfo.getPackage());
 
         if (shortcutInfo.getShortLabel() != null) {
-            if(!TextUtils.isEmpty(appName)){
+            if(includePackageName && !TextUtils.isEmpty(appName)){
                 pojo.setName(appName + ": " + shortcutInfo.getShortLabel().toString());
             } else {
                 pojo.setName(shortcutInfo.getShortLabel().toString());
             }
         } else if (shortcutInfo.getLongLabel() != null) {
-            if(!TextUtils.isEmpty(appName)){
+            if(includePackageName && !TextUtils.isEmpty(appName)){
                 pojo.setName(appName + ": " + shortcutInfo.getLongLabel().toString());
             } else {
                 pojo.setName(shortcutInfo.getLongLabel().toString());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="pref_fav_tags_drawable">Generate icons for fav tags</string>
     <string name="notification_support">Display a dot on apps with notifications</string>
     <string name="notification_dialog">Check KISS in the following menu to turn it on.</string>
-    <string name="cant_pin_shortcut">Could not add shortcuts. Is KISS your default launcher\?</string>
+    <string name="cant_pin_shortcut">Could not add shortcut. Is KISS your default launcher\?</string>
+    <string name="cant_save_shortcuts">Could not add shortcuts. Is KISS your default launcher\?</string>
     <string name="copy_confirmation">Copied to clipboard</string>
 </resources>


### PR DESCRIPTION
Bug fixes for shortcuts:
- Put back support for pined shortcuts (idk how or why I removed that...)
- Delete all shortcuts only when user wants to reset them
- Pinned shortcuts do not have the prefix of the app name. My rationale for this was that users probably know what they pinned, since you usually pin something that you use often. The downside to this is that searching for app name doesn't give you pinned shortcuts in results...
- Prevent adding duplicate shortcuts