### PR TITLE
Use contact ID rather than lookup key

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
@@ -8,10 +8,8 @@ import android.provider.ContactsContract;
 import android.util.Log;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -52,7 +50,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                         ContactsContract.CommonDataKinds.Phone.STARRED,
                         ContactsContract.CommonDataKinds.Phone.IS_PRIMARY,
                         ContactsContract.Contacts.PHOTO_ID,
-                        ContactsContract.CommonDataKinds.Phone.CONTACT_ID}, null, null, ContactsContract.CommonDataKinds.Phone.TIMES_CONTACTED + " DESC");
+                        ContactsContract.Contacts._ID}, null, null, null);
 
         // Prevent duplicates by keeping in memory encountered contacts.
         Map<String, Set<ContactsPojo>> mapContacts = new HashMap<>();
@@ -66,11 +64,13 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                 int starredIndex = cur.getColumnIndex(ContactsContract.CommonDataKinds.Phone.STARRED);
                 int isPrimaryIndex = cur.getColumnIndex(ContactsContract.CommonDataKinds.Phone.IS_PRIMARY);
                 int photoIdIndex = cur.getColumnIndex(ContactsContract.Contacts.PHOTO_ID);
+                int contactIdIndex = cur.getColumnIndex(ContactsContract.Contacts._ID);
 
                 while (cur.moveToNext()) {
                     String lookupKey = cur.getString(lookupIndex);
-                    Integer timesContacted = cur.getInt(timesContactedIndex);
+                    int timesContacted = cur.getInt(timesContactedIndex);
                     String name = cur.getString(displayNameIndex);
+                    int contactId = cur.getInt(contactIdIndex);
 
                     String phone = cur.getString(numberIndex);
                     if (phone == null) {
@@ -87,16 +87,13 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                                 Long.parseLong(photoId));
                     }
 
-                    ContactsPojo contact = new ContactsPojo(pojoScheme + lookupKey + phone,
+                    ContactsPojo contact = new ContactsPojo(pojoScheme + contactId + '/' + phone,
                             lookupKey, phone, normalizedPhone, icon, primary, timesContacted,
                             starred, false);
 
                     contact.setName(name);
 
                     if (contact.getName() != null) {
-                        //TBog: contact should have the normalized name already
-                        //contact.setName( contact.getName(), true );
-
                         if (mapContacts.containsKey(contact.lookupKey))
                             mapContacts.get(contact.lookupKey).add(contact);
                         else {

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -35,13 +35,12 @@ public class QuerySearcher extends Searcher {
 
     @Override
     protected int getMaxResultCount() {
-        if(MAX_RESULT_COUNT == -1) {
+        if (MAX_RESULT_COUNT == -1) {
             // Convert `"number-of-display-elements"` to double first before truncating to int to avoid
             // `java.lang.NumberFormatException` crashes for values larger than `Integer.MAX_VALUE`
             try {
                 MAX_RESULT_COUNT = Double.valueOf(prefs.getString("number-of-display-elements", String.valueOf(DEFAULT_MAX_RESULTS))).intValue();
-            }
-            catch(NumberFormatException e) {
+            } catch (NumberFormatException e) {
                 // If, for any reason, setting is empty, return default value.
                 MAX_RESULT_COUNT = DEFAULT_MAX_RESULTS;
             }

--- a/app/src/main/java/fr/neamar/kiss/utils/FuzzyScore.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/FuzzyScore.java
@@ -238,7 +238,7 @@ public class FuzzyScore {
          */
         public int score;
         public boolean match;
-        public final ArrayList<Integer> matchedIndices;
+        final ArrayList<Integer> matchedIndices;
 
         MatchInfo() {
             matchedIndices = null;


### PR DESCRIPTION
Contact history was implemented using LOOKUP_KEY, as it seemed to be
good practice in the Android world.
However, LOOKUP_KEY can and will change.

At this point, we might as well use the shorter contact id, that may
also change but seems to change less frequently and is much shorter to
store and manipulate.


<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->