### PR TITLE
improve notification dot behaviour

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
+++ b/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
@@ -132,8 +132,8 @@ public class NotificationListener extends NotificationListenerService {
         }
     }
 
-    // Low priority notifications should not be displayed
+    // Low priority and ongoing notifications should not be displayed
     public boolean isNotificationTrivial(Notification notification) {
-        return notification.priority <= Notification.PRIORITY_MIN;
+        return notification.priority <= Notification.PRIORITY_MIN || (notification.flags & Notification.FLAG_ONGOING_EVENT) != 0;
     }
 }


### PR DESCRIPTION
do not show notification dots for ongoing notifications as these will always be shown and can not be cleared by user. this is an improvement of #1211 and should fix #1319.

See also https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder.html#setOngoing(boolean) and https://developer.android.com/training/notify-user/badges#disable regarding badges for ongoing notifications.
It would even be better if we can use notification channels for checking canShowBadge() but as neamar pointed out somewhere this is not possible (for now)
