### PR TITLE
Display correct icons for apps with more than one launchable activity

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -187,8 +187,15 @@ public class IconsHandler {
         try {
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 LauncherApps launcher = (LauncherApps) ctx.getSystemService(Context.LAUNCHER_APPS_SERVICE);
-                LauncherActivityInfo info = launcher.getActivityList(componentName.getPackageName(), userHandle.getRealHandle()).get(0);
-                return info.getBadgedIcon(0);
+                List<LauncherActivityInfo> icons = launcher.getActivityList(componentName.getPackageName(), userHandle.getRealHandle());
+                for (LauncherActivityInfo info : icons) {
+                    if (info.getComponentName().equals(componentName)) {
+                        return info.getBadgedIcon(0);
+                    }
+                }
+
+                // This should never happen, let's jsut return the first icon
+                return icons.get(0).getBadgedIcon(0);
             } else {
                 return pm.getActivityIcon(componentName);
             }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Notification.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Notification.java
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.provider.Settings;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
@@ -48,13 +49,12 @@ class Notification extends Forwarder {
                 String allowedApps = Settings.Secure.getString(mainActivity.getContentResolver(), "enabled_notification_listeners");
                 if (allowedApps.contains(mainActivity.getPackageName())) {
                     notifsPrefBuilder = mainActivity.getSharedPreferences(NotificationListener.NOTIFICATION_PREFERENCES_NAME, MODE_PRIVATE);
-                }
-                else {
+                } else {
                     // We don't have permission, make sure the SharedPreferences is empty to avoid displaying "ghost" notifications
                     mainActivity.getSharedPreferences(NotificationListener.NOTIFICATION_PREFERENCES_NAME, MODE_PRIVATE).edit().clear().apply();
                 }
             } catch (Error e) {
-                e.printStackTrace();
+                Log.i("Notification", "Unable to check for notification access: " + e.toString());
             }
         }
         notificationPreferences = notifsPrefBuilder;
@@ -86,14 +86,13 @@ class Notification extends Forwarder {
     private void animateDot(final View notificationDot, Boolean hasNotification) {
         int currentVisibility = notificationDot.getVisibility();
 
-        if(currentVisibility != View.VISIBLE && hasNotification) {
+        if (currentVisibility != View.VISIBLE && hasNotification) {
             // There is a notification and dot was not visible
             notificationDot.setVisibility(View.VISIBLE);
             notificationDot.setScaleX(0);
             notificationDot.setScaleY(0);
             notificationDot.animate().scaleX(1).scaleY(1).setListener(null);
-        }
-        else if(currentVisibility == View.VISIBLE && !hasNotification) {
+        } else if (currentVisibility == View.VISIBLE && !hasNotification) {
             // There is no notification anymore, and dot was visible
             notificationDot.animate().scaleX(0).scaleY(0).setListener(new AnimatorListenerAdapter() {
                 @Override


### PR DESCRIPTION
Display correct icons for apps with more than one launchable activity
 
We used to always return the very first image from the package, but this is not correct as more than one icon can be exposed through the manifest.

This fixes all apps with more than one launchable activity, which is especially common on Samsung and Huawei devices.

Before:
![2020-01-25 17 48 34](https://user-images.githubusercontent.com/536844/73124398-4054c700-3f9b-11ea-889f-143601d8e145.png)

After:
![2020-01-25 17 48 58](https://user-images.githubusercontent.com/536844/73124399-4054c700-3f9b-11ea-9f55-ce9fa5f5f48c.png)

Fix #1170