### PR TITLE
Use a custom accent color through Overlays for better theming

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/UIColors.java
+++ b/app/src/main/java/fr/neamar/kiss/UIColors.java
@@ -10,22 +10,82 @@ import android.preference.PreferenceManager;
 import android.view.Window;
 import android.view.WindowManager;
 
-import androidx.annotation.NonNull;
-
 public class UIColors {
     public static final int COLOR_DEFAULT = 0xFF4caf50;
     // Source: https://material.io/guidelines/style/color.html#color-color-palette
     public static final int[] COLOR_LIST = new int[]{
-            0xFF4CAF50, 0xFFD32F2F, 0xFFC2185B, 0xFF7B1FA2,
-            0xFF512DA8, 0xFF303F9F, 0xFF1976D2, 0xFF0288D1,
-            0xFF0097A7, 0xFF00796B, 0xFF388E3C, 0xFF689F38,
-            0xFFAFB42B, 0xFFFBC02D, 0xFFFFA000, 0xFFF57C00,
-            0xFFE64A19, 0xFF5D4037, 0xFF616161, 0xFF455A64,
+            0xFF4CAF50,
+            0xFFD32F2F,
+            0xFFC2185B,
+            0xFF7B1FA2,
+            0xFF512DA8,
+            0xFF303F9F,
+            0xFF1976D2,
+            0xFF0288D1,
+            0xFF0097A7,
+            0xFF00796B,
+            0xFF388E3C,
+            0xFF689F38,
+            0xFFAFB42B,
+            0xFFFBC02D,
+            0xFFFFA000,
+            0xFFF57C00,
+            0xFFE64A19,
+            0xFF5D4037,
+            0xFF616161,
+            0xFF455A64,
             0xFF000000
     };
+
+    private static final int[] OVERLAY_LIST = new int[]{
+            -1,
+            R.style.OverlayAccentD32F2F,
+            R.style.OverlayAccentC2185B,
+            R.style.OverlayAccent7B1FA2,
+            R.style.OverlayAccent512DA8,
+            R.style.OverlayAccent303F9F,
+            R.style.OverlayAccent1976D2,
+            R.style.OverlayAccent0288D1,
+            R.style.OverlayAccent0097A7,
+            R.style.OverlayAccent00796B,
+            R.style.OverlayAccent388E3C,
+            R.style.OverlayAccent689F38,
+            R.style.OverlayAccentAFB42B,
+            R.style.OverlayAccentFBC02D,
+            R.style.OverlayAccentFFA000,
+            R.style.OverlayAccentF57C00,
+            R.style.OverlayAccentE64A19,
+            R.style.OverlayAccent5D4037,
+            R.style.OverlayAccent616161,
+            R.style.OverlayAccent455A64,
+            -1,
+    };
+
     private static final String COLOR_DEFAULT_STR = String.format("#%06X", COLOR_DEFAULT & 0xFFFFFF);
 
     private static int primaryColor = -1;
+
+    // https://stackoverflow.com/questions/25815769/how-to-really-programmatically-change-primary-and-accent-color-in-android-loll
+    public static void applyOverlay(Activity activity) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+
+        // We want to update the accent color for the theme.
+        // Each possible accent color is defined as a custom overlay, we need to find the matching one and apply it
+        int primaryColor = getPrimaryColor(activity);
+
+        for (int i = 0; i < COLOR_LIST.length; i++) {
+
+            if (COLOR_LIST[i] == primaryColor) {
+                int resId = OVERLAY_LIST[i];
+                if(resId != -1) {
+                    activity.getTheme().applyStyle(resId, true);
+                }
+                return;
+            }
+        }
+    }
 
     public static void updateThemePrimaryColor(Activity activity) {
         int notificationBarColorOverride = getNotificationBarColor(activity);
@@ -64,8 +124,7 @@ public class UIColors {
             // Transparent can't be displayed for text color, replace with light gray.
             if (primaryColorStr.equals("#00000000") || primaryColorStr.equals("#AAFFFFFF")) {
                 primaryColor = 0xFFBDBDBD;
-            }
-            else {
+            } else {
                 primaryColor = Color.parseColor(primaryColorStr);
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -44,6 +44,8 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.setTheme(R.style.AppThemeAmoledDark);
                 break;
         }
+
+        UIColors.applyOverlay(mainActivity);
     }
 
     void onCreate() {
@@ -174,8 +176,11 @@ class InterfaceTweaks extends Forwarder {
         // Launcher button should have the main color
         ImageView launcherButton = mainActivity.findViewById(R.id.launcherButton);
         launcherButton.setColorFilter(primaryColorOverride);
-        ProgressBar loaderBar = mainActivity.findViewById(R.id.loaderBar);
-        loaderBar.getIndeterminateDrawable().setColorFilter(primaryColorOverride, PorterDuff.Mode.SRC_IN);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            ProgressBar loaderBar = mainActivity.findViewById(R.id.loaderBar);
+            loaderBar.getIndeterminateDrawable().setColorFilter(primaryColorOverride, PorterDuff.Mode.SRC_IN);
+        }
 
         // Kissbar background
         mainActivity.kissBar.getBackground().mutate().setColorFilter(primaryColorOverride, PorterDuff.Mode.SRC_IN);

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -57,25 +57,83 @@
         <item name="textShadowRadius">3</item>
     </style>
 
-    <style name="OverlayAccentD32F2F"><item name="android:colorAccent">#D32F2F</item></style>
-    <style name="OverlayAccentC2185B"><item name="android:colorAccent">#C2185B</item></style>
-    <style name="OverlayAccent7B1FA2"><item name="android:colorAccent">#7B1FA2</item></style>
-    <style name="OverlayAccent512DA8"><item name="android:colorAccent">#512DA8</item></style>
-    <style name="OverlayAccent303F9F"><item name="android:colorAccent">#303F9F</item></style>
-    <style name="OverlayAccent1976D2"><item name="android:colorAccent">#1976D2</item></style>
-    <style name="OverlayAccent0288D1"><item name="android:colorAccent">#0288D1</item></style>
-    <style name="OverlayAccent0097A7"><item name="android:colorAccent">#0097A7</item></style>
-    <style name="OverlayAccent00796B"><item name="android:colorAccent">#00796B</item></style>
-    <style name="OverlayAccent388E3C"><item name="android:colorAccent">#388E3C</item></style>
-    <style name="OverlayAccent689F38"><item name="android:colorAccent">#689F38</item></style>
-    <style name="OverlayAccentAFB42B"><item name="android:colorAccent">#AFB42B</item></style>
-    <style name="OverlayAccentFBC02D"><item name="android:colorAccent">#FBC02D</item></style>
-    <style name="OverlayAccentFFA000"><item name="android:colorAccent">#FFA000</item></style>
-    <style name="OverlayAccentF57C00"><item name="android:colorAccent">#F57C00</item></style>
-    <style name="OverlayAccentE64A19"><item name="android:colorAccent">#E64A19</item></style>
-    <style name="OverlayAccent5D4037"><item name="android:colorAccent">#5D4037</item></style>
-    <style name="OverlayAccent616161"><item name="android:colorAccent">#616161</item></style>
-    <style name="OverlayAccent455A64"><item name="android:colorAccent">#455A64</item></style>
+    <style name="OverlayAccentD32F2F">
+        <item name="android:colorAccent">#D32F2F</item>
+        <item name="android:colorPrimary">#D32F2F</item>
+    </style>
+    <style name="OverlayAccentC2185B">
+        <item name="android:colorAccent">#C2185B</item>
+        <item name="android:colorPrimary">#C2185B</item>
+    </style>
+    <style name="OverlayAccent7B1FA2">
+        <item name="android:colorAccent">#7B1FA2</item>
+        <item name="android:colorPrimary">#7B1FA2</item>
+    </style>
+    <style name="OverlayAccent512DA8">
+        <item name="android:colorAccent">#512DA8</item>
+        <item name="android:colorPrimary">#512DA8</item>
+    </style>
+    <style name="OverlayAccent303F9F">
+        <item name="android:colorAccent">#303F9F</item>
+        <item name="android:colorPrimary">#303F9F</item>
+    </style>
+    <style name="OverlayAccent1976D2">
+        <item name="android:colorAccent">#1976D2</item>
+        <item name="android:colorPrimary">#1976D2</item>
+    </style>
+    <style name="OverlayAccent0288D1">
+        <item name="android:colorAccent">#0288D1</item>
+        <item name="android:colorPrimary">#0288D1</item>
+    </style>
+    <style name="OverlayAccent0097A7">
+        <item name="android:colorAccent">#0097A7</item>
+        <item name="android:colorPrimary">#0097A7</item>
+    </style>
+    <style name="OverlayAccent00796B">
+        <item name="android:colorAccent">#00796B</item>
+        <item name="android:colorPrimary">#00796B</item>
+    </style>
+    <style name="OverlayAccent388E3C">
+        <item name="android:colorAccent">#388E3C</item>
+        <item name="android:colorPrimary">#388E3C</item>
+    </style>
+    <style name="OverlayAccent689F38">
+        <item name="android:colorAccent">#689F38</item>
+        <item name="android:colorPrimary">#689F38</item>
+    </style>
+    <style name="OverlayAccentAFB42B">
+        <item name="android:colorAccent">#AFB42B</item>
+        <item name="android:colorPrimary">#AFB42B</item>
+    </style>
+    <style name="OverlayAccentFBC02D">
+        <item name="android:colorAccent">#FBC02D</item>
+        <item name="android:colorPrimary">#FBC02D</item>
+    </style>
+    <style name="OverlayAccentFFA000">
+        <item name="android:colorAccent">#FFA000</item>
+        <item name="android:colorPrimary">#FFA000</item>
+    </style>
+    <style name="OverlayAccentF57C00">
+        <item name="android:colorAccent">#F57C00</item>
+        <item name="android:colorPrimary">#F57C00</item>
+
+    </style>
+    <style name="OverlayAccentE64A19">
+        <item name="android:colorAccent">#E64A19</item>
+        <item name="android:colorPrimary">#E64A19</item>
+    </style>
+    <style name="OverlayAccent5D4037">
+        <item name="android:colorAccent">#5D4037</item>
+        <item name="android:colorPrimary">#5D4037</item>
+    </style>
+    <style name="OverlayAccent616161">
+        <item name="android:colorAccent">#616161</item>
+        <item name="android:colorPrimary">#616161</item>
+    </style>
+    <style name="OverlayAccent455A64">
+        <item name="android:colorAccent">#455A64</item>
+        <item name="android:colorPrimary">#455A64</item>
+    </style>
 
     <style name="SettingTheme" parent="AppThemeLight">
         <item name="android:actionBarStyle">@style/SettingsActionBar</item>

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -57,6 +57,26 @@
         <item name="textShadowRadius">3</item>
     </style>
 
+    <style name="OverlayAccentD32F2F"><item name="android:colorAccent">#D32F2F</item></style>
+    <style name="OverlayAccentC2185B"><item name="android:colorAccent">#C2185B</item></style>
+    <style name="OverlayAccent7B1FA2"><item name="android:colorAccent">#7B1FA2</item></style>
+    <style name="OverlayAccent512DA8"><item name="android:colorAccent">#512DA8</item></style>
+    <style name="OverlayAccent303F9F"><item name="android:colorAccent">#303F9F</item></style>
+    <style name="OverlayAccent1976D2"><item name="android:colorAccent">#1976D2</item></style>
+    <style name="OverlayAccent0288D1"><item name="android:colorAccent">#0288D1</item></style>
+    <style name="OverlayAccent0097A7"><item name="android:colorAccent">#0097A7</item></style>
+    <style name="OverlayAccent00796B"><item name="android:colorAccent">#00796B</item></style>
+    <style name="OverlayAccent388E3C"><item name="android:colorAccent">#388E3C</item></style>
+    <style name="OverlayAccent689F38"><item name="android:colorAccent">#689F38</item></style>
+    <style name="OverlayAccentAFB42B"><item name="android:colorAccent">#AFB42B</item></style>
+    <style name="OverlayAccentFBC02D"><item name="android:colorAccent">#FBC02D</item></style>
+    <style name="OverlayAccentFFA000"><item name="android:colorAccent">#FFA000</item></style>
+    <style name="OverlayAccentF57C00"><item name="android:colorAccent">#F57C00</item></style>
+    <style name="OverlayAccentE64A19"><item name="android:colorAccent">#E64A19</item></style>
+    <style name="OverlayAccent5D4037"><item name="android:colorAccent">#5D4037</item></style>
+    <style name="OverlayAccent616161"><item name="android:colorAccent">#616161</item></style>
+    <style name="OverlayAccent455A64"><item name="android:colorAccent">#455A64</item></style>
+
     <style name="SettingTheme" parent="AppThemeLight">
         <item name="android:actionBarStyle">@style/SettingsActionBar</item>
 


### PR DESCRIPTION
Fix #1337

Standard view unchanged:
![2020-02-14 16 18 05](https://user-images.githubusercontent.com/536844/74543474-bcf91680-4f45-11ea-864c-6051e1fd86ea.png)

App list properly tinted, and overscroll too:
![2020-02-14 16 18 20](https://user-images.githubusercontent.com/536844/74543476-bd91ad00-4f45-11ea-864c-406443c6c124.png)