### PR TITLE
If KISS is not the default launcher, then pressing back should exit the app

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -9,6 +9,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.database.DataSetObserver;
 import android.os.Build;
 import android.os.Bundle;
@@ -468,7 +470,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             // will hide history again)
             searchEditText.setText("");
         }
-        // No call to super.onBackPressed(), since this would quit the launcher.
+
+        // Calling super.onBackPressed() will quit the launcher, only do this if KISS is not the user's default home.
+        if (!isKissDefaultLauncher()) {
+            super.onBackPressed();
+        }
     }
 
     @Override
@@ -859,5 +865,20 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
         clearButton.setVisibility(View.VISIBLE);
         menuButton.setVisibility(View.INVISIBLE);
+    }
+
+    public boolean isKissDefaultLauncher() {
+        String homePackage;
+        try {
+            Intent i = new Intent(Intent.ACTION_MAIN);
+            i.addCategory(Intent.CATEGORY_HOME);
+            PackageManager pm = getPackageManager();
+            final ResolveInfo mInfo = pm.resolveActivity(i, PackageManager.MATCH_DEFAULT_ONLY);
+            homePackage = mInfo.activityInfo.packageName;
+        } catch (Exception e) {
+            homePackage = "unknown";
+        }
+
+        return homePackage.equals(this.getPackageName());
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/OreoShortcuts.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/OreoShortcuts.java
@@ -2,8 +2,6 @@ package fr.neamar.kiss.forwarder;
 
 import android.content.Intent;
 import android.content.pm.LauncherApps;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.utils.ShortcutUtil;
@@ -18,7 +16,7 @@ class OreoShortcuts extends Forwarder {
         if (ShortcutUtil.areShortcutsEnabled(mainActivity)) {
             // On first run save all shortcuts
             if (prefs.getBoolean("first-run-shortcuts", true)) {
-                if(getHomePackage().equals(mainActivity.getPackageName())) {
+                if(mainActivity.isKissDefaultLauncher()) {
                     // Save all shortcuts
                     ShortcutUtil.addAllShortcuts(mainActivity);
                     // Set flag to falseX
@@ -36,19 +34,5 @@ class OreoShortcuts extends Forwarder {
             }
         }
 
-    }
-
-    private String getHomePackage() {
-        try {
-            Intent i = new Intent(Intent.ACTION_MAIN);
-            i.addCategory(Intent.CATEGORY_HOME);
-            PackageManager pm = mainActivity.getPackageManager();
-            final ResolveInfo mInfo = pm.resolveActivity(i, PackageManager.MATCH_DEFAULT_ONLY);
-            return mInfo.activityInfo.packageName;
-        }
-        catch(Exception e)
-        {
-            return "unknown";
-        }
     }
 }


### PR DESCRIPTION
Fix #1297.

Nothing changes when KISS is the default launcher (which is, I assume, the most common use case)