### PR TITLE
When searching with more than one provider, avoid invalid animations.

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -772,6 +772,10 @@ public class DataHandler extends BroadcastReceiver
      * @param id pojo.id of item to record
      */
     public void addToHistory(String id) {
+        if(id.isEmpty()) {
+            return;
+        }
+
         boolean frozen = PreferenceManager.getDefaultSharedPreferences(context).
                 getBoolean("freeze-history", false);
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SearchProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SearchProvider.java
@@ -79,8 +79,6 @@ public class SearchProvider extends SimpleProvider {
 
         if (prefs.getBoolean("enable-search", true)) {
             for (SearchPojo pojo : searchProviders) {
-                // Set the id, otherwise the result will be boosted since KISS will assume we've selected this search provider multiple times before"
-                pojo.id = "search://" + query;
                 pojo.query = query;
                 records.add(pojo);
             }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SearchProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SearchProvider.java
@@ -95,7 +95,7 @@ public class SearchProvider extends SimpleProvider {
             // (tradeoff: non https URL will break, but they shouldn't exist anymore)
             guessedUrl = guessedUrl.replace("http://", "https://");
             if (URLUtil.isValidUrl(guessedUrl)) {
-                SearchPojo pojo = new SearchPojo("", guessedUrl, SearchPojo.URL_QUERY);
+                SearchPojo pojo = new SearchPojo("search://url-access","", guessedUrl, SearchPojo.URL_QUERY);
                 pojo.relevance = 50;
                 pojo.setName(guessedUrl, false);
                 records.add(pojo);

--- a/app/src/main/java/fr/neamar/kiss/pojo/SearchPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/SearchPojo.java
@@ -1,21 +1,22 @@
 package fr.neamar.kiss.pojo;
 
+import android.util.Log;
+
 public class SearchPojo extends Pojo {
     public static final int SEARCH_QUERY = 0;
     public static final int URL_QUERY = 1;
     public static final int CALCULATOR_QUERY = 2;
 
-    public String query = "";
-    public String url = "";
-    public int type = SEARCH_QUERY;
+    public String query;
+    public String url;
+    public final int type;
 
     public SearchPojo(String query, String url, int type) {
-        this(DEFAULT_ID, query, url, type);
+        this(url, query, url, type);
     }
 
     public SearchPojo(String id, String query, String url, int type) {
         super(id);
-
         if(type != SEARCH_QUERY && type != URL_QUERY && type != CALCULATOR_QUERY) {
             throw new IllegalArgumentException("Wrong type!");
         }
@@ -23,5 +24,11 @@ public class SearchPojo extends Pojo {
         this.query = query;
         this.url = url;
         this.type = type;
+    }
+
+    @Override
+    public String getHistoryId() {
+        // Search POJO should not appear in history
+        return "";
     }
 }


### PR DESCRIPTION
The search result would keep appearing from below, rather than remain stable. This was visually ugly, and is fixed.