### PR TITLE
Do not reset list scroll unless we're running a new query

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -564,7 +564,7 @@ public class DataHandler extends BroadcastReceiver
         DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
         dataHandler.removeFromFavorites(app.id);
 
-        //Exclude shortcuts for this app
+        // Exclude shortcuts for this app
         removeShortcuts(app.packageName);
     }
 
@@ -576,7 +576,7 @@ public class DataHandler extends BroadcastReceiver
         PreferenceManager.getDefaultSharedPreferences(context).edit().putStringSet("excluded-apps", excluded).apply();
         app.setExcluded(false);
 
-        //Add shortcuts for this app
+        // Add shortcuts for this app
         addShortcut(app.packageName);
     }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -623,7 +623,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
     public void onFavoriteChange() {
         forwarderManager.onFavoriteChange();
-        launchOccurred();
     }
 
     private void displayKissBar(Boolean display) {
@@ -767,7 +766,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     @Override
     public void temporarilyDisableTranscriptMode() {
         list.setTranscriptMode(AbsListView.TRANSCRIPT_MODE_DISABLED);
-        // Add a message to be processaed after all current messages, to reset transcript mode to default
+        // Add a message to be processed after all current messages, to reset transcript mode to default
         list.post(() -> list.setTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL));
     }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.PopupWindow;
 import android.widget.TextView;
@@ -741,6 +742,12 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             searchTask.cancel(true);
             searchTask = null;
         }
+    }
+
+    @Override
+    public void updateTranscriptMode(int transcriptMode) {
+        list.setTranscriptMode(transcriptMode);
+        list.post(() -> list.setTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL));
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -713,13 +713,14 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      * It will ask all the providers for data
      * This function is not called for non search-related changes! Have a look at onDataSetChanged() if that's what you're looking for :)
      *
+     * @param isRefresh whether the query is refreshing the existing result, or is a completely new query
      * @param query the query on which to search
      */
     private void updateSearchRecords(boolean isRefresh, String query) {
         resetTask();
         dismissPopup();
 
-        forwarderManager.updateSearchRecords(query);
+        forwarderManager.updateSearchRecords(isRefresh, query);
 
         if (query.isEmpty()) {
             systemUiVisibilityHelper.resetScroll();
@@ -748,17 +749,17 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      * The value we have by default, TRANSCRIPT_MODE_ALWAYS_SCROLL, means that on every new search,
      * (actually, on any change to the listview's adapter items)
      * scroll is reset to the bottom, which makes sense as we want the most relevant search results
-     * to be visible first.
+     * to be visible first (searching for "ab" after "a" should reset the scroll).
      * However, when updating an existing result set (for instance to remove a record, add a tag,
      * etc.), we don't want the scroll to be reset. When this happens, we temporarily disable
-     * the scroll mode to be disabled.
+     * the scroll mode.
      * However, we need to be careful here: the PullView system we use actually relies on
-     * TRANSCRIPT_MODE_ALWAYS_SCROLL being active. So we add a new message in the queur to change
+     * TRANSCRIPT_MODE_ALWAYS_SCROLL being active. So we add a new message in the queue to change
      * back the transcript mode once we've rendered the change.
      * <p>
      * (why is PullView dependent on this? When you show the keyboard, no event is being dispatched
-     * to our application, but if we don't reset the scroll when they keyboard appears then you
-     * could be looking at an element that isn't the latest one when you start scrolling down
+     * to our application, but if we don't reset the scroll when the keyboard appears then you
+     * could be looking at an element that isn't the latest one as you start scrolling down
      * [which will hide the keyboard] and start a very ugly animation revealing items currently
      * hidden. Fairly easy to test, remove the transcript mode from the XML and the .post() here,
      * then scroll in your history, display the keyboard and scroll again on your history)

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -192,7 +192,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             public void onReceive(Context context, Intent intent) {
                 //noinspection ConstantConditions
                 if (intent.getAction().equalsIgnoreCase(LOAD_OVER)) {
-                    updateSearchRecords();
+                    updateSearchRecords(true);
                 } else if (intent.getAction().equalsIgnoreCase(FULL_LOAD_OVER)) {
                     Log.v(TAG, "All providers are done loading.");
 
@@ -291,7 +291,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                     displayKissBar(false, false);
                 }
                 String text = s.toString();
-                updateSearchRecords(text);
+                updateSearchRecords(false, text);
                 displayClearOnInput();
             }
         });
@@ -400,7 +400,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
         // We need to update the history in case an external event created new items
         // (for instance, installed a new app, got a phone call or simply clicked on a favorite)
-        updateSearchRecords();
+        updateSearchRecords(true);
         displayClearOnInput();
 
         if (isViewingAllApps()) {
@@ -567,9 +567,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      * Display KISS menu
      */
     public void onLauncherButtonClicked(View launcherButton) {
-        updateSearchRecords();
         // Display or hide the kiss bar, according to current view tag (showMenu / hideMenu).
-        // displayKissBar(launcherButton.getTag().equals("showMenu"));
+        displayKissBar(launcherButton.getTag().equals("showMenu"));
     }
 
     @Override
@@ -705,8 +704,8 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         forwarderManager.onDisplayKissBar(display);
     }
 
-    public void updateSearchRecords() {
-        updateSearchRecords(searchEditText.getText().toString());
+    public void updateSearchRecords(boolean isRefresh) {
+        updateSearchRecords(isRefresh, searchEditText.getText().toString());
     }
 
     /**
@@ -716,7 +715,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
      *
      * @param query the query on which to search
      */
-    private void updateSearchRecords(String query) {
+    private void updateSearchRecords(boolean isRefresh, String query) {
         resetTask();
         dismissPopup();
 
@@ -725,7 +724,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         if (query.isEmpty()) {
             systemUiVisibilityHelper.resetScroll();
         } else {
-            runTask(new QuerySearcher(this, query));
+            QuerySearcher querySearcher = new QuerySearcher(this, query);
+            querySearcher.setRefresh(isRefresh);
+            runTask(querySearcher);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -744,9 +744,30 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         }
     }
 
+    /**
+     * transcriptMode on the listView decides when to scroll back to the first item.
+     * The value we have by default, TRANSCRIPT_MODE_ALWAYS_SCROLL, means that on every new search,
+     * (actually, on any change to the listview's adapter items)
+     * scroll is reset to the bottom, which makes sense as we want the most relevant search results
+     * to be visible first.
+     * However, when updating an existing result set (for instance to remove a record, add a tag,
+     * etc.), we don't want the scroll to be reset. When this happens, we temporarily disable
+     * the scroll mode to be disabled.
+     * However, we need to be careful here: the PullView system we use actually relies on
+     * TRANSCRIPT_MODE_ALWAYS_SCROLL being active. So we add a new message in the queur to change
+     * back the transcript mode once we've rendered the change.
+     * <p>
+     * (why is PullView dependent on this? When you show the keyboard, no event is being dispatched
+     * to our application, but if we don't reset the scroll when they keyboard appears then you
+     * could be looking at an element that isn't the latest one when you start scrolling down
+     * [which will hide the keyboard] and start a very ugly animation revealing items currently
+     * hidden. Fairly easy to test, remove the transcript mode from the XML and the .post() here,
+     * then scroll in your history, display the keyboard and scroll again on your history)
+     */
     @Override
-    public void updateTranscriptMode(int transcriptMode) {
-        list.setTranscriptMode(transcriptMode);
+    public void temporarilyDisableTranscriptMode() {
+        list.setTranscriptMode(AbsListView.TRANSCRIPT_MODE_DISABLED);
+        // Add a message to be processaed after all current messages, to reset transcript mode to default
         list.post(() -> list.setTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL));
     }
 

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -771,6 +771,18 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     }
 
     /**
+     * Force  set transcript mode.
+     * Be careful when using this, it's almost always better to use temporarilyDisableTranscriptMode()
+     * unless you need to deal with the keyboard appearing for something else than a search.
+     * Always make sure you call this function twice, once to disable, and once to re-enable
+     * @param transcriptMode new transcript mode to set on the list
+     */
+    @Override
+    public void updateTranscriptMode(int transcriptMode) {
+        list.setTranscriptMode(transcriptMode);
+    }
+
+    /**
      * Call this function when we're leaving the activity after clicking a search result
      * to clear the search list.
      * We can't use onPause(), since it may be called for a configuration change

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -130,7 +130,6 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
 
     public void removeResult(Context context, Result result) {
         results.remove(result);
-        result.deleteRecord(context);
         notifyDataSetChanged();
         // Do not reset scroll, we want the remaining items to still be in vieww
         parent.temporarilyDisableTranscriptMode();

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AbsListView;
 import android.widget.BaseAdapter;
 import android.widget.SectionIndexer;
 
@@ -132,20 +133,33 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         results.remove(result);
         result.deleteRecord(context);
         notifyDataSetChanged();
+        updateTranscriptMode(true);
     }
 
-    public void updateResults(List<Result> results, String query) {
+    public void updateResults(List<Result> results, boolean isRefresh, String query) {
         this.results.clear();
         this.results.addAll(results);
         StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
 
         fuzzyScore = new FuzzyScore(queryNormalized.codePoints, true);
         notifyDataSetChanged();
+
+        updateTranscriptMode(isRefresh);
+    }
+
+    private void updateTranscriptMode(boolean isRefresh) {
+        if(isRefresh) {
+            parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_DISABLED);
+        }
+        else {
+            parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
+        }
     }
 
     public void clear() {
         this.results.clear();
         notifyDataSetChanged();
+        updateTranscriptMode(false);
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AbsListView;
 import android.widget.BaseAdapter;
 import android.widget.SectionIndexer;
 
@@ -133,7 +132,8 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         results.remove(result);
         result.deleteRecord(context);
         notifyDataSetChanged();
-        updateTranscriptMode(true);
+        // Do not reset scroll, we want the remaining items to still be in vieww
+        parent.temporarilyDisableTranscriptMode();
     }
 
     public void updateResults(List<Result> results, boolean isRefresh, String query) {
@@ -144,22 +144,16 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         fuzzyScore = new FuzzyScore(queryNormalized.codePoints, true);
         notifyDataSetChanged();
 
-        updateTranscriptMode(isRefresh);
+        if(isRefresh) {
+            // We're refreshing an existing dataset, do not reset scroll!
+            parent.temporarilyDisableTranscriptMode();
+        }
     }
 
-    private void updateTranscriptMode(boolean isRefresh) {
-        if(isRefresh) {
-            parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_DISABLED);
-        }
-        else {
-            parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
-        }
-    }
 
     public void clear() {
         this.results.clear();
         notifyDataSetChanged();
-        updateTranscriptMode(false);
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -131,7 +131,7 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
     public void removeResult(Context context, Result result) {
         results.remove(result);
         notifyDataSetChanged();
-        // Do not reset scroll, we want the remaining items to still be in vieww
+        // Do not reset scroll, we want the remaining items to still be in view
         parent.temporarilyDisableTranscriptMode();
     }
 

--- a/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
+++ b/app/src/main/java/fr/neamar/kiss/adapter/RecordAdapter.java
@@ -149,6 +149,14 @@ public class RecordAdapter extends BaseAdapter implements SectionIndexer {
         }
     }
 
+    /**
+     * Force set transcript mode on the list.
+     * Prefer to use `parent.temporarilyDisableTranscriptMode();`
+     */
+    public void updateTranscriptMode(int transcriptMode) {
+        parent.updateTranscriptMode(transcriptMode);
+    }
+
 
     public void clear() {
         this.results.clear();

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -18,6 +18,7 @@ import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.searcher.HistorySearcher;
 import fr.neamar.kiss.searcher.NullSearcher;
+import fr.neamar.kiss.searcher.Searcher;
 
 // Deals with any settings in the "User Experience" setting sub-screen
 class ExperienceTweaks extends Forwarder {
@@ -168,7 +169,7 @@ class ExperienceTweaks extends Forwarder {
         }
     }
 
-    void updateSearchRecords(String query) {
+    void updateSearchRecords(boolean isRefresh, String query) {
         if (query.isEmpty()) {
             if (isMinimalisticModeEnabled()) {
                 mainActivity.runTask(new NullSearcher(mainActivity));
@@ -179,7 +180,9 @@ class ExperienceTweaks extends Forwarder {
                     mainActivity.favoritesBar.setVisibility(View.GONE);
                 }
             } else {
-                mainActivity.runTask(new HistorySearcher(mainActivity));
+                Searcher searcher = new HistorySearcher(mainActivity);
+                searcher.setRefresh(isRefresh);
+                mainActivity.runTask(searcher);
             }
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
@@ -95,9 +95,9 @@ public class ForwarderManager extends Forwarder {
         favoritesForwarder.onDataSetChanged();
     }
 
-    public void updateSearchRecords(String query) {
+    public void updateSearchRecords(boolean isRefresh, String query) {
         favoritesForwarder.updateSearchRecords(query);
-        experienceTweaks.updateSearchRecords(query);
+        experienceTweaks.updateSearchRecords(isRefresh, query);
     }
 
     public void onFavoriteChange() {

--- a/app/src/main/java/fr/neamar/kiss/forwarder/TagsMenu.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/TagsMenu.java
@@ -12,21 +12,21 @@ import android.widget.ListAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-import androidx.annotation.LayoutRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.TagsHandler;
 import fr.neamar.kiss.dataprovider.simpleprovider.TagsProvider;
-import fr.neamar.kiss.pojo.TagDummyPojo;
 import fr.neamar.kiss.ui.ListPopup;
 
 /**
@@ -277,20 +277,17 @@ public class TagsMenu extends Forwarder {
                 }
             }
         });
-        popupMenu.setOnItemLongClickListener(new ListPopup.OnItemLongClickListener() {
-            @Override
-            public boolean onItemLongClick(ListAdapter adapter, View view, int position) {
-                Object adapterItem = adapter.getItem(position);
-                if (adapterItem instanceof TagsMenu.MenuItemTag) {
-                    TagsMenu.MenuItemTag item = (TagsMenu.MenuItemTag) adapterItem;
-                    String msg = mainActivity.getResources().getString(R.string.toast_favorites_added);
-                    KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(TagsProvider.generateUniqueId(item.tag));
-                    mainActivity.onFavoriteChange();
-                    Toast.makeText(mainActivity, String.format(msg, item.tag), Toast.LENGTH_SHORT).show();
-                    return true;
-                }
-                return false;
+        popupMenu.setOnItemLongClickListener((adapter1, view, position) -> {
+            Object adapterItem = adapter1.getItem(position);
+            if (adapterItem instanceof MenuItemTag) {
+                MenuItemTag item = (MenuItemTag) adapterItem;
+                String msg = mainActivity.getResources().getString(R.string.toast_favorites_added);
+                KissApplication.getApplication(mainActivity).getDataHandler().addToFavorites(TagsProvider.generateUniqueId(item.tag));
+                mainActivity.onFavoriteChange();
+                Toast.makeText(mainActivity, String.format(msg, item.tag), Toast.LENGTH_SHORT).show();
+                return true;
             }
+            return false;
         });
 
         popupMenu.show(anchor, 0f);

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -178,9 +178,7 @@ public class AppResult extends Result {
                             excludeFromHistory(context, appPojo, parent);
                             return true;
                         case EXCLUDE_KISS_ID:
-                            // remove item since it will be hidden
-                            parent.removeResult(context, AppResult.this);
-                            excludeFromKiss(context, appPojo);
+                            excludeFromKiss(context, appPojo, parent);
                             return true;
                     }
 
@@ -198,19 +196,18 @@ public class AppResult extends Result {
     }
 
     private void excludeFromHistory(Context context, AppPojo appPojo, final RecordAdapter parent) {
-        //add to excluded from history app list
-        KissApplication.getApplication(context).getDataHandler().addToExcludedFromHistory(appPojo);
-        //remove from history
-        deleteRecord(context);
-        //refresh current history
-        if (!((MainActivity) context).isViewingAllApps()) {
-            parent.removeResult(context, AppResult.this);
-        }
-        //inform user
+        // add to excluded from history app list
+         KissApplication.getApplication(context).getDataHandler().addToExcludedFromHistory(appPojo);
+        // remove from history
+        removeFromHistory(context);
+        // inform user
         Toast.makeText(context, R.string.excluded_app_history_added, Toast.LENGTH_LONG).show();
     }
 
-    private void excludeFromKiss(Context context, AppPojo appPojo) {
+    private void excludeFromKiss(Context context, AppPojo appPojo, final RecordAdapter parent) {
+        // remove item since it will be hidden
+        parent.removeResult(context, AppResult.this);
+
         KissApplication.getApplication(context).getDataHandler().addToExcluded(appPojo);
         // In case the newly excluded app was in a favorite, refresh them
         ((MainActivity) context).onFavoriteChange();

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -16,12 +16,13 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
+import android.widget.AbsListView;
 import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.MultiAutoCompleteTextView;
@@ -188,7 +189,7 @@ public class AppResult extends Result {
                 popupExcludeMenu.show();
                 return true;
             case R.string.menu_tags_edit:
-                launchEditTagsDialog(context, appPojo);
+                launchEditTagsDialog(context, parent, appPojo);
                 return true;
         }
 
@@ -214,7 +215,7 @@ public class AppResult extends Result {
         Toast.makeText(context, R.string.excluded_app_list_added, Toast.LENGTH_LONG).show();
     }
 
-    private void launchEditTagsDialog(final Context context, final AppPojo app) {
+    private void launchEditTagsDialog(final Context context, RecordAdapter parent, final AppPojo app) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setTitle(context.getResources().getString(R.string.tags_add_title));
 
@@ -225,7 +226,6 @@ public class AppResult extends Result {
                 android.R.layout.simple_dropdown_item_1line, KissApplication.getApplication(context).getDataHandler().getTagsHandler().getAllTagsAsArray());
         tagInput.setTokenizer(new SpaceTokenizer());
         tagInput.setText(appPojo.getTags());
-
         tagInput.setAdapter(adapter);
         builder.setView(v);
 
@@ -237,12 +237,32 @@ public class AppResult extends Result {
             // Show toast message
             String msg = context.getResources().getString(R.string.tags_confirmation_added);
             Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+            // We'll need to reset the list view to its previous transcript mode,
+            // but it has to happen *after* the keyboard is hidden, otherwise scroll will be reset
+            // Let's wait for half a second, that's ugly but we don't have any other option :(
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
+                }
+            }, 500);
         });
-        builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.cancel());
+        builder.setNegativeButton(android.R.string.cancel, (dialog, which) -> {
+            dialog.cancel();
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    // See comment above
+                    parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_ALWAYS_SCROLL);
+                }
+            }, 500);
 
+        });
+
+        parent.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_DISABLED);
         AlertDialog dialog = builder.create();
-        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
-
         dialog.show();
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -239,7 +239,7 @@ public abstract class Result {
     boolean popupMenuClickHandler(Context context, RecordAdapter parent, @StringRes int stringId, View parentView) {
         switch (stringId) {
             case R.string.menu_remove:
-                removeItem(context, parent);
+                removeFromResultsAndHistory(context, parent);
                 return true;
             case R.string.menu_favorites_add:
                 launchAddToFavorites(context, pojo);
@@ -252,6 +252,7 @@ public abstract class Result {
         MainActivity mainActivity = (MainActivity) context;
         // Update favorite bar
         mainActivity.onFavoriteChange();
+        mainActivity.launchOccurred();
         // Update Search to reflect favorite add, if the "exclude favorites" option is active
         if (mainActivity.prefs.getBoolean("exclude-favorites", false) && mainActivity.isViewingSearchResults()) {
             mainActivity.updateSearchRecords(true);
@@ -278,7 +279,8 @@ public abstract class Result {
      * @param context android context
      * @param parent  adapter on which to remove the item
      */
-    private void removeItem(Context context, RecordAdapter parent) {
+    private void removeFromResultsAndHistory(Context context, RecordAdapter parent) {
+        removeFromHistory(context);
         Toast.makeText(context, R.string.removed_item, Toast.LENGTH_SHORT).show();
         parent.removeResult(context, this);
     }
@@ -378,7 +380,7 @@ public abstract class Result {
         KissApplication.getApplication(context).getDataHandler().addToHistory(pojo.getHistoryId());
     }
 
-    public void deleteRecord(Context context) {
+    void removeFromHistory(Context context) {
         DBHelper.removeFromHistory(context, pojo.id);
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -250,11 +250,11 @@ public abstract class Result {
         }
 
         MainActivity mainActivity = (MainActivity) context;
-        //Update favorite bar
+        // Update favorite bar
         mainActivity.onFavoriteChange();
-        //Update Search to reflect favorite add, if the "exclude favorites" option is active
+        // Update Search to reflect favorite add, if the "exclude favorites" option is active
         if (mainActivity.prefs.getBoolean("exclude-favorites", false) && mainActivity.isViewingSearchResults()) {
-            mainActivity.updateSearchRecords();
+            mainActivity.updateSearchRecords(true);
         }
 
         return false;

--- a/app/src/main/java/fr/neamar/kiss/searcher/QueryInterface.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QueryInterface.java
@@ -4,6 +4,7 @@ import fr.neamar.kiss.ui.ListPopup;
 
 public interface QueryInterface {
     void temporarilyDisableTranscriptMode();
+    void updateTranscriptMode(int transcriptMode);
 
     void launchOccurred();
 

--- a/app/src/main/java/fr/neamar/kiss/searcher/QueryInterface.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QueryInterface.java
@@ -3,6 +3,8 @@ package fr.neamar.kiss.searcher;
 import fr.neamar.kiss.ui.ListPopup;
 
 public interface QueryInterface {
+    void updateTranscriptMode(int transcriptMode);
+
     void launchOccurred();
 
     void registerPopup(ListPopup popup);

--- a/app/src/main/java/fr/neamar/kiss/searcher/QueryInterface.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QueryInterface.java
@@ -3,7 +3,7 @@ package fr.neamar.kiss.searcher;
 import fr.neamar.kiss.ui.ListPopup;
 
 public interface QueryInterface {
-    void updateTranscriptMode(int transcriptMode);
+    void temporarilyDisableTranscriptMode();
 
     void launchOccurred();
 

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -105,11 +105,7 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
 
             activity.beforeListChange();
 
-            activity.adapter.updateResults(results, query);
-
-            if (!isRefresh) {
-                activity.list.setSelection(results.size() - 1);
-            }
+            activity.adapter.updateResults(results, isRefresh, query);
 
             activity.afterListChange();
         }

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -27,6 +27,11 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
     final WeakReference<MainActivity> activityWeakReference;
     private final PriorityQueue<Pojo> processedPojos;
     private long start;
+    /**
+     * Set to true when we are simply refreshing current results (scroll will not be reset)
+     * When false, we reset the scroll back to the last item in the list
+     */
+    private boolean isRefresh = false;
     protected final String query;
 
     Searcher(MainActivity activity, String query) {
@@ -102,6 +107,10 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
 
             activity.adapter.updateResults(results, query);
 
+            if (!isRefresh) {
+                activity.list.setSelection(results.size() - 1);
+            }
+
             activity.afterListChange();
         }
 
@@ -109,5 +118,9 @@ public abstract class Searcher extends AsyncTask<Void, Result, Void> {
 
         long time = System.currentTimeMillis() - start;
         Log.v("Timing", "Time to run query `" + query + "` on " + getClass().getSimpleName() + " to completion: " + time + "ms");
+    }
+
+    public void setRefresh(boolean refresh) {
+        isRefresh = refresh;
     }
 }

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -45,6 +45,7 @@
             android:divider="?attr/dividerDrawable"
             android:dividerHeight="1dp"
             android:stackFromBottom="true"
+            android:transcriptMode="alwaysScroll"
             tools:listitem="@layout/item_app" />
 
         <fr.neamar.kiss.ui.BottomPullEffectView

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -45,7 +45,6 @@
             android:divider="?attr/dividerDrawable"
             android:dividerHeight="1dp"
             android:stackFromBottom="true"
-            android:transcriptMode="alwaysScroll"
             tools:listitem="@layout/item_app" />
 
         <fr.neamar.kiss.ui.BottomPullEffectView


### PR DESCRIPTION
See #1214, #1036, #1244, #1205, and #1303 which are all related to this.

This issue was caused by the use of transcriptMode=alwaysScroll on the
listView XML.

More details:
https://developer.android.com/reference/android/widget/AbsListView.html#attr_android:transcriptMode

This value, however, can't just be removed as this would create other
bugs, so I implemented a fix where we temporarily disable the transcript
mode when we need to refresh an existing result set.

Fun fact: this "bug" has been in KISS for 8 years, it was introduced the very first time I inverted the UI (to get the search bar to the bottom, it used to be at the top): https://github.com/Neamar/KISS/commit/9ac0c08955a25f5813485a618036904a06714a26

It looked like this:
![image](https://user-images.githubusercontent.com/536844/74602414-753ed000-50a8-11ea-948f-0c83a5d3cc02.png)

Fix #1036 
Fix #1205 
Fix #1244
Fix #1303 