### PR TITLE
Do not display favorites for a couple frames when showing apps

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -155,12 +155,8 @@ class ExperienceTweaks extends Forwarder {
     }
 
     void onDisplayKissBar(Boolean display) {
-        if (isMinimalisticModeEnabledForFavorites()) {
-            if (display) {
-                mainActivity.favoritesBar.setVisibility(View.VISIBLE);
-            } else {
-                mainActivity.favoritesBar.setVisibility(View.GONE);
-            }
+        if (isMinimalisticModeEnabledForFavorites() && !display) {
+            mainActivity.favoritesBar.setVisibility(View.GONE);
         }
 
         if (!display && isKeyboardOnStartEnabled()) {


### PR DESCRIPTION
This was a bug, the favorite bar should not be set to visible when running onDisplayKissBar()

Fix #1362


<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->