### PR TITLE
Display ripple animation on favorite click

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -55,7 +55,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         ViewHolder(@NonNull Result result, @NonNull Pojo pojo, @NonNull Context context, @NonNull ViewGroup parent) {
             this.result = result;
             this.pojo = pojo;
-            view = result.inflateFavorite(context, null, parent);
+            view = result.inflateFavorite(context, parent);
             view.setTag(this);
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.ContactsContract;
@@ -15,7 +14,6 @@ import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
@@ -25,10 +23,8 @@ import java.util.ArrayList;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
-import fr.neamar.kiss.UIColors;
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.notification.NotificationListener;
-import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.result.Result;
 import fr.neamar.kiss.ui.ListPopup;
@@ -113,7 +109,18 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         return null;
     }
 
+    private boolean isDone = false;
+
     void onFavoriteChange() {
+        ArrayList<Pojo> favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler().getFavorites();
+        favCount = favoritesPojo.size();
+
+        if(!isDone && favCount > 0) {
+            Pojo favoritePojo = favoritesPojo.get(0);
+            ViewHolder vh = new ViewHolder(Result.fromPojo(mainActivity, favoritePojo), favoritePojo, mainActivity, mainActivity.favoritesBar);
+            mainActivity.favoritesBar.addView(vh.view);
+        }
+        /*
         ArrayList<Pojo> favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler().getFavorites();
 
         favCount = favoritesPojo.size();
@@ -173,6 +180,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         // kepp viewholders in memory for future recycling
         favoritesViews = holders;
         mDragEnabled = favCount > 1;
+         */
     }
 
     void updateSearchRecords(String query) {

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -192,7 +192,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
     @Override
     public void onClick(View v) {
         ViewHolder viewHolder = (ViewHolder) v.getTag();
-        // viewHolder.result.fastLaunch(mainActivity, v);
+        viewHolder.result.fastLaunch(mainActivity, v);
         v.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
 
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.ContactsContract;
@@ -14,6 +15,7 @@ import android.view.HapticFeedbackConstants;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
@@ -23,8 +25,10 @@ import java.util.ArrayList;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
+import fr.neamar.kiss.UIColors;
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.notification.NotificationListener;
+import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.result.Result;
 import fr.neamar.kiss.ui.ListPopup;
@@ -109,20 +113,8 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         return null;
     }
 
-    private boolean isDone = false;
-
     void onFavoriteChange() {
         ArrayList<Pojo> favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler().getFavorites();
-        favCount = favoritesPojo.size();
-
-        if(!isDone && favCount > 0) {
-            Pojo favoritePojo = favoritesPojo.get(0);
-            ViewHolder vh = new ViewHolder(Result.fromPojo(mainActivity, favoritePojo), favoritePojo, mainActivity, mainActivity.favoritesBar);
-            mainActivity.favoritesBar.addView(vh.view);
-        }
-        /*
-        ArrayList<Pojo> favoritesPojo = KissApplication.getApplication(mainActivity).getDataHandler().getFavorites();
-
         favCount = favoritesPojo.size();
 
         ArrayList<ViewHolder> holders = new ArrayList<>(favCount);
@@ -180,7 +172,6 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         // kepp viewholders in memory for future recycling
         favoritesViews = holders;
         mDragEnabled = favCount > 1;
-         */
     }
 
     void updateSearchRecords(String query) {
@@ -201,7 +192,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
     @Override
     public void onClick(View v) {
         ViewHolder viewHolder = (ViewHolder) v.getTag();
-        viewHolder.result.fastLaunch(mainActivity, v);
+        // viewHolder.result.fastLaunch(mainActivity, v);
         v.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP);
 
     }
@@ -224,11 +215,11 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         if (motionEvent.getAction() == MotionEvent.ACTION_DOWN) {
             startTime = motionEvent.getEventTime();
             contextMenuShown = false;
-            return true;
+            return false;
         }
-        // No need to do the extra work
+        // No need to do any extra work while dragging
         if (isDragging) {
-            return true;
+            return false;
         }
 
         // Click handlers first
@@ -237,8 +228,9 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
         int LONG_PRESS_DELAY = 250;
         if (holdTime < LONG_PRESS_DELAY && motionEvent.getAction() == MotionEvent.ACTION_UP) {
             this.onClick(view);
+
             view.performClick();
-            return true;
+            return false;
         }
 
         if (holdTime > LONG_PRESS_DELAY) {
@@ -276,7 +268,7 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
 
                 contextMenuShown = true;
                 this.onLongClick(view);
-                return true;
+                return false;
             }
         }
 

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -23,7 +23,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -213,13 +212,13 @@ public class ContactsResult extends Result {
 
     @NonNull
     @Override
-    public View inflateFavorite(@NonNull Context context, @Nullable View favoriteView, @NonNull ViewGroup parent) {
+    public View inflateFavorite(@NonNull Context context, @NonNull ViewGroup parent) {
         Drawable drawable = getDrawable(context);
         if ( drawable != null ) {
             Bitmap iconBitmap = drawableToBitmap(drawable);
             drawable = new RoundedQuickContactBadge.RoundedDrawable(iconBitmap);
         }
-        favoriteView = super.inflateFavorite(context, favoriteView, parent);
+        View favoriteView = super.inflateFavorite(context, parent);
         ImageView favoriteImage = favoriteView.findViewById(R.id.favorite);
         favoriteImage.setImageDrawable(drawable);
         return favoriteView;

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -22,7 +22,6 @@ import android.widget.Toast;
 
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import java.lang.ref.WeakReference;
@@ -101,9 +100,8 @@ public abstract class Result {
     public abstract View display(Context context, View convertView, @NonNull ViewGroup parent, FuzzyScore fuzzyScore);
 
     @NonNull
-    public View inflateFavorite(@NonNull Context context, @Nullable View favoriteView, @NonNull ViewGroup parent) {
-        if (favoriteView == null)
-            favoriteView = LayoutInflater.from(context).inflate(R.layout.favorite_item, parent, false);
+    public View inflateFavorite(@NonNull Context context, @NonNull ViewGroup parent) {
+        View favoriteView = LayoutInflater.from(context).inflate(R.layout.favorite_item, parent, false);
         Drawable drawable = getDrawable(context);
         ImageView favoriteImage = favoriteView.findViewById(R.id.favorite);
         if (drawable == null)

--- a/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
@@ -24,7 +24,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
@@ -152,9 +151,8 @@ public class TagDummyResult extends Result {
 
     @NonNull
     @Override
-    public View inflateFavorite(@NonNull Context context, @Nullable View favoriteView, @NonNull ViewGroup parent) {
-        if (favoriteView == null)
-            favoriteView = LayoutInflater.from(context).inflate(R.layout.favorite_tag, parent, false);
+    public View inflateFavorite(@NonNull Context context, @NonNull ViewGroup parent) {
+        View favoriteView = LayoutInflater.from(context).inflate(R.layout.favorite_tag, parent, false);
         ImageView favoriteIcon = favoriteView.findViewById(android.R.id.background);
         TextView favoriteText = favoriteView.findViewById(android.R.id.text1);
 

--- a/app/src/main/res/layout/favorite_item.xml
+++ b/app/src/main/res/layout/favorite_item.xml
@@ -4,6 +4,8 @@
     android:layout_width="0px"
     android:layout_height="match_parent"
     android:layout_weight="1"
+    android:clickable="true"
+    android:focusable="true"
     android:background="?attr/appSelectableItemBackground"
     android:padding="@dimen/favorite_padding"
     tools:layout_width="match_parent">
@@ -14,7 +16,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:contentDescription="@null"
-        tools:src="@drawable/ic_contact" />
+        android:src="@drawable/ic_contact" />
 
     <ImageView
         android:id="@+id/item_notification_dot"

--- a/app/src/main/res/layout/favorite_item.xml
+++ b/app/src/main/res/layout/favorite_item.xml
@@ -16,7 +16,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:contentDescription="@null"
-        android:src="@drawable/ic_contact" />
+        tools:src="@drawable/ic_contact" />
 
     <ImageView
         android:id="@+id/item_notification_dot"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -73,15 +73,7 @@
         android:gravity="center_vertical"
         android:importantForAccessibility="no"
         android:orientation="horizontal"
-        tools:ignore="UnusedAttribute">
-
-        <include
-            layout="@layout/favorite_item"
-            android:layout_width="0px"
-            android:layout_height="match_parent"
-            android:layout_weight="1" />
-
-    </LinearLayout>
+        tools:ignore="UnusedAttribute" />
 
     <RelativeLayout
         android:id="@+id/searchEditLayout"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -68,6 +68,7 @@
         android:background="?attr/searchBackgroundColor"
         android:clipToPadding="false"
         android:elevation="2dp"
+        android:baselineAligned="false"
         android:focusableInTouchMode="true"
         android:gravity="center_vertical"
         android:importantForAccessibility="no"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -66,15 +66,22 @@
         android:layout_marginBottom="10dp"
         android:animateLayoutChanges="true"
         android:background="?attr/searchBackgroundColor"
+        android:baselineAligned="false"
         android:clipToPadding="false"
         android:elevation="2dp"
-        android:baselineAligned="false"
         android:focusableInTouchMode="true"
         android:gravity="center_vertical"
         android:importantForAccessibility="no"
         android:orientation="horizontal"
-        tools:ignore="UnusedAttribute"
-        tools:layout="@layout/favorite_item" />
+        tools:ignore="UnusedAttribute">
+
+        <include
+            layout="@layout/favorite_item"
+            android:layout_width="0px"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+
+    </LinearLayout>
 
     <RelativeLayout
         android:id="@+id/searchEditLayout"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -73,7 +73,8 @@
         android:gravity="center_vertical"
         android:importantForAccessibility="no"
         android:orientation="horizontal"
-        tools:ignore="UnusedAttribute" />
+        tools:ignore="UnusedAttribute"
+        tools:layout="@layout/favorite_item" />
 
     <RelativeLayout
         android:id="@+id/searchEditLayout"


### PR DESCRIPTION
Issue was caused by the use of setOnTouchListener(), which disables default animation.
You need to return false from onTouch() to get the default behavior, otherwise the touch event is 'consumed' and you won't see the animation.

You also need to mark the view as android:clickable, with the correct background type.

In the end, fix was easy, but hard to find.

Fix #989