### PR TITLE
fix widget LongClick listener

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -273,8 +273,8 @@ class Widgets extends Forwarder {
         });
         hostView.setLongClickable(true);
         hostView.setOnLongClickListener(v -> {
-            mainActivity.openContextMenu(hostView);
             widgetWithMenuCurrentlyDisplayed = hostView;
+            mainActivity.openContextMenu(hostView);
             return true;
         });
 


### PR DESCRIPTION
make sure we have a widget selected before opening the context menu
fix #1405