### PR TITLE
Revamp widget long press detection

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
@@ -3,40 +3,78 @@ package fr.neamar.kiss.ui;
 import android.appwidget.AppWidgetHostView;
 import android.content.Context;
 import android.view.MotionEvent;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
 
+/**
+ * Source: https://github.com/willli666/Android-Trebuchet-Launcher-Standalone/blob/master/src/com/cyanogenmod/trebuchet/LauncherAppWidgetHostView.java
+ */
 public class WidgetView extends AppWidgetHostView {
-
-    private OnLongClickListener longClick;
-    private long down;
+    private boolean mHasPerformedLongPress;
+    private CheckForLongPress mPendingCheckForLongPress;
 
     public WidgetView(Context context) {
         super(context);
     }
 
-    public WidgetView(Context context, int animationIn, int animationOut) {
-        super(context, animationIn, animationOut);
-    }
-
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        this.longClick = l;
-    }
-
-    @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        switch(ev.getAction() ) {
-            case MotionEvent.ACTION_DOWN:
-                down = System.currentTimeMillis();
+        // Consume any touch events for ourselves after longpress is triggered
+        if (mHasPerformedLongPress) {
+            mHasPerformedLongPress = false;
+            return true;
+        }
+
+        // Watch for longpress events at this level to make sure
+        // users can always pick up this widget
+        switch (ev.getAction()) {
+            case MotionEvent.ACTION_DOWN: {
+                postCheckForLongClick();
                 break;
-            case MotionEvent.ACTION_MOVE:
-                boolean upVal = System.currentTimeMillis() - down > 300L;
-                if( upVal ) {
-                    longClick.onLongClick( WidgetView.this );
-                    return true;
+            }
+
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                mHasPerformedLongPress = false;
+                if (mPendingCheckForLongPress != null) {
+                    removeCallbacks(mPendingCheckForLongPress);
                 }
                 break;
         }
 
+        // Otherwise continue letting touch events fall through to children
         return false;
+    }
+
+    class CheckForLongPress implements Runnable {
+        private int mOriginalWindowAttachCount;
+
+        public void run() {
+            if ((getParent() != null) && hasWindowFocus()
+                    && mOriginalWindowAttachCount == getWindowAttachCount()
+                    && !mHasPerformedLongPress) {
+                if (performLongClick()) {
+                    mHasPerformedLongPress = true;
+                }
+            }
+        }
+
+        void rememberWindowAttachCount() {
+            mOriginalWindowAttachCount = getWindowAttachCount();
+        }
+    }
+
+    private void postCheckForLongClick() {
+        mHasPerformedLongPress = false;
+
+        if (mPendingCheckForLongPress == null) {
+            mPendingCheckForLongPress = new CheckForLongPress();
+        }
+        mPendingCheckForLongPress.rememberWindowAttachCount();
+        postDelayed(mPendingCheckForLongPress, ViewConfiguration.getLongPressTimeout());
+    }
+
+    @Override
+    public int getDescendantFocusability() {
+        return ViewGroup.FOCUS_BLOCK_DESCENDANTS;
     }
 }


### PR DESCRIPTION
Widgets that do not capture clicks were not displaying the widget menu.
With this PR, all widgets should now properly display the context menu.

This also ensures that menu are displayed as PopupMenu, around the widget, allowing us to get rid of the currentlySelectedWidget attribute, and keeping the onOptionsItemSelected() function for MainActivity events only.

Fix #1411