### PR TITLE
Handle the adaptive icons (closes #777)

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Random;
 
 import fr.neamar.kiss.utils.UserHandle;
+import fr.neamar.kiss.utils.DrawableUtils;
 
 /**
  * Inspired from http://stackoverflow.com/questions/31490630/how-to-load-icon-from-icon-pack
@@ -95,7 +96,10 @@ public class IconsHandler {
         cacheClear();
 
         // system icons, nothing to do
-        if (iconsPackPackageName.equalsIgnoreCase("default")) {
+        if (iconsPackPackageName.equalsIgnoreCase("default")
+            || iconsPackPackageName.equalsIgnoreCase("squircle")
+            || iconsPackPackageName.equalsIgnoreCase("square")
+            || iconsPackPackageName.equalsIgnoreCase("circle")) {
             return;
         }
 
@@ -188,7 +192,17 @@ public class IconsHandler {
                 List<LauncherActivityInfo> icons = launcher.getActivityList(componentName.getPackageName(), userHandle.getRealHandle());
                 for (LauncherActivityInfo info : icons) {
                     if (info.getComponentName().equals(componentName)) {
-                        return info.getBadgedIcon(0);
+                        Drawable icon = info.getBadgedIcon(0);
+
+                        // Handle the adaptive icons
+                        if(iconsPackPackageName.equalsIgnoreCase("squircle") ||
+                            iconsPackPackageName.equalsIgnoreCase("square") ||
+                            iconsPackPackageName.equalsIgnoreCase("circle")) {
+                            return DrawableUtils.handleAdaptiveIcons(ctx, icon);
+                        }
+                        else {
+                            return icon;
+                        }
                     }
                 }
 
@@ -210,7 +224,10 @@ public class IconsHandler {
     @SuppressWarnings("CatchAndPrintStackTrace")
     public Drawable getDrawableIconForPackage(ComponentName componentName, UserHandle userHandle) {
         // system icons, nothing to do
-        if (iconsPackPackageName.equalsIgnoreCase("default")) {
+        if (iconsPackPackageName.equalsIgnoreCase("default")
+            || iconsPackPackageName.equalsIgnoreCase("squircle")
+            || iconsPackPackageName.equalsIgnoreCase("square")
+            || iconsPackPackageName.equalsIgnoreCase("circle")) {
             return this.getDefaultAppDrawable(componentName, userHandle);
         }
 

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -96,10 +96,7 @@ public class IconsHandler {
         cacheClear();
 
         // system icons, nothing to do
-        if (iconsPackPackageName.equalsIgnoreCase("default")
-            || iconsPackPackageName.equalsIgnoreCase("squircle")
-            || iconsPackPackageName.equalsIgnoreCase("square")
-            || iconsPackPackageName.equalsIgnoreCase("circle")) {
+        if (iconsPackPackageName.equalsIgnoreCase("default") || DrawableUtils.isIconsPackAdaptive(iconsPackPackageName)) {
             return;
         }
 
@@ -195,9 +192,7 @@ public class IconsHandler {
                         Drawable icon = info.getBadgedIcon(0);
 
                         // Handle the adaptive icons
-                        if(iconsPackPackageName.equalsIgnoreCase("squircle") ||
-                            iconsPackPackageName.equalsIgnoreCase("square") ||
-                            iconsPackPackageName.equalsIgnoreCase("circle")) {
+                        if(DrawableUtils.isIconsPackAdaptive(iconsPackPackageName)) {
                             return DrawableUtils.handleAdaptiveIcons(ctx, icon);
                         }
                         else {
@@ -224,10 +219,7 @@ public class IconsHandler {
     @SuppressWarnings("CatchAndPrintStackTrace")
     public Drawable getDrawableIconForPackage(ComponentName componentName, UserHandle userHandle) {
         // system icons, nothing to do
-        if (iconsPackPackageName.equalsIgnoreCase("default")
-            || iconsPackPackageName.equalsIgnoreCase("squircle")
-            || iconsPackPackageName.equalsIgnoreCase("square")
-            || iconsPackPackageName.equalsIgnoreCase("circle")) {
+        if (iconsPackPackageName.equalsIgnoreCase("default") || DrawableUtils.isIconsPackAdaptive(iconsPackPackageName)) {
             return this.getDefaultAppDrawable(componentName, userHandle);
         }
 

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -525,10 +525,10 @@ public class SettingsActivity extends PreferenceActivity implements
 
         // Give the choice of adaptive icons to compatible devices only
         if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            entries = new CharSequence[iph.getIconsPacks().size() + 4];
-            entryValues = new CharSequence[iph.getIconsPacks().size() + 4];
+            entries = new CharSequence[iph.getIconsPacks().size() + 5];
+            entryValues = new CharSequence[iph.getIconsPacks().size() + 5];
 
-            i = 3;
+            i = 4;
             entries[0] = this.getString(R.string.icons_pack_default_name);
             entryValues[0] = "default";
 
@@ -540,6 +540,9 @@ public class SettingsActivity extends PreferenceActivity implements
 
             entries[3] = this.getString(R.string.icons_pack_circle_name);
             entryValues[3] = "circle";
+
+            entries[4] = this.getString(R.string.icons_pack_teardrop_name);
+            entryValues[4] = "teardrop";
         } else {
             entries = new CharSequence[iph.getIconsPacks().size() + 1];
             entryValues = new CharSequence[iph.getIconsPacks().size() + 1];

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -523,6 +523,7 @@ public class SettingsActivity extends PreferenceActivity implements
         CharSequence[] entryValues;
         int i;
 
+        // Give the choice of adaptive icons to compatible devices only
         if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             entries = new CharSequence[iph.getIconsPacks().size() + 4];
             entryValues = new CharSequence[iph.getIconsPacks().size() + 4];

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -519,12 +519,35 @@ public class SettingsActivity extends PreferenceActivity implements
     private void setListPreferenceIconsPacksData(ListPreference lp) {
         IconsHandler iph = KissApplication.getApplication(this).getIconsHandler();
 
-        CharSequence[] entries = new CharSequence[iph.getIconsPacks().size() + 1];
-        CharSequence[] entryValues = new CharSequence[iph.getIconsPacks().size() + 1];
+        CharSequence[] entries;
+        CharSequence[] entryValues;
+        int i;
 
-        int i = 0;
-        entries[0] = this.getString(R.string.icons_pack_default_name);
-        entryValues[0] = "default";
+        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            entries = new CharSequence[iph.getIconsPacks().size() + 4];
+            entryValues = new CharSequence[iph.getIconsPacks().size() + 4];
+
+            i = 3;
+            entries[0] = this.getString(R.string.icons_pack_default_name);
+            entryValues[0] = "default";
+
+            entries[1] = this.getString(R.string.icons_pack_squircle_name);
+            entryValues[1] = "squircle";
+
+            entries[2] = this.getString(R.string.icons_pack_square_name);
+            entryValues[2] = "square";
+
+            entries[3] = this.getString(R.string.icons_pack_circle_name);
+            entryValues[3] = "circle";
+        } else {
+            entries = new CharSequence[iph.getIconsPacks().size() + 1];
+            entryValues = new CharSequence[iph.getIconsPacks().size() + 1];
+
+            i = 0;
+            entries[0] = this.getString(R.string.icons_pack_default_name);
+            entryValues[0] = "default";
+        }
+
         for (String packageIconsPack : iph.getIconsPacks().keySet()) {
             entries[++i] = iph.getIconsPacks().get(packageIconsPack);
             entryValues[i] = packageIconsPack;

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -313,6 +313,7 @@ public class DBHelper {
         return records;
     }
 
+    /* TODELETE */
     public static byte[] getShortcutIcon(Context context, int dbId) {
         SQLiteDatabase db = getDatabase(context);
 
@@ -327,6 +328,7 @@ public class DBHelper {
         cursor.close();
         return iconBlob;
     }
+    /* TODELETE */
 
     /**
      * Remove shortcuts for a given package name

--- a/app/src/main/java/fr/neamar/kiss/pojo/ShortcutPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/ShortcutPojo.java
@@ -36,6 +36,7 @@ public final class ShortcutPojo extends PojoWithTags {
         return intentUri.replace(ShortcutPojo.OREO_PREFIX, "");
     }
 
+    /* TODELETE */
     public Bitmap getIcon(Context context) {
         byte[] iconBlob = DBHelper.getShortcutIcon(context, this.dbId);
 
@@ -45,4 +46,5 @@ public final class ShortcutPojo extends PojoWithTags {
 
         return BitmapFactory.decodeByteArray(iconBlob, 0, iconBlob.length);
     }
+    /* TODELETE */
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -215,8 +215,9 @@ public class ContactsResult extends Result {
     public View inflateFavorite(@NonNull Context context, @NonNull ViewGroup parent) {
         Drawable drawable = getDrawable(context);
         if ( drawable != null ) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             Bitmap iconBitmap = drawableToBitmap(drawable);
-            drawable = new RoundedQuickContactBadge.RoundedDrawable(iconBitmap);
+            drawable = new RoundedQuickContactBadge.RoundedDrawable(iconBitmap, prefs.getString("icons-pack", "default"));
         }
         View favoriteView = super.inflateFavorite(context, parent);
         ImageView favoriteImage = favoriteView.findViewById(R.id.favorite);

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -47,7 +47,6 @@ import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
 
-
 public class ShortcutsResult extends Result {
     private final ShortcutPojo shortcutPojo;
 
@@ -113,15 +112,21 @@ public class ShortcutsResult extends Result {
             return view;
         }
 
-
         if (!prefs.getBoolean("icons-hide", false)) {
             Drawable shortcutDrawable = getDrawable(context);
+            String iconsPack = prefs.getString("icons-pack", "default");
+            if(DrawableUtils.isIconsPackAdaptive(iconsPack)) {
+                appDrawable = DrawableUtils.handleAdaptiveIcons(context, appDrawable);
+                if(shortcutDrawable != null) {
+                    shortcutDrawable = DrawableUtils.handleAdaptiveIcons(context, shortcutDrawable);
+                }
+            }
             if (shortcutDrawable != null) {
-                shortcutIcon.setImageDrawable(DrawableUtils.handleAdaptiveIcons(context, shortcutDrawable));
-                appIcon.setImageDrawable(DrawableUtils.handleAdaptiveIcons(context, appDrawable));
+                shortcutIcon.setImageDrawable(shortcutDrawable);
+                appIcon.setImageDrawable(appDrawable);
             } else {
                 // No icon for this shortcut, use app icon
-                shortcutIcon.setImageDrawable(DrawableUtils.handleAdaptiveIcons(context, appDrawable));
+                shortcutIcon.setImageDrawable(appDrawable);
                 appIcon.setImageResource(android.R.drawable.ic_menu_send);
             }
         }
@@ -154,14 +159,6 @@ public class ShortcutsResult extends Result {
                         shortcutDrawable = launcherApps.getShortcutIconDrawable(shortcuts.get(0), 0);
                     }
                 }
-            }
-        }
-        if(shortcutDrawable != null) {
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-            String iconsPack = prefs.getString("icon-pack", "default");
-
-            if(DrawableUtils.isIconsPackAdaptive(iconsPack)) {
-                shortcutDrawable = DrawableUtils.handleAdaptiveIcons(context, shortcutDrawable);
             }
         }
 

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -41,6 +41,7 @@ import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.FuzzyScore;
 import fr.neamar.kiss.utils.SpaceTokenizer;
+import fr.neamar.kiss.utils.DrawableUtils;
 
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
@@ -115,11 +116,11 @@ public class ShortcutsResult extends Result {
             Bitmap icon = shortcutPojo.getIcon(context);
             if (icon != null) {
                 BitmapDrawable drawable = new BitmapDrawable(context.getResources(), icon);
-                shortcutIcon.setImageDrawable(drawable);
-                appIcon.setImageDrawable(appDrawable);
+                shortcutIcon.setImageDrawable(DrawableUtils.handleAdaptiveIcons(context, drawable));
+                appIcon.setImageDrawable(DrawableUtils.handleAdaptiveIcons(context, appDrawable));
             } else {
                 // No icon for this shortcut, use app icon
-                shortcutIcon.setImageDrawable(appDrawable);
+                shortcutIcon.setImageDrawable(DrawableUtils.handleAdaptiveIcons(context, appDrawable));
                 appIcon.setImageResource(android.R.drawable.ic_menu_send);
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/ui/GoogleCalendarIcon.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/GoogleCalendarIcon.java
@@ -29,10 +29,7 @@ public class GoogleCalendarIcon {
         // Do nothing if using a custom icon pack
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String currentIconPack = prefs.getString("icons-pack", "default");
-        if (!("default".equals(currentIconPack)
-              || "squircle".equals(currentIconPack)
-              || "square".equals(currentIconPack)
-              || "circle".equals(currentIconPack))) {
+        if (!("default".equals(currentIconPack) || DrawableUtils.isIconsPackAdaptive(currentIconPack))) {
             return null;
         }
 

--- a/app/src/main/java/fr/neamar/kiss/ui/GoogleCalendarIcon.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/GoogleCalendarIcon.java
@@ -14,6 +14,8 @@ import androidx.annotation.Nullable;
 
 import java.util.Calendar;
 
+import fr.neamar.kiss.utils.DrawableUtils;
+
 /**
  * This class is used to display a custom icon for Google Calendar
  * Every day, the icon is different and display the current day
@@ -27,7 +29,10 @@ public class GoogleCalendarIcon {
         // Do nothing if using a custom icon pack
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String currentIconPack = prefs.getString("icons-pack", "default");
-        if (!"default".equals(currentIconPack)) {
+        if (!("default".equals(currentIconPack)
+              || "squircle".equals(currentIconPack)
+              || "square".equals(currentIconPack)
+              || "circle".equals(currentIconPack))) {
             return null;
         }
 
@@ -39,7 +44,12 @@ public class GoogleCalendarIcon {
             Resources resourcesForApplication = pm.getResourcesForApplication(GOOGLE_CALENDAR);
             int dayResId = getDayResId(metaData, resourcesForApplication);
             if (dayResId != 0) {
-                return resourcesForApplication.getDrawable(dayResId);
+                Drawable icon = resourcesForApplication.getDrawable(dayResId);
+                if("default".equals(currentIconPack)){
+                    return icon;
+                } else {
+                    return DrawableUtils.handleAdaptiveIcons(context, icon);
+                }
             }
         } catch (PackageManager.NameNotFoundException ignored) {
         }

--- a/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss.ui;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
@@ -17,6 +18,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
 import android.widget.QuickContactBadge;
+import android.preference.PreferenceManager;
+
+import fr.neamar.kiss.utils.DrawableUtils;
 
 /**
  * A rounded version of {@link QuickContactBadge]
@@ -24,17 +28,21 @@ import android.widget.QuickContactBadge;
  * @author kishu27 (http://linkd.in/1laN852)
  */
 public class RoundedQuickContactBadge extends QuickContactBadge {
+    private static Context ctx;
 
     public RoundedQuickContactBadge(Context context) {
         super(context);
+        this.ctx = context;
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs) {
         super(context, attrs);
+        this.ctx = context;
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        this.ctx = context;
     }
 
     public static class RoundedDrawable extends Drawable {
@@ -81,7 +89,15 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
         @Override
         public void draw(@NonNull Canvas canvas) {
             float radius = mDisplayBounds.height() * 0.5f;
-            canvas.drawCircle(mDisplayBounds.centerX(), mDisplayBounds.centerY(), radius, mPaint);
+
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+            String iconsPack = prefs.getString("icons-pack", "default");
+
+            if(DrawableUtils.isIconsPackAdaptive(iconsPack)) {
+                DrawableUtils.setIconShape(canvas, mPaint, iconsPack);
+            } else {
+                canvas.drawCircle(mDisplayBounds.centerX(), mDisplayBounds.centerY(), radius, mPaint);
+            }
         }
 
         @Override

--- a/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/RoundedQuickContactBadge.java
@@ -28,21 +28,24 @@ import fr.neamar.kiss.utils.DrawableUtils;
  * @author kishu27 (http://linkd.in/1laN852)
  */
 public class RoundedQuickContactBadge extends QuickContactBadge {
-    private static Context ctx;
+    private final String iconsPack;
 
     public RoundedQuickContactBadge(Context context) {
         super(context);
-        this.ctx = context;
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        iconsPack = prefs.getString("icons-pack", "default");
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs) {
         super(context, attrs);
-        this.ctx = context;
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        iconsPack = prefs.getString("icons-pack", "default");
     }
 
     public RoundedQuickContactBadge(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        this.ctx = context;
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        iconsPack = prefs.getString("icons-pack", "default");
     }
 
     public static class RoundedDrawable extends Drawable {
@@ -51,8 +54,9 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
         private final BitmapShader mBitmapShader;
         private final RectF mBitmapRect;
         private final RectF mDisplayBounds;
+        private final String mIconsPack;
 
-        public RoundedDrawable(Bitmap bitmap) {
+        public RoundedDrawable(Bitmap bitmap, String iconsPack) {
             mBitmapShader = new BitmapShader(bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
 
             mPaint = new Paint();
@@ -62,6 +66,8 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
             mBitmapRect = new RectF(0, 0, bitmap.getWidth(), bitmap.getHeight());
             mDisplayBounds = new RectF();
             mDisplayBounds.set(mBitmapRect);
+
+            mIconsPack = iconsPack;
         }
 
         @Override
@@ -90,11 +96,8 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
         public void draw(@NonNull Canvas canvas) {
             float radius = mDisplayBounds.height() * 0.5f;
 
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
-            String iconsPack = prefs.getString("icons-pack", "default");
-
-            if(DrawableUtils.isIconsPackAdaptive(iconsPack)) {
-                DrawableUtils.setIconShape(canvas, mPaint, iconsPack);
+            if(DrawableUtils.isIconsPackAdaptive(mIconsPack)) {
+                DrawableUtils.setIconShape(canvas, mPaint, mIconsPack);
             } else {
                 canvas.drawCircle(mDisplayBounds.centerX(), mDisplayBounds.centerY(), radius, mPaint);
             }
@@ -121,7 +124,7 @@ public class RoundedQuickContactBadge extends QuickContactBadge {
     public void setImageDrawable(@Nullable Drawable drawable) {
         if (drawable instanceof BitmapDrawable) {
             Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
-            drawable = new RoundedDrawable(bitmap);
+            drawable = new RoundedDrawable(bitmap, iconsPack);
         }
         super.setImageDrawable(drawable);
     }

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -68,12 +68,20 @@ public class DrawableUtils {
             Bitmap iconBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
             Canvas iconCanvas = new Canvas(iconBitmap);
 
-            // Stretch adaptive layers because they are 108dp and the icon size is 48dp
-            bgDrawable.setBounds(-layerOffset, -layerOffset, iconSize+layerOffset, iconSize+layerOffset);
-            bgDrawable.draw(iconCanvas);
+            if(bgDrawable != null) {
+                // Stretch adaptive layers because they are 108dp and the icon size is 48dp
+                bgDrawable.setBounds(-layerOffset, -layerOffset, iconSize+layerOffset, iconSize+layerOffset);
+                bgDrawable.draw(iconCanvas);
+            } else {
+                Paint iconPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                iconPaint.setARGB(255,0,0,0);
+                iconCanvas.drawPaint(iconPaint);
+            }
 
-            fgDrawable.setBounds(-layerOffset, -layerOffset, iconSize+layerOffset, iconSize+layerOffset);
-            fgDrawable.draw(iconCanvas);
+            if(fgDrawable != null) {
+                fgDrawable.setBounds(-layerOffset, -layerOffset, iconSize+layerOffset, iconSize+layerOffset);
+                fgDrawable.draw(iconCanvas);
+            }
 
             outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
             outputCanvas = new Canvas(outputBitmap);

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -92,20 +92,32 @@ public class DrawableUtils {
         }
         // If icon is not adaptive, put it in a white canvas to make it have a unified shape
         else {
-            int iconSize = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, ctx.getResources().getDisplayMetrics()));
+            if(icon != null) {
+                // Shrink icon to 70% of its size so that it fits the shape
+                int iconSize = Math.round(1.42f*icon.getIntrinsicHeight());
+                int iconOffset = Math.round(0.21f*icon.getIntrinsicHeight());
 
-            outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
-            outputCanvas = new Canvas(outputBitmap);
-            outputPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-            outputPaint.setARGB(255,255,255,255);
+                outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
+                outputCanvas = new Canvas(outputBitmap);
+                outputPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                outputPaint.setARGB(255,255,255,255);
 
-            // Shrink icon to 70% of its size so that it fits the shape
-            int topLeftCorner = Math.round(0.15f*iconSize);
-            int bottomRightCorner = Math.round(0.85f*iconSize);
-            icon.setBounds(topLeftCorner, topLeftCorner, bottomRightCorner, bottomRightCorner);
+                int topLeftCorner = iconOffset;
+                int bottomRightCorner = iconSize-iconOffset;
+                icon.setBounds(topLeftCorner, topLeftCorner, bottomRightCorner, bottomRightCorner);
 
-            setIconShape(outputCanvas, outputPaint, iconsPackName);
-            icon.draw(outputCanvas);
+                setIconShape(outputCanvas, outputPaint, iconsPackName);
+                icon.draw(outputCanvas);
+            } else {
+                int iconSize = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, ctx.getResources().getDisplayMetrics()));
+
+                outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
+                outputCanvas = new Canvas(outputBitmap);
+                outputPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                outputPaint.setARGB(255,0,0,0);
+
+                setIconShape(outputCanvas, outputPaint, iconsPackName);
+            }
         }
         return new BitmapDrawable(ctx.getResources(), outputBitmap);
     }

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.utils;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
@@ -42,6 +43,10 @@ public class DrawableUtils {
         return bitmap;
     }
 
+    /**
+     * Handle adaptive icons for compatible devices
+     */
+    @SuppressLint("NewApi")
     public static Drawable handleAdaptiveIcons(Context ctx, Drawable icon) {
         Bitmap outputBitmap;
         Canvas outputCanvas;
@@ -97,7 +102,10 @@ public class DrawableUtils {
         return new BitmapDrawable(ctx.getResources(), outputBitmap);
     }
 
-    // Set the icon shape for adaptive icons
+    /**
+     * Set the shape of adaptive icons
+     */
+    @SuppressLint("NewApi")
     private static void setIconShape(Canvas canvas, Paint paint, String iconsPackName) {
         int iconSize = canvas.getHeight();
 

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -1,13 +1,23 @@
 package fr.neamar.kiss.utils;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
 import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Matrix;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.AdaptiveIconDrawable;
+import android.graphics.Shader.TileMode;
+import android.preference.PreferenceManager;
+import android.util.TypedValue;
 
 import androidx.annotation.NonNull;
 
-class DrawableUtils {
+public class DrawableUtils {
 
     // https://stackoverflow.com/questions/3035692/how-to-convert-a-drawable-to-a-bitmap
     static Bitmap drawableToBitmap(@NonNull Drawable drawable) {
@@ -32,4 +42,88 @@ class DrawableUtils {
         return bitmap;
     }
 
+    public static Drawable handleAdaptiveIcons(Context ctx, Drawable icon) {
+        Bitmap outputBitmap;
+        Canvas outputCanvas;
+        Paint outputPaint;
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
+        String iconsPackName = prefs.getString("icons-pack", "default");
+
+        if(icon instanceof AdaptiveIconDrawable) {
+            AdaptiveIconDrawable adaptiveIcon = (AdaptiveIconDrawable) icon;
+            Drawable bgDrawable = adaptiveIcon.getBackground();
+            Drawable fgDrawable = adaptiveIcon.getForeground();
+
+            int layerSize = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 108f, ctx.getResources().getDisplayMetrics()));
+            int iconSize = Math.round(layerSize / (1 + 2 * adaptiveIcon.getExtraInsetFraction()));
+            int layerOffset = (layerSize - iconSize) / 2;
+
+            // Create a bitmap of the icon to use it as the shader of the outputBitmap
+            Bitmap iconBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
+            Canvas iconCanvas = new Canvas(iconBitmap);
+
+            // Stretch adaptive layers because they are 108dp and the icon size is 48dp
+            bgDrawable.setBounds(-layerOffset, -layerOffset, iconSize+layerOffset, iconSize+layerOffset);
+            bgDrawable.draw(iconCanvas);
+
+            fgDrawable.setBounds(-layerOffset, -layerOffset, iconSize+layerOffset, iconSize+layerOffset);
+            fgDrawable.draw(iconCanvas);
+
+            outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
+            outputCanvas = new Canvas(outputBitmap);
+            outputPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            outputPaint.setShader(new BitmapShader(iconBitmap, TileMode.CLAMP, TileMode.CLAMP));
+
+            setIconShape(outputCanvas, outputPaint, iconsPackName);
+        }
+        // If icon is not adaptive, put it in a white canvas to make it have a unified shape
+        else {
+            int iconSize = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, ctx.getResources().getDisplayMetrics()));
+
+            outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
+            outputCanvas = new Canvas(outputBitmap);
+            outputPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            outputPaint.setARGB(255,255,255,255);
+
+            // Shrink icon to 70% of its size so that it fits the shape
+            int topLeftCorner = Math.round(0.15f*iconSize);
+            int bottomRightCorner = Math.round(0.85f*iconSize);
+            icon.setBounds(topLeftCorner, topLeftCorner, bottomRightCorner, bottomRightCorner);
+
+            setIconShape(outputCanvas, outputPaint, iconsPackName);
+            icon.draw(outputCanvas);
+        }
+        return new BitmapDrawable(ctx.getResources(), outputBitmap);
+    }
+
+    // Set the icon shape for adaptive icons
+    private static void setIconShape(Canvas canvas, Paint paint, String iconsPackName) {
+        int iconSize = canvas.getHeight();
+
+        if(iconsPackName.equalsIgnoreCase("squircle")) {
+            // |x|^n + |y|^n = |r|^n with n = 3
+            int radius = iconSize / 2;
+            double radiusToPow = radius * radius * radius;
+
+            Path path = new Path();
+            path.moveTo(-radius, 0);
+            for (int x = -radius ; x <= radius ; x++)
+                path.lineTo(x, ((float) Math.cbrt(radiusToPow - Math.abs(x * x * x))));
+            for (int x = radius ; x >= -radius ; x--)
+                path.lineTo(x, ((float) -Math.cbrt(radiusToPow - Math.abs(x * x * x))));
+            path.close();
+
+            Matrix matrix = new Matrix();
+            matrix.postTranslate(radius, radius);
+            path.transform(matrix);
+
+            canvas.drawPath(path, paint);
+        } else if(iconsPackName.equalsIgnoreCase("square")) {
+            canvas.drawRoundRect(0f, 0f, iconSize, iconSize, iconSize/8, iconSize/12, paint);
+        } else if(iconsPackName.equalsIgnoreCase("circle")) {
+            int radius = iconSize / 2;
+            canvas.drawCircle(radius, radius, radius, paint);
+        }
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -106,7 +106,7 @@ public class DrawableUtils {
      * Set the shape of adaptive icons
      */
     @SuppressLint("NewApi")
-    private static void setIconShape(Canvas canvas, Paint paint, String iconsPackName) {
+    public static void setIconShape(Canvas canvas, Paint paint, String iconsPackName) {
         int iconSize = canvas.getHeight();
 
         if(iconsPackName.equalsIgnoreCase("squircle")) {
@@ -132,6 +132,21 @@ public class DrawableUtils {
         } else if(iconsPackName.equalsIgnoreCase("circle")) {
             int radius = iconSize / 2;
             canvas.drawCircle(radius, radius, radius, paint);
+        } else if(iconsPackName.equalsIgnoreCase("teardrop")) {
+            Path path = new Path();
+            path.addArc(0, 0, iconSize, iconSize, 90, 270);
+            path.lineTo(iconSize, iconSize*0.70f);
+            path.arcTo(iconSize*0.70f, iconSize*0.70f, iconSize, iconSize, 0, 90, false);
+            path.close();
+
+            canvas.drawPath(path, paint);
         }
+    }
+
+    public static boolean isIconsPackAdaptive(String iconsPack) {
+        return (iconsPack.equalsIgnoreCase("squircle")
+                || iconsPack.equalsIgnoreCase("square")
+                || iconsPack.equalsIgnoreCase("circle")
+                || iconsPack.equalsIgnoreCase("teardrop"));
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
@@ -114,6 +114,7 @@ public class ShortcutUtil {
         record.packageName = shortcutInfo.getPackage();
         record.intentUri = ShortcutPojo.OREO_PREFIX + shortcutInfo.getId();
 
+        /* TODELETE */
         LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
         final Drawable iconDrawable = launcherApps.getShortcutIconDrawable(shortcutInfo, 0);
         Bitmap icon = iconDrawable == null ? null : DrawableUtils.drawableToBitmap(iconDrawable);
@@ -122,6 +123,7 @@ public class ShortcutUtil {
             icon.compress(Bitmap.CompressFormat.PNG, 100, baos);
             record.icon_blob = baos.toByteArray();
         }
+        /* TODELETE */
 
         String appName = getAppNameFromPackageName(context, shortcutInfo.getPackage());
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <string name="freeze_history_warn">Are you sure you want to freeze history and turn off further updates? Your history will not change anymore.</string>
     <string name="icons_pack_name">Icons (ADW.Launcher theme)</string>
     <string name="icons_pack_default_name">System icons</string>
+    <string name="icons_pack_squircle_name">Squircle</string>
+    <string name="icons_pack_square_name">Square</string>
+    <string name="icons_pack_circle_name">Circle</string>
     <string name="alias_phone">dial,call,phone</string>
     <string name="alias_contacts">contacts,people,relations</string>
     <string name="alias_web">Internet,web,browser</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="icons_pack_squircle_name">Squircle</string>
     <string name="icons_pack_square_name">Square</string>
     <string name="icons_pack_circle_name">Circle</string>
+    <string name="icons_pack_teardrop_name">Teardrop</string>
     <string name="alias_phone">dial,call,phone</string>
     <string name="alias_contacts">contacts,people,relations</string>
     <string name="alias_web">Internet,web,browser</string>


### PR DESCRIPTION
Hi!

I added an adaptive icon handler which gives the same shape to all the icons (as said in #777 ).
Animations and parallax are not implemented here.
Only compatible devices can access the feature (I had to add two @SuppressLint("NewApi")).
Applications which does not have an adaptive icon are put in a canvas with the same shape as the other icons, like some launchers do.
The proposed shapes are squircle (or superellipse/Lamé Curve), square (with soft edges) and circle:
<img src="https://user-images.githubusercontent.com/12786313/78694269-b14e1e80-78fc-11ea-9903-89561a0e48f4.png" width="33%"><img src="https://user-images.githubusercontent.com/12786313/78694228-a3989900-78fc-11ea-9f40-a252e64e5e61.png" width="33%"><img src="https://user-images.githubusercontent.com/12786313/78694250-aabfa700-78fc-11ea-852f-48ab482426a2.png" width="33%">

(The user, of course, still has the choice not to use the adaptive icons at all)

I put the code that manipulates the icon drawables in DrawableUtil (and thus made the class public), so that it can be used by the IconHandler but also by the GoogleCalendarIcon class.
The possibilities for adaptive icons in the settings are only shown to compatible devices.

I hope that you will like it! 

Fix #777