### PR TITLE
Add full word bonus to Fuzzy Score

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
+++ b/app/src/main/java/fr/neamar/kiss/normalizer/StringNormalizer.java
@@ -45,7 +45,7 @@ public class StringNormalizer {
             String decomposedCharString;
             // Is it within the basic latin range?
             // If so, we can skip the expensive call to Normalizer.normalize
-            if(codepoint < 'z') {
+            if(codepoint <= 'z') {
                 // Ascii range, no need to normalize!
                 // Add directly if it's not a dash
                 // (HYPHEN-MINUS is the only character before 'z' in one of the

--- a/app/src/test/java/fr/neamar/kiss/utils/FuzzyScoreTest.java
+++ b/app/src/test/java/fr/neamar/kiss/utils/FuzzyScoreTest.java
@@ -1,0 +1,59 @@
+package fr.neamar.kiss.utils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import fr.neamar.kiss.normalizer.StringNormalizer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class FuzzyScoreTest {
+    private static final int full_word_bonus = 1000000;
+    private static final int adjacency_bonus  = 100000;
+    private static final int separator_bonus  = 10000;
+    private static final int camel_bonus      = 1000;
+    private static final int leading_letter_penalty     = -100;
+    private static final int max_leading_letter_penalty = -300;
+    private static final int unmatched_letter_penalty   = -1;
+
+    @ParameterizedTest
+    @MethodSource("testProvider")
+    public void testOperations(String query, String testString, int result) {
+        StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
+        StringNormalizer.Result testStringNormalized = StringNormalizer.normalizeWithResult(testString, false);
+
+        assertThat(doFuzzy(queryNormalized.codePoints, testStringNormalized.codePoints), equalTo(result));
+    }
+
+    private static Stream<Arguments> testProvider() {
+        return Stream.of(
+                Arguments.of("no match", "some string", 0),
+                Arguments.of("yt", "YouTube", separator_bonus + camel_bonus + 5 * unmatched_letter_penalty),
+                Arguments.of("js", "js", full_word_bonus + adjacency_bonus + separator_bonus),
+
+                // Test full match start of word
+                Arguments.of("js", "js end", full_word_bonus + adjacency_bonus + separator_bonus + 4 * unmatched_letter_penalty),
+                // Test full match end of word
+                Arguments.of("js", "start js", full_word_bonus + adjacency_bonus + separator_bonus + 6 * unmatched_letter_penalty + max_leading_letter_penalty),
+
+                Arguments.of("js", "John Smith", 2 * separator_bonus + 8 * unmatched_letter_penalty),
+                Arguments.of("jsmith", "John Smith", 2 * separator_bonus + 4 * unmatched_letter_penalty + 4 * adjacency_bonus + full_word_bonus)
+        );
+    }
+
+    private Integer doFuzzy(int[] query, int[] testString) {
+        return new FuzzyScore(query, false)
+                .setFullWordBonus(full_word_bonus)
+                .setAdjacencyBonus(adjacency_bonus)
+                .setSeparatorBonus(separator_bonus)
+                .setCamelBonus(camel_bonus)
+                .setLeadingLetterPenalty(leading_letter_penalty)
+                .setMaxLeadingLetterPenalty(max_leading_letter_penalty)
+                .setUnmatchedLetterPenalty(unmatched_letter_penalty)
+                .match(testString).score;
+    }
+}


### PR DESCRIPTION
The motivation behind this is mainly short tags uses. These matches should
be ranked higher than fuzzy matches or part of word matches.
| Before | After |
|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot_1586710112](https://user-images.githubusercontent.com/1615426/79074710-3e72e800-7cee-11ea-811c-6f897541dee8.png) | ![Screenshot_1586710086](https://user-images.githubusercontent.com/1615426/79074711-3fa41500-7cee-11ea-80ab-054d19d588b6.png) |