### PR TITLE
Do not display context menu on scrolling widgets

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
@@ -12,23 +12,36 @@ import android.view.ViewGroup;
 public class WidgetView extends AppWidgetHostView {
     private boolean mHasPerformedLongPress;
     private CheckForLongPress mPendingCheckForLongPress;
+    private float xPos;
+    private float yPos;
 
     public WidgetView(Context context) {
         super(context);
     }
 
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        // Consume any touch events for ourselves after longpress is triggered
+        // Consume any touch events for ourselves after long press is triggered
         if (mHasPerformedLongPress) {
             mHasPerformedLongPress = false;
             return true;
         }
 
-        // Watch for longpress events at this level to make sure
+        // Watch for long press events at this level to make sure
         // users can always pick up this widget
         switch (ev.getAction()) {
             case MotionEvent.ACTION_DOWN: {
                 postCheckForLongClick();
+                xPos = ev.getX();
+                yPos = ev.getY();
+                break;
+            }
+            case MotionEvent.ACTION_MOVE: {
+                if(Math.abs(ev.getX() - xPos) > 5 || Math.abs(ev.getY() - yPos) > 5) {
+                    mHasPerformedLongPress = false;
+                    if (mPendingCheckForLongPress != null) {
+                        removeCallbacks(mPendingCheckForLongPress);
+                    }
+                }
                 break;
             }
 
@@ -71,6 +84,16 @@ public class WidgetView extends AppWidgetHostView {
         }
         mPendingCheckForLongPress.rememberWindowAttachCount();
         postDelayed(mPendingCheckForLongPress, ViewConfiguration.getLongPressTimeout());
+    }
+
+    @Override
+    public void cancelLongPress() {
+        super.cancelLongPress();
+
+        mHasPerformedLongPress = false;
+        if (mPendingCheckForLongPress != null) {
+            removeCallbacks(mPendingCheckForLongPress);
+        }
     }
 
     @Override


### PR DESCRIPTION
We need to check if the pointer moved since the initial touch. If it did move, then we should not display the context menu.

Fix #1442


<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->