### PR TITLE
Add a setting to disable double tap to lock

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -72,9 +72,23 @@ class ExperienceTweaks extends Forwarder {
 
         gd = new GestureDetector(mainActivity, new GestureDetector.SimpleOnGestureListener() {
             @Override
+            public boolean onSingleTapUp(MotionEvent e) {
+                // Double tap disabled: display history directly
+                if(!prefs.getBoolean("double-tap", false)) {
+                    if (prefs.getBoolean("history-onclick", false)) {
+                        doAction("display-history");
+                    }
+                }
+                return super.onSingleTapUp(e);
+            }
+
+            @Override
             public boolean onSingleTapConfirmed(MotionEvent e) {
-                if (prefs.getBoolean("history-onclick", false)) {
-                    doAction("display-history");
+                // Double tap enabled: wait to confirm this is indeed a single tap, not a double tap
+                if(prefs.getBoolean("double-tap", false)) {
+                    if (prefs.getBoolean("history-onclick", false)) {
+                        doAction("display-history");
+                    }
                 }
 
                 return super.onSingleTapConfirmed(e);
@@ -83,6 +97,9 @@ class ExperienceTweaks extends Forwarder {
             @Override
             public boolean onDoubleTap(MotionEvent e) {
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                    return super.onDoubleTap(e);
+                }
+                if(!prefs.getBoolean("double-tap", false)) {
                     return super.onDoubleTap(e);
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,4 +232,5 @@
     <string name="gesture_up_name">Action on swipe up</string>
     <string name="gesture_down_name">Action on swipe down</string>
     <string name="enable_double_tap_to_lock">To enable double-tap to lock, you\'ll need to grant additional permissions: enable KISS in the following screen.</string>
+    <string name="double_tap_to_lock">Double tap to lock screen</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -226,6 +226,10 @@
                 android:entryValues="@array/gestureValues"
                 android:key="gesture-down"
                 android:title="@string/gesture_down_name" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
+                android:key="double-tap"
+                android:title="@string/double_tap_to_lock" />
         </PreferenceCategory>
         <PreferenceScreen
             android:key="wallpaper-holder"
@@ -275,9 +279,7 @@
                 android:key="pref-toggle-tags-list"
                 android:title="@string/pref_toggle_tags_select" />
         </PreferenceScreen>
-
     </PreferenceScreen>
-
     <PreferenceScreen
         android:key="providers"
         android:summary="@string/providers_summary"


### PR DESCRIPTION
Allows us to display history super fast when the feature isn't enabled.