### PR TITLE
Added settings option to hide the edit text hint from the search bar

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -54,7 +54,7 @@ public class SettingsActivity extends PreferenceActivity implements
     private static final int PERMISSION_READ_PHONE_STATE = 1;
 
     // Those settings require the app to restart
-    final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide enable-favorites-bar notification-bar-color black-notification-icons theme-shadow theme-separator theme-result-color large-favorites-bar";
+    final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide enable-favorites-bar notification-bar-color black-notification-icons theme-shadow theme-separator theme-result-color large-favorites-bar pref-hide-search-bar-hint";
     // Those settings require a restart of the settings
     final static private String settingsRequiringRestartForSettingsActivity = "theme force-portrait";
     private boolean requireFullRestart = false;

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -85,6 +85,10 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.searchEditText.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
             }
         }
+
+        if (prefs.getBoolean("pref-hide-search-bar-hint", false)) {
+            mainActivity.searchEditText.setHint("");
+        }
     }
 
     void onResume() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="rounded_list">Rounded list corners</string>
     <string name="rounded_bars">Rounded bar corners</string>
     <string name="swap_kiss_button_with_menu">KISS button on the right</string>
+    <string name="hide_search_bar_hint">Remove hint text from search bar</string>
     <!-- Widget strings, preference ID should not be translated -->
     <string name="menu_widget_add">Add widget</string>
     <string name="menu_widget_remove">Remove widget</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -165,6 +165,10 @@
                 android:defaultValue="false"
                 android:key="pref-swap-kiss-button-with-menu"
                 android:title="@string/swap_kiss_button_with_menu" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
+                android:key="pref-hide-search-bar-hint"
+                android:title="@string/hide_search_bar_hint" />
         </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen


### PR DESCRIPTION
So the goal here is to be able to remove the text hint on the search bar with the search instructions. It is not necessary once you get used to the simple UI and detracts from a minimalist aesthetic approach. This is already acknowledged under the Minimalist UI option - which removes the hint - but I did not want to sacrifice the history list always visible just to lose the text. If this adds too much redundancy against the Minimalist UI option, I understand :+1: 