### PR TITLE
Add option to hide favorites from apps

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -500,10 +500,16 @@ public class DataHandler extends BroadcastReceiver
 
     @NonNull
     public Set<String> getExcluded() {
-        Set<String> excluded = PreferenceManager.getDefaultSharedPreferences(context).getStringSet("excluded-apps", null);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        Set<String> excluded = prefs.getStringSet("excluded-apps", null);
         if (excluded == null) {
             excluded = new HashSet<>();
             excluded.add(context.getPackageName());
+        }
+        boolean excludeFavorites = prefs.getBoolean("exclude-favorites-apps", false);
+        if (excludeFavorites) {
+            Set<String> favApps = new HashSet<String>(Arrays.asList(prefs.getString("favorite-apps-list", "").split(";")));
+            excluded.addAll(favApps);
         }
         return excluded;
     }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -252,7 +252,7 @@ public abstract class Result {
         mainActivity.onFavoriteChange();
         mainActivity.launchOccurred();
         // Update Search to reflect favorite add, if the "exclude favorites" option is active
-        if (mainActivity.prefs.getBoolean("exclude-favorites", false) && mainActivity.isViewingSearchResults()) {
+        if (mainActivity.prefs.getBoolean("exclude-favorites-history", false) && mainActivity.isViewingSearchResults()) {
             mainActivity.updateSearchRecords(true);
         }
 

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -39,7 +39,7 @@ public class HistorySearcher extends Searcher {
     protected Void doInBackground(Void... voids) {
         // Ask for records
         String historyMode = prefs.getString("history-mode", "recency");
-        boolean excludeFavorites = prefs.getBoolean("exclude-favorites", false);
+        boolean excludeFavorites = prefs.getBoolean("exclude-favorites-history", false);
 
         MainActivity activity = activityWeakReference.get();
         if (activity == null)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -93,7 +93,7 @@
     <string name="history_mode_desc">إختر طريقة ترتيب السجل</string>
     <string name="menu_shortcut_remove">أزل الإختصارات</string>
     <string name="enable_favorites_bar">أظهر التطبيقات المفضلة فوق شريط البحث</string>
-    <string name="exclude_favorites">إستبعاد التطبيقات المفضلة من البحث</string>
+    <string name="exclude_favorites_history">إستبعاد التطبيقات المفضلة من البحث</string>
     <string name="favorites_hide">إخفاء شريط التطبيقات المفضلة</string>
     <string name="settings_storage">التخزين</string>
     <string name="settings_dev">إعدادات المطور</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -88,7 +88,7 @@
     <string name="enable_phone">Показване на входящите повиквания в историята</string>
     <string name="enable_app">Показване на новоинсталираните приложение в историята</string>
     <string name="enable_favorites_bar">Показване на любими над полето за търсене</string>
-    <string name="exclude_favorites">Изключване на \"Предпочитани\" от историята</string>
+    <string name="exclude_favorites_history">Изключване на \"Предпочитани\" от историята</string>
     <string name="favorites_hide">Скрий лентата с предпочитани</string>
 
     <string name="restart_name">Рестартиране на KISS</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,7 +74,7 @@
     <string name="enable_app">Neu installierte Apps im Verlauf anzeigen</string>
     <string name="enable_favorites_bar">Favoriten über der Suchleiste anzeigen</string>
     <string name="favorites_hide">Favoritenleiste zunächst ausblenden</string>
-    <string name="exclude_favorites">Favoriten im Verlauf verstecken</string>
+    <string name="exclude_favorites_history">Favoriten im Verlauf verstecken</string>
     <string name="reset_favorites_name">Favoriten zurücksetzen</string>
     <string name="reset_favorites_warn">Wollen Sie wirklich alle Einträge aus der Favoritenleiste entfernen?</string>
     <string name="favorites_erased">Favoriten entfernt.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -78,7 +78,7 @@
     <string name="enable_app">Εμφάνιση πρόσφατα εγκατεστημένων εφαρμογών στο ιστορικό</string>
     <string name="restart_name">Επανεκκίνηση KISS</string>
     <string name="restart_warn">Επιθυμείτε να επανεκκινήσετε την εφαρμογή; Αν το KISS δεν είναι ο προεπιλεγμένος launcher, η εφαρμογή απλώς θα τερματίσει.</string>
-    <string name="exclude_favorites">Απόκρυψη αγαπημένων από το ιστορικό</string>
+    <string name="exclude_favorites_history">Απόκρυψη αγαπημένων από το ιστορικό</string>
     <string name="favorites_hide">Απόκρυψη γραμμής αγαπημένων</string>
     <string name="enable_favorites_bar">Εμφάνιση αγαπημένων πάνω από το πεδίο αναζήτησης</string>
     <string name="menu_shortcut_remove">Αφαίρεση συντόμευσης</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -89,7 +89,7 @@
     <string name="settings_tethering">Anclaje a red</string>
     <string name="menu_shortcut_remove">Eliminar atajo</string>
     <string name="enable_favorites_bar">Mostrar barra de favoritos</string>
-    <string name="exclude_favorites">Excluir favoritos del historial</string>
+    <string name="exclude_favorites_history">Excluir favoritos del historial</string>
     <string name="favorites_hide">Ocultar barra de favoritos al iniciar</string>
     <string name="restart_desc">Corregir problemas con el tema o con nuevos contactos no mostrados</string>
     <string name="restart_name">Reiniciar KISS</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -87,7 +87,7 @@
     <string name="pref_hide_navbar_desc">Ezkutatu nabigazio-barra eta aktibatu modu murgiltzailea</string>
     <string name="pref_hide_navbar">Ezkutatu nabigazio-barra</string>
     <string name="favorites_hide">Ezkutatu gogokoen barra hasieran</string>
-    <string name="exclude_favorites">Baztertu gogokoak historiatik</string>
+    <string name="exclude_favorites_history">Baztertu gogokoak historiatik</string>
     <string name="enable_favorites_bar">Erakutsi gogokoak bilaketa-barran</string>
     <string name="enable_app">Erakutsi berriki instalatutako aplikazioak historian</string>
     <string name="enable_phone">Erakutsi sarrerako deiak historian</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -127,7 +127,7 @@
     <string name="enable_phone">Näytä tulevat puhelut historiassa</string>
     <string name="enable_app">Näytä äskettäin asennetut sovellukset historiassa</string>
     <string name="enable_favorites_bar">Näytä suosikit hakupalkin yllä</string>
-    <string name="exclude_favorites">Poissulje suosikit historiasta</string>
+    <string name="exclude_favorites_history">Poissulje suosikit historiasta</string>
     <string name="favorites_hide">Piilota suosikkipalkki</string>
     <string name="pref_hide_navbar">Piilota navigointipalkki</string>
     <string name="pref_hide_navbar_desc">Piilota navigointipalkki ja ota käyttöön immersive-tila</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -93,7 +93,7 @@
     <string name="menu_exclude">Exclure l\'application…</string>
     <string name="menu_shortcut_remove">Supprimer le raccourci</string>
     <string name="enable_favorites_bar">Afficher les favoris au-dessus du champ de recherche</string>
-    <string name="exclude_favorites">Exclure les favoris de l’historique</string>
+    <string name="exclude_favorites_history">Exclure les favoris de l’historique</string>
     <string name="favorites_hide">Masquer la barre des favoris au départ</string>
     <string name="restart_desc">Corriger les problèmes de thème ou de non-affichage des nouveaux contacts</string>
     <string name="restart_warn">Voulez-vous vraiment redémarrer KISS ? Si KISS n’est pas votre écran d\'accueil par défaut, l’application quittera simplement.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -112,7 +112,7 @@
     <string name="enable_phone">Prikaži povijest dolaznih poziva</string>
     <string name="enable_app">Prikaži povijest novih aplikacija</string>
     <string name="enable_favorites_bar">Prikaži favorite iznad polja za pretraživanje</string>
-    <string name="exclude_favorites">Sakrij favorite iz povijesti</string>
+    <string name="exclude_favorites_history">Sakrij favorite iz povijesti</string>
     <string name="favorites_hide">Sakrij polje favorita</string>
 
     <string name="restart_desc">Popravi probleme teme / ne prikazivanje novih kontakata</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -219,6 +219,6 @@
     <string name="misc">Egyéb</string>
     <string name="settings_dev">Fejlesztői beállítások</string>
     <string name="settings_storage">Tárhely</string>
-    <string name="exclude_favorites">Kedvencek kizárása az előzményekből</string>
+    <string name="exclude_favorites_history">Kedvencek kizárása az előzményekből</string>
     <string name="enable_favorites_bar">Kedvencek megjelenítése a keresősáv felett</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -93,7 +93,7 @@
     <string name="history_mode_desc">Pilih bagaimana riwayat harus diurutkan</string>
     <string name="menu_shortcut_remove">Hapus pintasan</string>
     <string name="enable_favorites_bar">Tampilkan favorit di atas bilah pencarian</string>
-    <string name="exclude_favorites">Kecualikan favorit dari riwayat</string>
+    <string name="exclude_favorites_history">Kecualikan favorit dari riwayat</string>
     <string name="favorites_hide">Sembunyikan bilah favorit</string>
     <string name="settings_storage">Penyimpanan</string>
     <string name="settings_dev">Pengaturan pengembang</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -116,7 +116,7 @@
     <string name="enable_phone">Mostra Chiamate Ricevute</string>
     <string name="enable_app">Mostra App appena Installate</string>
     <string name="enable_favorites_bar">Mostra Preferiti sopra la Barra di Ricerca</string>
-    <string name="exclude_favorites">Escludi Preferiti dalla Cronologia</string>
+    <string name="exclude_favorites_history">Escludi Preferiti dalla Cronologia</string>
     <string name="favorites_hide">Nascondi Barra dei Preferiti all\'Avvio</string>
     <string name="pref_hide_navbar">Nascondi Barra di Navigazione</string>
     <string name="pref_hide_navbar_desc">Nascondi la Barra di Navigazione, attivando la Modalità a Schermo Intero</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -93,7 +93,7 @@
     <string name="history_mode_desc">履歴を保存する方法を選択します</string>
     <string name="menu_shortcut_remove">ショートカットを削除</string>
     <string name="enable_favorites_bar">検索バーの上にお気に入りを表示</string>
-    <string name="exclude_favorites">履歴からお気に入りを除外する</string>
+    <string name="exclude_favorites_history">履歴からお気に入りを除外する</string>
     <string name="favorites_hide">最初、お気に入りバーを非表示</string>
     <string name="settings_storage">ストレージ</string>
     <string name="settings_dev">開発者向けの設定</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -99,7 +99,7 @@
     <string name="enable_phone">Rodyti įeinančius skambučius istorijoje</string>
     <string name="enable_app">Rodyti neseniai instaliuotas programėles istorijoje</string>
     <string name="enable_favorites_bar">Rodyti mėgiamiausius virš paieškos laukelio</string>
-    <string name="exclude_favorites">Neįtraukti mėgiamisuiųjų į istoriją</string>
+    <string name="exclude_favorites_history">Neįtraukti mėgiamisuiųjų į istoriją</string>
     <string name="favorites_hide">Slėpti mėgiamisuiųjų skydelį</string>
     <string name="restart_desc">Sutvarkyti temos klaidas / nauji kontaktai nerodomi</string>
     <string name="restart_name">Paleisti iš naujo KISS</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -84,7 +84,7 @@
     <string name="restart_desc">പുതിയ കോണ്ടാക്ടുകൾ കാണിക്കാത്തതും മറ്റ് ഛായ സംബന്ധ തകരാറുകളും പരിഹരിക്കാം</string>
     <string name="pref_hide_circle_desc">ബട്ടണുകൾ ഇപ്പോഴും പ്രവർത്തിക്കും, പക്ഷെ അവ അദൃശ്യമായിരിക്കും.</string>
     <string name="pref_hide_statusbar_desc">അറിയിപ്പിനുള്ള പാളി മൂടിവെച്ചിട്ട് ഇമ്മേഴ്സിവ് (Immersive) ഭാവത്തിൽ പ്രവേശിക്കുക</string>
-    <string name="exclude_favorites">ഇഷ്ടപ്പട്ടികയിൽ ഉള്ളതിനെ മുൻസമ്പർക്കപ്പട്ടികയിൽ നിന്ന് അവഗണിക്കുക</string>
+    <string name="exclude_favorites_history">ഇഷ്ടപ്പട്ടികയിൽ ഉള്ളതിനെ മുൻസമ്പർക്കപ്പട്ടികയിൽ നിന്ന് അവഗണിക്കുക</string>
     <string name="enable_favorites_bar">തിരച്ചിൽകൂടിനു മുകളിൽ ഇഷ്ടപ്പട്ടിക കാണിക്കുക</string>
     <string name="history_erased">മുൻസമ്പർക്കങ്ങൾ മായ്ച്ചുമാറ്റി .</string>
     <string name="alias_phone">ഡയൽ,ഫോൺ,വിളികൾ</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -100,7 +100,7 @@
     <string name="tags_confirmation_added">Merkelapper lagret</string>
     <string name="menu_shortcut_remove">Fjern snarvei</string>
     <string name="enable_favorites_bar">Vis favoritter ovenfor søk</string>
-    <string name="exclude_favorites">Utelat favoritter fra historikk</string>
+    <string name="exclude_favorites_history">Utelat favoritter fra historikk</string>
     <string name="favorites_hide">Skjul favorittbjelke</string>
     <string name="default_launcher_title">Endre forvalgt oppstarter</string>
     <string name="alternate_history_inputs">Alternative historikkinndatametoder</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -98,7 +98,7 @@
     <string name="enable_phone">Toon inkomende gesprekken in geschiedenis</string>
     <string name="enable_app">Laat laatst geïnstalleerde apps zien in geschiedenis</string>
     <string name="enable_favorites_bar">Favoriete boven zoekbalk weergeven</string>
-    <string name="exclude_favorites">Toon favorieten niet in geschiedenis</string>
+    <string name="exclude_favorites_history">Toon favorieten niet in geschiedenis</string>
     <string name="favorites_hide">Verberg favorietenbalk</string>
     <string name="restart_desc">Themaproblemen en contacten die niet worden weergegeven herstellen</string>
     <string name="restart_name">Herstart KISS</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -130,7 +130,7 @@
     <string name="menu_exclude_history">z historii</string>
     <string name="menu_shortcut_remove">Usuń skrót</string>
     <string name="enable_favorites_bar">Pokaż ulubione nad paskiem wyszukiwania</string>
-    <string name="exclude_favorites">Wyklucz ulubione z historii</string>
+    <string name="exclude_favorites_history">Wyklucz ulubione z historii</string>
     <string name="favorites_hide">Początkowo ukryj pasek ulubionych</string>
     <string name="pref_hide_navbar">Ukryj pasek nawigacyjny</string>
     <string name="pref_hide_navbar_desc">Ukryj pasek nawigacyjny i włącz tryb immersyjny</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -77,7 +77,7 @@
     <string name="excluded_app_list_erased">Lista de aplicativos excluídos apagada.</string>
     <string name="menu_shortcut_remove">Remover atalho</string>
     <string name="toast_favorites_added">%s foi adicionado aos favoritos</string>
-    <string name="exclude_favorites">Remover do histórico os favoritos</string>
+    <string name="exclude_favorites_history">Remover do histórico os favoritos</string>
     <string name="restart_name">Reiniciar KISS</string>
     <string name="items_title">%d itens</string>
     <string name="reset_excluded_apps_name">Limpar lista de aplicativos excluídos do KISS</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -99,7 +99,7 @@
     <string name="enable_phone">Mostrar chamadas recebidas no histórico</string>
     <string name="enable_app">Mostrar aplicações instaladas recentemente no histórico</string>
     <string name="enable_favorites_bar">Mostrar favoritos acima da barra de pesquisa</string>
-    <string name="exclude_favorites">Excluir favoritos do histórico</string>
+    <string name="exclude_favorites_history">Excluir favoritos do histórico</string>
     <string name="favorites_hide">Ocultar barra de favoritos inicialmente</string>
     <string name="restart_desc">Corrigir problemas no tema e novos contactos que não são mostrados</string>
     <string name="restart_name">Reiniciar KISS</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -93,7 +93,7 @@
     <string name="history_mode_desc">Selectează modul în care este sortat istoricul</string>
     <string name="menu_shortcut_remove">Șterge scurtătura</string>
     <string name="enable_favorites_bar">Arată favoritele deasupra barei de căutare</string>
-    <string name="exclude_favorites">Exclude aplicațiile favorite din istoric</string>
+    <string name="exclude_favorites_history">Exclude aplicațiile favorite din istoric</string>
     <string name="favorites_hide">Ascunde bara de favorite la început</string>
     <string name="settings_storage">Stocare</string>
     <string name="settings_dev">Optiuni dezvoltator</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -93,7 +93,7 @@
     <string name="history_mode_desc">Способ заполнения истории</string>
     <string name="menu_shortcut_remove">Убрать ярлык</string>
     <string name="enable_favorites_bar">Избранное над поиском</string>
-    <string name="exclude_favorites">Исключить избранные из истории</string>
+    <string name="exclude_favorites_history">Исключить избранные из истории</string>
     <string name="favorites_hide">Скрыть избранное</string>
     <string name="settings_storage">Накопитель</string>
     <string name="settings_dev">Для разработчиков</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -111,7 +111,7 @@
     <string name="enable_phone">Visa inkommande samtal i historiken</string>
     <string name="enable_app">Visa nyligen installerade appar i historiken</string>
     <string name="enable_favorites_bar">Visa favoriter ovanför sökfältet</string>
-    <string name="exclude_favorites">Exkludera favoriter från historiken</string>
+    <string name="exclude_favorites_history">Exkludera favoriter från historiken</string>
     <string name="favorites_hide">Dölj favoritmenyn</string>
 
     <string name="restart_desc">Fixa temaproblem / nya kontakter visas ej</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -87,7 +87,7 @@
     <string name="enable_phone">Приказуј долазне позиве у историјату</string>
     <string name="enable_app">Прикажи новоинсталиране апликације у историјату</string>
     <string name="enable_favorites_bar">Прикажи омиљене изнад траке за претрагу</string>
-    <string name="exclude_favorites">Искључи омиљене из историјата</string>
+    <string name="exclude_favorites_history">Искључи омиљене из историјата</string>
     <string name="favorites_hide">Сакриј траку омиљених</string>
     <string name="restart_desc">Поправи проблеме теме и приказа нових контаката</string>
     <string name="ui_excluded_apps_dialog_title">Одзначите апликације које желите да укључите</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -119,7 +119,7 @@
     <string name="enable_phone">Visa inkommande samtal i historik</string>
     <string name="enable_app">Visa nyligen installerade appar i historik</string>
     <string name="enable_favorites_bar">Visa favoriter ovanför sökfält</string>
-    <string name="exclude_favorites">Exkludera favoriter från historik</string>
+    <string name="exclude_favorites_history">Exkludera favoriter från historik</string>
     <string name="favorites_hide">Göm favoritfält</string>
     <string name="pref_hide_navbar">Göm navigationsfält</string>
     <string name="pref_hide_statusbar">Göm statusrad</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -96,7 +96,7 @@
     <string name="settings_dev">Geliştirici ayarları</string>
     <string name="settings_accessibility">Erişebilirlik</string>
     <string name="menu_shortcut_remove">Kısayolu kaldır</string>
-    <string name="exclude_favorites">Sık kullanılanları geçmişe dahil etme</string>
+    <string name="exclude_favorites_history">Sık kullanılanları geçmişe dahil etme</string>
     <string name="favorites_hide">İlkin sık kullanılanlar çubuğunu gizle</string>
     <string name="misc">Diğer</string>
     <string name="keyboard_options">Klavye seçenekleri</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -126,7 +126,7 @@
     <string name="enable_phone">Показати вхідні виклики в дієписі</string>
     <string name="enable_app">Показати нещодавно встановлені застосунки в дієписі</string>
     <string name="enable_favorites_bar">Показ уподобань над панеллю пошуку</string>
-    <string name="exclude_favorites">Виключити вподобане з дієпису</string>
+    <string name="exclude_favorites_history">Виключити вподобане з дієпису</string>
     <string name="favorites_hide">Сховати панель уподобань</string>
     <string name="pref_hide_navbar">Приховати навігаційну панель</string>
     <string name="pref_hide_navbar_desc">Сховати панель навігації та увімкнути режим занурення</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -93,7 +93,7 @@
     <string name="history_mode_desc">选择如何对历史记录进行分类</string>
     <string name="menu_shortcut_remove">移除快捷方式</string>
     <string name="enable_favorites_bar">在搜索栏上方显示收藏</string>
-    <string name="exclude_favorites">历史记录中排除收藏</string>
+    <string name="exclude_favorites_history">历史记录中排除收藏</string>
     <string name="favorites_hide">初始隐藏收藏栏</string>
     <string name="settings_storage">存储</string>
     <string name="settings_dev">开发者设置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -131,7 +131,7 @@
     <string name="enable_phone">在歷史紀錄中顯示來電紀錄</string>
     <string name="enable_app">在歷史紀錄中顯示新增的應用程式</string>
     <string name="enable_favorites_bar">在搜尋列上方顯示最愛</string>
-    <string name="exclude_favorites">歷史紀錄中隱藏收藏最愛</string>
+    <string name="exclude_favorites_history">歷史紀錄中隱藏收藏最愛</string>
     <string name="favorites_hide">隱藏最愛列</string>
     <string name="pref_hide_navbar">隱藏導航列</string>
     <string name="pref_hide_navbar_desc">隱藏導航列並開啟 KitKat (4.4) 起支援的沈浸模式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,8 @@
     <string name="enable_phone">Show incoming calls in history</string>
     <string name="enable_app">Show newly installed apps in history</string>
     <string name="enable_favorites_bar">Show favorites above search bar</string>
-    <string name="exclude_favorites">Exclude favorites from history</string>
+    <string name="exclude_favorites_apps">Exclude favorites from apps list</string>
+    <string name="exclude_favorites_history">Exclude favorites from history</string>
     <string name="favorites_hide">Hide favorites bar initially</string>
     <string name="pref_hide_navbar">Hide navbar</string>
     <string name="pref_hide_navbar_desc">Hide navigation bar and turn on immersive mode</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -80,9 +80,13 @@
             android:key="large-favorites-bar"
             android:title="@string/large_favorites_bar" />
         <fr.neamar.kiss.preference.SwitchPreference
+            android:defaultValue="false"
+            android:key="exclude-favorites-apps"
+            android:title="@string/exclude_favorites_apps" />
+        <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="true"
-            android:key="exclude-favorites"
-            android:title="@string/exclude_favorites" />
+            android:key="exclude-favorites-history"
+            android:title="@string/exclude_favorites_history" />
         <MultiSelectListPreference
             android:defaultValue="@array/favTagsDefault"
             android:key="pref-fav-tags-list"


### PR DESCRIPTION
Because hidding apps are also removed from favorites, I've added the option (disabled by default) next to "Exclude favorites from history" to reduce redundancy and get an even more minimalistic apps list.
I've also renamed "exclude_favorites" to "exclude_favorites_history" for clarity.