### PR TITLE
Accept hardware keyboard presses to search on the Main screen even if the Search field is not focused.

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -38,6 +38,7 @@ import android.widget.TextView.OnEditorActionListener;
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.broadcast.IncomingCallHandler;
@@ -482,7 +483,10 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             menuButton.performHapticFeedback(LONG_PRESS);
             return true;
         }
-
+        if(keycode != KeyEvent.KEYCODE_BACK ) {
+            searchEditText.requestFocus();
+            searchEditText.dispatchKeyEvent(e);
+        }
         return super.onKeyDown(keycode, e);
     }
 


### PR DESCRIPTION
Currently, on device with a **hardware keyboard** (example: Gemini PDA), search field can loose focus and you have to tap on it to search for an app.
This change will always listen for a keyboard tap and pass the event to the search field if necessary.