### PR TITLE
Fix a crash showing a Shortcut result with a disabled work profile

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -12,11 +12,10 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ShortcutInfo;
-import android.graphics.Bitmap;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.UserHandle;
+import android.os.UserManager;
 import android.preference.PreferenceManager;
 import android.view.View;
 import android.view.ViewGroup;
@@ -39,9 +38,9 @@ import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.ui.ListPopup;
+import fr.neamar.kiss.utils.DrawableUtils;
 import fr.neamar.kiss.utils.FuzzyScore;
 import fr.neamar.kiss.utils.SpaceTokenizer;
-import fr.neamar.kiss.utils.DrawableUtils;
 
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
@@ -115,9 +114,9 @@ public class ShortcutsResult extends Result {
         if (!prefs.getBoolean("icons-hide", false)) {
             Drawable shortcutDrawable = getDrawable(context);
             String iconsPack = prefs.getString("icons-pack", "default");
-            if(DrawableUtils.isIconsPackAdaptive(iconsPack)) {
+            if (DrawableUtils.isIconsPackAdaptive(iconsPack)) {
                 appDrawable = DrawableUtils.handleAdaptiveIcons(context, appDrawable);
-                if(shortcutDrawable != null) {
+                if (shortcutDrawable != null) {
                     shortcutDrawable = DrawableUtils.handleAdaptiveIcons(context, shortcutDrawable);
                 }
             }
@@ -129,11 +128,10 @@ public class ShortcutsResult extends Result {
                 shortcutIcon.setImageDrawable(appDrawable);
                 appIcon.setImageResource(android.R.drawable.ic_menu_send);
             }
-            if(!prefs.getBoolean("subicon-visible", true)) {
+            if (!prefs.getBoolean("subicon-visible", true)) {
                 appIcon.setVisibility(View.GONE);
             }
-        }
-        else {
+        } else {
             appIcon.setImageDrawable(null);
             shortcutIcon.setImageDrawable(null);
         }
@@ -143,8 +141,9 @@ public class ShortcutsResult extends Result {
 
     public Drawable getDrawable(Context context) {
         Drawable shortcutDrawable = null;
-        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
             assert launcherApps != null;
 
             if (launcherApps.hasShortcutHostPermission()) {
@@ -157,9 +156,11 @@ public class ShortcutsResult extends Result {
 
                 // Find the correct UserHandle, and retrieve the icon.
                 for (UserHandle userHandle : userHandles) {
-                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
-                    if (shortcuts != null && shortcuts.size() > 0) {
-                        shortcutDrawable = launcherApps.getShortcutIconDrawable(shortcuts.get(0), 0);
+                    if (userManager.isUserRunning(userHandle)) {
+                        List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
+                        if (shortcuts != null && shortcuts.size() > 0) {
+                            shortcutDrawable = launcherApps.getShortcutIconDrawable(shortcuts.get(0), 0);
+                        }
                     }
                 }
             }

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -194,6 +194,7 @@ public class ShortcutsResult extends Result {
     @TargetApi(Build.VERSION_CODES.O)
     private void doOreoLaunch(Context context, View v) {
         final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+        UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
         assert launcherApps != null;
 
         // Only the default launcher is allowed to start shortcuts
@@ -211,10 +212,12 @@ public class ShortcutsResult extends Result {
 
         // Find the correct UserHandle, and launch the shortcut.
         for (UserHandle userHandle : userHandles) {
-            List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
-            if (shortcuts != null && shortcuts.size() > 0 && shortcuts.get(0).isEnabled()) {
-                launcherApps.startShortcut(shortcuts.get(0), v.getClipBounds(), null);
-                return;
+            if (userManager.isUserRunning(userHandle)) {
+                List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
+                if (shortcuts != null && shortcuts.size() > 0 && shortcuts.get(0).isEnabled()) {
+                    launcherApps.startShortcut(shortcuts.get(0), v.getClipBounds(), null);
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
- Add a shortcut to KISS (e.g. search for "weather" on the Google app and "add to homescreen")
- Add a work profile (e.g. with https://github.com/android/enterprise-samples/tree/main/BasicManagedProfile)
- Disable the work profile from the quick settings
- Start typing into KISS something that'd show the shortcut (e.g "weather")

I was getting an insta-crash with:
```
2020-10-02 21:48:24.899 17955-17955/fr.neamar.kiss.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: fr.neamar.kiss.debug, PID: 17955
    java.lang.IllegalStateException: User 10 is locked or not running
        at android.os.Parcel.createExceptionOrNull(Parcel.java:2412)
        at android.os.Parcel.createException(Parcel.java:2388)
        at android.os.Parcel.readException(Parcel.java:2371)
        at android.os.Parcel.readException(Parcel.java:2313)
        at android.content.pm.ILauncherApps$Stub$Proxy.getShortcuts(ILauncherApps.java:1419)
        at android.content.pm.LauncherApps.getShortcuts(LauncherApps.java:1070)
        at fr.neamar.kiss.result.ShortcutsResult.getDrawable(ShortcutsResult.java:160)
        at fr.neamar.kiss.result.ShortcutsResult.display(ShortcutsResult.java:116)
        at fr.neamar.kiss.adapter.RecordAdapter.getView(RecordAdapter.java:96)
        at android.widget.AbsListView.obtainView(AbsListView.java:2388)
        at android.widget.ListView.makeAndAddView(ListView.java:2067)
        at android.widget.ListView.fillUp(ListView.java:828)
        at android.widget.ListView.layoutChildren(ListView.java:1805)
        at android.widget.AbsListView.onLayout(AbsListView.java:2185)
        at android.view.View.layout(View.java:22874)
        at android.view.ViewGroup.layout(ViewGroup.java:6397)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
        at android.view.View.layout(View.java:22874)
        at android.view.ViewGroup.layout(ViewGroup.java:6397)
        at android.widget.RelativeLayout.onLayout(RelativeLayout.java:1103)
        at android.view.View.layout(View.java:22874)
        at android.view.ViewGroup.layout(ViewGroup.java:6397)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
        at android.view.View.layout(View.java:22874)
        at android.view.ViewGroup.layout(ViewGroup.java:6397)
        at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1829)
        at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1673)
        at android.widget.LinearLayout.onLayout(LinearLayout.java:1582)
        at android.view.View.layout(View.java:22874)
        at android.view.ViewGroup.layout(ViewGroup.java:6397)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
        at com.android.internal.policy.DecorView.onLayout(DecorView.java:785)
        at android.view.View.layout(View.java:22874)
        at android.view.ViewGroup.layout(ViewGroup.java:6397)
        at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:3510)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2982)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1988)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8218)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:976)
        at android.view.Choreographer.doCallbacks(Choreographer.java:797)
        at android.view.Choreographer.doFrame(Choreographer.java:732)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:961)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:200)
        at android.os.Looper.loop(Looper.java:286)
        at android.app.ActivityThread.main(ActivityThread.java:7629)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:958)
     Caused by: android.os.RemoteException: Remote stack trace:
        at com.android.server.pm.ShortcutService.throwIfUserLockedL(ShortcutService.java:1220)
        at com.android.server.pm.ShortcutService$LocalService.getShortcuts(ShortcutService.java:2877)
        at com.android.server.pm.LauncherAppsService$LauncherAppsImpl.getShortcuts(LauncherAppsService.java:743)
        at android.content.pm.ILauncherApps$Stub.onTransact(ILauncherApps.java:621)
        at android.os.Binder.execTransactInternal(Binder.java:1176)
```

And it is documented as throwing: https://developer.android.com/reference/android/content/pm/LauncherApps#getShortcuts(android.content.pm.LauncherApps.ShortcutQuery,%2520android.os.UserHandle)