### PR TITLE
update errorprone

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id 'com.android.application'
-    id 'net.ltgt.errorprone' version '1.1.1'
+    id 'net.ltgt.errorprone' version '1.3.0'
 }
 
 android {
@@ -51,11 +51,14 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:2.1'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
-    errorprone ("com.google.errorprone:error_prone_core:2.3.4")
+    errorprone("com.google.errorprone:error_prone_core:2.5.1")
 }
 
 tasks.withType(JavaCompile).configureEach {
     options.errorprone {
         disable('MissingOverride')
+        disable('MissingSummary')
+        disable('EmptyBlockTag')
+        disable('EmptyCatch')
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/UIColors.java
+++ b/app/src/main/java/fr/neamar/kiss/UIColors.java
@@ -12,10 +12,10 @@ import android.view.Window;
 import android.view.WindowManager;
 
 public class UIColors {
-    public static final int COLOR_DEFAULT = 0xFF4caf50;
+    public static final int COLOR_DEFAULT = 0xFF4CAF50;
     // Source: https://material.io/guidelines/style/color.html#color-color-palette
-    public static final int[] COLOR_LIST = new int[]{
-            0xFF4CAF50,
+    private static final int[] COLOR_LIST = new int[]{
+            COLOR_DEFAULT,
             0xFFD32F2F,
             0xFFC2185B,
             0xFF7B1FA2,
@@ -187,5 +187,9 @@ public class UIColors {
 
     static void clearPrimaryColorCache(Context context) {
         primaryColor = -1;
+    }
+
+    public static int[] getColorList() {
+        return COLOR_LIST;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -510,10 +510,9 @@ public class DBHelper {
     }
 
 
-    /* Delete
+    /** Delete
      *
      * @param context android context
-     * @param tag   query to insert
      * @param record  record to insert
      */
     public static void deleteTagsForId(Context context, String record) {

--- a/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
@@ -45,7 +45,7 @@ public class ColorPreference extends DialogPreference implements OnColorSelected
 
     private void drawPalette() {
         if (this.palette != null) {
-            this.palette.drawPalette(UIColors.COLOR_LIST, this.selectedColor);
+            this.palette.drawPalette(UIColors.getColorList(), this.selectedColor);
         }
     }
 
@@ -109,25 +109,13 @@ public class ColorPreference extends DialogPreference implements OnColorSelected
 
         // Bind click events from the custom color values
         Button button1 = view.findViewById(R.id.colorTransparentDark);
-        button1.setOnClickListener(new View.OnClickListener() {
-            public void onClick(View v) {
-                ColorPreference.this.onColorSelected(COLOR_DARK_TRANSPARENT);
-            }
-        });
+        button1.setOnClickListener(v -> ColorPreference.this.onColorSelected(COLOR_DARK_TRANSPARENT));
 
         Button button2 = view.findViewById(R.id.colorTransparentWhite);
-        button2.setOnClickListener(new View.OnClickListener() {
-            public void onClick(View v) {
-                ColorPreference.this.onColorSelected(COLOR_LIGHT_TRANSPARENT);
-            }
-        });
+        button2.setOnClickListener(v -> ColorPreference.this.onColorSelected(COLOR_LIGHT_TRANSPARENT));
 
         Button button3 = view.findViewById(R.id.colorTransparent);
-        button3.setOnClickListener(new View.OnClickListener() {
-            public void onClick(View v) {
-                ColorPreference.this.onColorSelected(COLOR_TRANSPARENT);
-            }
-        });
+        button3.setOnClickListener(v -> ColorPreference.this.onColorSelected(COLOR_TRANSPARENT));
 
         if(ColorPreference.this.selectedColor == COLOR_DARK_TRANSPARENT) this.selectButton(button1);
         if(ColorPreference.this.selectedColor == COLOR_LIGHT_TRANSPARENT) this.selectButton(button2);

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -36,20 +36,6 @@ public class DrawableUtils {
     public static final int SHAPE_HEXAGON = 10;
     public static final int SHAPE_OCTAGON = 11;
 
-    public static final int[] SHAPE_LIST = {
-            SHAPE_SYSTEM,
-            SHAPE_CIRCLE,
-            SHAPE_SQUARE,
-            SHAPE_SQUIRCLE,
-            SHAPE_ROUND_RECT,
-            SHAPE_TEARDROP_BR,
-            SHAPE_TEARDROP_BL,
-            SHAPE_TEARDROP_TL,
-            SHAPE_TEARDROP_TR,
-            SHAPE_HEXAGON,
-            SHAPE_OCTAGON,
-    };
-
     private static final Paint PAINT = new Paint();
     private static final Path SHAPE_PATH = new Path();
     private static final RectF RECT_F = new RectF();

--- a/app/src/main/java/fr/neamar/kiss/utils/Permission.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/Permission.java
@@ -8,7 +8,6 @@ import android.os.Build;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.ListIterator;
 
 import androidx.annotation.NonNull;
@@ -27,7 +26,7 @@ public class Permission {
 
     // Static weak reference to the linked activity, this is sadly required
     // to ensure classes requesting permission can access activity.requestPermission()
-    private static WeakReference<Activity> currentActivity = new WeakReference<Activity>(null);
+    private static WeakReference<Activity> currentActivity = new WeakReference<>(null);
 
     private static ArrayList<PermissionResultListener> permissionListeners;
 
@@ -42,7 +41,7 @@ public class Permission {
         if (listener != null) {
             listener.permission = permission;
             if (permissionListeners == null) {
-                permissionListeners = new ArrayList<PermissionResultListener>();
+                permissionListeners = new ArrayList<>();
             }
             permissionListeners.add(listener);
         }
@@ -53,6 +52,7 @@ public class Permission {
         }
     }
 
+    @SuppressWarnings("StaticAssignmentInConstructor")
     public Permission(Activity activity) {
         // Store the latest reference to a MainActivity
         currentActivity = new WeakReference<>(activity);
@@ -82,7 +82,7 @@ public class Permission {
     public static class PermissionResultListener {
         public int permission = 0;
 
-        public void onGranted() {};
-        public void onDenied() {};
+        public void onGranted() {}
+        public void onDenied() {}
     }
 }


### PR DESCRIPTION
* update errorprone plugin to 1.3.0
* update errorprone core to 2.5.1
* fix some new errorprone warnings/errors
* disable MissingSummary and EmptyBlockTag checks, these are related to javadoc only which shouldn't result in build errors
* disable EmptyCatch check, this is often used intentionally