### PR TITLE
Fix swatches in color picker not being centered or being cut off

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
@@ -99,8 +99,8 @@ public class ColorPreference extends DialogPreference implements OnColorSelected
                 android.util.Log.i("ColorPreference", "View Width:  " + view.getWidth() + " | " + view.getMeasuredWidth());
                 // Calculate number of swatches to display
                 int swatchSize = ColorPreference.this.palette.getResources().getDimensionPixelSize(R.dimen.color_swatch_small);
-                ColorPreference.this.palette.init(ColorPickerDialog.SIZE_SMALL, (view.getWidth() - (swatchSize * 2 / 3)) / swatchSize, ColorPreference.this);
-
+                int swatchMargin = ColorPreference.this.palette.getResources().getDimensionPixelSize(R.dimen.color_swatch_margins_small);
+                ColorPreference.this.palette.init(ColorPickerDialog.SIZE_SMALL, view.getWidth() / (swatchSize + swatchMargin), ColorPreference.this);
 
                 // Cause redraw and (by extension) also a layout recalculation
                 this.ignoreNextUpdate = true;

--- a/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ColorPreference.java
@@ -96,6 +96,7 @@ public class ColorPreference extends DialogPreference implements OnColorSelected
                     return;
                 }
 
+                android.util.Log.i("ColorPreference", "View Width:  " + view.getWidth() + " | " + view.getMeasuredWidth());
                 // Calculate number of swatches to display
                 int swatchSize = ColorPreference.this.palette.getResources().getDimensionPixelSize(R.dimen.color_swatch_small);
                 ColorPreference.this.palette.init(ColorPickerDialog.SIZE_SMALL, (view.getWidth() - (swatchSize * 2 / 3)) / swatchSize, ColorPreference.this);
@@ -139,7 +140,6 @@ public class ColorPreference extends DialogPreference implements OnColorSelected
     @Override
     protected void onBindDialogView(View view) {
         super.onBindDialogView(view);
-        android.util.Log.i("ColorPreference", "View Width:  " + view.getWidth() + " | " + view.getMeasuredWidth());
         // Set selected color value based on the actual color value currently used
         // (but fall back to default from XML)
         this.selectedColor = Color.parseColor(

--- a/app/src/main/res/layout/pref_color.xml
+++ b/app/src/main/res/layout/pref_color.xml
@@ -11,8 +11,9 @@
 
         <com.android.colorpicker.ColorPickerPalette
             android:id="@+id/colorPicker"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center" />
 
         <Button
             android:id="@+id/colorTransparentDark"


### PR DESCRIPTION

### Issue
Seems like on devices with high dpi, the color picker sometimes had difficulty in accurately calculating the required number of swatch columns. [1. Either they'd get cut off](https://github.com/Neamar/KISS/issues/1216#issue-455137889), or [2. Not centered](https://github.com/Neamar/KISS/issues/1216#issuecomment-599753194).

### Potential fix
I tried to fix issue 1 it by reducing the number of swatch columns + making color palette wrap around content, and issue 2 by making the color palette centered. This seems to fix it for me:  [before changes(9 columns)](https://user-images.githubusercontent.com/50471800/107880074-86f8c480-6f02-11eb-8646-0fc75d3b6db9.png) and [after changes(8 columns)](https://user-images.githubusercontent.com/50471800/107880152-05edfd00-6f03-11eb-9084-4c12390b967d.png). Also tested in emulator with different minimum widths in developer options from 320 to 700 on default Pixel 3a resolution.

fixes #1216, closes #1671, closes #1557.
