### PR TITLE
Semi-transparent search and favorites bar

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -120,13 +120,15 @@ class InterfaceTweaks extends Forwarder {
             } else {
                 // Before API21, you can't access values from current theme using ?attr/
                 // So we made four different drawables (#931).
+                Resources res = mainActivity.getResources();
+
                 if (getSearchBackgroundColor() == Color.WHITE) {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_light);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_light);
-                } else if (getSearchBackgroundColor() == Color.parseColor("#88FFFFFF")) {
+                } else if (getSearchBackgroundColor() == res.getColor(R.color.kiss_background_light_transparent)) {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_light);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_light);
-                } else if (getSearchBackgroundColor() == Color.parseColor("#88222222")) {
+                } else if (getSearchBackgroundColor() == res.getColor(R.color.kiss_background_dark_transparent)) {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_dark);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_dark);
                 } else {
@@ -147,11 +149,13 @@ class InterfaceTweaks extends Forwarder {
             } else {
                 // Before API21, you can't access values from current theme using ?attr/
                 // So we made four different drawables (#931).
+                Resources res = mainActivity.getResources();
+
                 if (getSearchBackgroundColor() == Color.WHITE)
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_light);
-                else if (getSearchBackgroundColor() == Color.parseColor("#88FFFFFF"))
+                else if (getSearchBackgroundColor() == res.getColor(R.color.kiss_background_light_transparent))
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_semi_trans_light);
-                else if (getSearchBackgroundColor() == Color.parseColor("#88222222"))
+                else if (getSearchBackgroundColor() == res.getColor(R.color.kiss_background_dark_transparent))
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_semi_trans_dark);
                 else
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_dark);

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -119,10 +119,16 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar);
             } else {
                 // Before API21, you can't access values from current theme using ?attr/
-                // So we made two different drawables (#931).
+                // So we made four different drawables (#931).
                 if (getSearchBackgroundColor() == Color.WHITE) {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_light);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_light);
+                } else if (getSearchBackgroundColor() == Color.parseColor("#88FFFFFF")) {
+                    mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_light);
+                    mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_light);
+                } else if (getSearchBackgroundColor() == Color.parseColor("#88222222")) {
+                    mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_dark);
+                    mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_dark);
                 } else {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_dark);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_dark);
@@ -140,12 +146,15 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.listContainer.setClipToOutline(true);
             } else {
                 // Before API21, you can't access values from current theme using ?attr/
-                // So we made two different drawables (#931).
-                if (getSearchBackgroundColor() == Color.WHITE) {
+                // So we made four different drawables (#931).
+                if (getSearchBackgroundColor() == Color.WHITE)
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_light);
-                } else {
+                else if (getSearchBackgroundColor() == Color.parseColor("#88FFFFFF"))
+                    mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_semi_trans_light);
+                else if (getSearchBackgroundColor() == Color.parseColor("#88222222"))
+                    mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_semi_trans_dark);
+                else
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_dark);
-                }
             }
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -119,7 +119,7 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar);
             } else {
                 // Before API21, you can't access values from current theme using ?attr/
-                // So we made four different drawables (#931).
+                // So we made different drawable for each theme (#931).
                 Resources res = mainActivity.getResources();
 
                 if (getSearchBackgroundColor() == Color.WHITE) {
@@ -131,6 +131,9 @@ class InterfaceTweaks extends Forwarder {
                 } else if (getSearchBackgroundColor() == res.getColor(R.color.kiss_background_dark_transparent)) {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_dark);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_semi_trans_dark);
+                } else if (getSearchBackgroundColor() == Color.BLACK) {
+                    mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_amoled);
+                    mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_amoled);
                 } else {
                     mainActivity.findViewById(R.id.externalFavoriteBar).setBackgroundResource(R.drawable.rounded_search_bar_pre21_dark);
                     mainActivity.findViewById(R.id.searchEditLayout).setBackgroundResource(R.drawable.rounded_search_bar_pre21_dark);
@@ -148,7 +151,7 @@ class InterfaceTweaks extends Forwarder {
                 mainActivity.listContainer.setClipToOutline(true);
             } else {
                 // Before API21, you can't access values from current theme using ?attr/
-                // So we made four different drawables (#931).
+                // So we made different drawable for each theme (#931).
                 Resources res = mainActivity.getResources();
 
                 if (getSearchBackgroundColor() == Color.WHITE)
@@ -157,6 +160,8 @@ class InterfaceTweaks extends Forwarder {
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_semi_trans_light);
                 else if (getSearchBackgroundColor() == res.getColor(R.color.kiss_background_dark_transparent))
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_semi_trans_dark);
+                else if (getSearchBackgroundColor() == Color.BLACK)
+                    mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_amoled);
                 else
                     mainActivity.findViewById(R.id.resultLayout).setBackgroundResource(R.drawable.rounded_result_layout_pre21_dark);
             }

--- a/app/src/main/res/drawable/rounded_result_layout_pre21_amoled.xml
+++ b/app/src/main/res/drawable/rounded_result_layout_pre21_amoled.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/black" />
+    <corners android:radius="@dimen/list_corner_radius" />
+</shape>

--- a/app/src/main/res/drawable/rounded_result_layout_pre21_semi_trans_dark.xml
+++ b/app/src/main/res/drawable/rounded_result_layout_pre21_semi_trans_dark.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/kiss_background_dark_transparent" />
+    <corners android:radius="@dimen/list_corner_radius" />
+</shape>

--- a/app/src/main/res/drawable/rounded_result_layout_pre21_semi_trans_light.xml
+++ b/app/src/main/res/drawable/rounded_result_layout_pre21_semi_trans_light.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/kiss_background_light_transparent" />
+    <corners android:radius="@dimen/list_corner_radius" />
+</shape>

--- a/app/src/main/res/drawable/rounded_search_bar_pre21_amoled.xml
+++ b/app/src/main/res/drawable/rounded_search_bar_pre21_amoled.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/black" />
+    <corners android:radius="@dimen/search_corner_radius" />
+</shape>

--- a/app/src/main/res/drawable/rounded_search_bar_pre21_semi_trans_dark.xml
+++ b/app/src/main/res/drawable/rounded_search_bar_pre21_semi_trans_dark.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/kiss_background_dark_transparent" />
+    <corners android:radius="@dimen/search_corner_radius" />
+</shape>

--- a/app/src/main/res/drawable/rounded_search_bar_pre21_semi_trans_light.xml
+++ b/app/src/main/res/drawable/rounded_search_bar_pre21_semi_trans_light.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/kiss_background_light_transparent" />
+    <corners android:radius="@dimen/search_corner_radius" />
+</shape>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -132,7 +132,7 @@
             android:layout_toLeftOf="@id/rightHandSideButtonsWrapper"
             android:layout_toEndOf="@id/leftHandSideButtonsWrapper"
             android:layout_toRightOf="@id/leftHandSideButtonsWrapper"
-            android:background="?attr/searchBackgroundColor"
+            android:background="@android:color/transparent"
             android:hint="@string/ui_search_hint"
             android:imeOptions="flagNoExtractUi|actionSearch"
             android:importantForAutofill="no"

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -35,6 +35,7 @@
     <style name="AppThemeSemiTransparent" parent="AppThemeLight">
         <item name="android:textColorSecondary">@color/kiss_text_on_semi_light</item>
         <item name="listBackgroundColor">@color/kiss_background_light_transparent</item>
+        <item name="searchBackgroundColor">@color/kiss_background_light_transparent</item>
         <item name="dividerDrawable">@null</item>
         <item name="android:colorPrimaryDark">@color/kiss_green_semitransparent</item>
         <item name="textShadowRadius">3</item>
@@ -44,6 +45,7 @@
         <item name="resultColor">@color/kiss_text_on_semi_dark</item>
         <item name="android:textColorSecondary">@color/kiss_text_on_dark</item>
         <item name="listBackgroundColor">@color/kiss_background_dark_transparent</item>
+        <item name="searchBackgroundColor">@color/kiss_background_dark_transparent</item>
         <item name="dividerDrawable">@null</item>
         <item name="android:colorPrimaryDark">@color/kiss_green_semitransparent</item>
         <item name="textShadowRadius">3</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -82,6 +82,7 @@
         <item name="resultShadowColor">@color/kiss_background_light_transparent</item>
         <item name="dividerDrawable">@null</item>
         <item name="listBackgroundColor">@color/kiss_background_light_transparent</item>
+        <item name="searchBackgroundColor">@color/kiss_background_light_transparent</item>
         <item name="textShadowRadius">3</item>
     </style>
 
@@ -90,6 +91,7 @@
         <item name="android:textColorSecondary">@color/kiss_text_on_dark</item>
         <item name="dividerDrawable">@null</item>
         <item name="listBackgroundColor">@color/kiss_background_dark_transparent</item>
+        <item name="searchBackgroundColor">@color/kiss_background_dark_transparent</item>
         <item name="textShadowRadius">3</item>
     </style>
 


### PR DESCRIPTION
Applied in Semi transparent and Dark Semi transparent themes.

While adding this I found that on devices with API <21, semi-transparent theme doesn't make  history/search results/app list semi-transparent when rounded list-corners were turned on, because there was no drawable available for that. 
So added them along with drawables for semi-transparent bars.
