### PR TITLE
Customise bar color independent of current theme

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -54,8 +54,11 @@ import fr.neamar.kiss.utils.Permission;
 public class SettingsActivity extends PreferenceActivity implements
         SharedPreferences.OnSharedPreferenceChangeListener {
     // Those settings require the app to restart
-    final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide enable-favorites-bar notification-bar-color black-notification-icons icons-pack theme-shadow theme-separator theme-result-color large-favorites-bar pref-hide-search-bar-hint";
-
+    final static private String settingsRequiringRestart = "primary-color transparent-search transparent-favorites"
+            + " pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide"
+            + " enable-favorites-bar notification-bar-color black-notification-icons icons-pack theme-shadow"
+            + " theme-separator theme-result-color large-favorites-bar pref-hide-search-bar-hint theme-wallpaper"
+            + " theme-bar-color";
     // Those settings require a restart of the settings
     final static private String settingsRequiringRestartForSettingsActivity = "theme force-portrait";
     private boolean requireFullRestart = false;

--- a/app/src/main/java/fr/neamar/kiss/UIColors.java
+++ b/app/src/main/java/fr/neamar/kiss/UIColors.java
@@ -138,6 +138,25 @@ public class UIColors {
                 activity.getTheme().applyStyle(R.style.OverlayWallpaperDisabled, true);
                 break;
         }
+
+        String barColor = prefs.getString("theme-bar-color", "default");
+        switch (barColor) {
+            case "light":
+                activity.getTheme().applyStyle(R.style.OverlayBarColorLight, true);
+                break;
+            case "dark":
+                activity.getTheme().applyStyle(R.style.OverlayBarColorDark, true);
+                break;
+            case "semi-light":
+                activity.getTheme().applyStyle(R.style.OverlayBarColorSemiLight, true);
+                break;
+            case "semi-dark":
+                activity.getTheme().applyStyle(R.style.OverlayBarColorSemiDark, true);
+                break;
+            case "black":
+                activity.getTheme().applyStyle(R.style.OverlayBarColorBlack, true);
+                break;
+        }
     }
 
     public static void updateThemePrimaryColor(Activity activity) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -149,4 +149,21 @@
         <item>11</item> <!-- SHAPE_OCTAGON -->
     </string-array>
 
+    <string-array name="barColorEntries">
+        <item>@string/theme_customize_default</item>
+        <item>@string/theme_light</item>
+        <item>@string/theme_semi_light</item>
+        <item>@string/theme_dark</item>
+        <item>@string/theme_semi_dark</item>
+        <item>@string/theme_amoled</item>
+    </string-array>
+    <string-array name="barColorValues" translatable="false">
+        <item>default</item>
+        <item>light</item>
+        <item>semi-light</item>
+        <item>dark</item>
+        <item>semi-dark</item>
+        <item>black</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,4 +307,5 @@
     <string name="export_settings">Export settings and tags</string>
     <string name="import_settings">Import settings and tags</string>
     <string name="import_settings_dialog">This will overwrite your current settings and tags with clipboard content. Existing tags will be REMOVED. Are you sure?</string>
+    <string name="theme_bar_color">Favorites bar and Search bar color</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -172,4 +172,20 @@
         <item name="resultSubtitleSize">@dimen/result_subtitle_size_small</item>
         <item name="resultButtonHeight">@dimen/result_button_height_small</item>
     </style>
+
+    <style name="OverlayBarColorLight">
+        <item name="searchBackgroundColor">@android:color/white</item>
+    </style>
+    <style name="OverlayBarColorSemiLight">
+        <item name="searchBackgroundColor">@color/kiss_background_light_transparent</item>
+    </style>
+    <style name="OverlayBarColorDark">
+        <item name="searchBackgroundColor">@color/kiss_list_background_inverse</item>
+    </style>
+    <style name="OverlayBarColorSemiDark">
+        <item name="searchBackgroundColor">@color/kiss_background_dark_transparent</item>
+    </style>
+    <style name="OverlayBarColorBlack">
+        <item name="searchBackgroundColor">@android:color/black</item>
+    </style>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -133,6 +133,13 @@
                 android:key="theme-wallpaper"
                 android:summary="%s"
                 android:title="@string/theme_wallpaper" />
+            <ListPreference
+                android:defaultValue="default"
+                android:entries="@array/barColorEntries"
+                android:entryValues="@array/barColorValues"
+                android:key="theme-bar-color"
+                android:summary="%s"
+                android:title="@string/theme_bar_color" />
         </PreferenceScreen>
         <fr.neamar.kiss.preference.SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
Can be changed from "Advanced theme customisation":

![image](https://user-images.githubusercontent.com/50471800/110295578-47139180-8017-11eb-8065-db69926ae6cd.png)

Apart from this one, also added wallpaper visibility  preference to settings that require app restart, as it needed restart on 2 devices I tested.

Resolves #1551 