### PR TITLE
fix shortcut icons

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -434,7 +434,7 @@ public class DataHandler extends BroadcastReceiver
 
         List<ShortcutInfo> shortcuts;
         try {
-            shortcuts = ShortcutUtil.getShortcut(context, packageName);
+            shortcuts = ShortcutUtil.getShortcuts(context, packageName);
         } catch (SecurityException | IllegalStateException e) {
             e.printStackTrace();
             return;

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -139,7 +139,6 @@ public class IconsHandler {
      */
     @SuppressWarnings("CatchAndPrintStackTrace")
     public Drawable getDrawableIconForPackage(ComponentName componentName, UserHandle userHandle) {
-        final String componentString = componentName.toString();
         final String cacheKey = AppPojo.getComponentName(componentName.getPackageName(), componentName.getClassName(), userHandle);
 
         // Search in cache
@@ -154,7 +153,7 @@ public class IconsHandler {
             // just checking will make this thread wait for the icon pack to load
             if (!mIconPack.isLoaded())
                 return null;
-            Drawable iconPackDrawable = mIconPack.getComponentDrawable(componentString);
+            Drawable iconPackDrawable = mIconPack.getComponentDrawable(ctx, componentName, userHandle);
             if (iconPackDrawable != null) {
                 Drawable drawable;
 

--- a/app/src/main/java/fr/neamar/kiss/icons/SystemIconPack.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/SystemIconPack.java
@@ -89,13 +89,23 @@ public class SystemIconPack implements IconPack<Void> {
             } else {
                 drawable = ctx.getPackageManager().getActivityIcon(componentName);
             }
-
-            // This should never happen, let's just return the generic activity icon
-            if (drawable == null)
-                drawable = ctx.getPackageManager().getDefaultActivityIcon();
         } catch (PackageManager.NameNotFoundException | IndexOutOfBoundsException e) {
             Log.e(TAG, "Unable to find component " + componentName.toShortString(), e);
         }
+
+        // This should never happen, let's just return the application icon
+        if (drawable == null) {
+            try {
+                drawable = ctx.getPackageManager().getApplicationIcon(componentName.getPackageName());
+            } catch (PackageManager.NameNotFoundException e) {
+                Log.e(TAG, "Unable to find package " + componentName.getPackageName(), e);
+            }
+        }
+
+        // This should never happen, let's just return the generic activity icon
+        if (drawable == null)
+            drawable = ctx.getPackageManager().getDefaultActivityIcon();
+
         return drawable;
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -211,11 +211,8 @@ public class ShortcutsResult extends Result {
     private Drawable getDrawableFromOreoShortcut(Context context) {
         ShortcutInfo shortcutInfo = getShortCut(context);
         if (shortcutInfo != null) {
-            final UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
-            assert userManager != null;
-
             IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
-            return iconsHandler.getDrawableIconForPackage(shortcutInfo.getActivity(), new fr.neamar.kiss.utils.UserHandle(userManager.getSerialNumberForUser(shortcutInfo.getUserHandle()), shortcutInfo.getUserHandle()));
+            return iconsHandler.getDrawableIconForPackage(shortcutInfo.getActivity(), new fr.neamar.kiss.utils.UserHandle());
         }
         return null;
     }

--- a/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
@@ -9,12 +9,14 @@ import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.content.pm.ShortcutInfo;
 import android.os.Build;
+import android.os.UserHandle;
 import android.os.UserManager;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -24,6 +26,7 @@ import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.shortcut.SaveAllOreoShortcutsAsync;
 import fr.neamar.kiss.shortcut.SaveSingleOreoShortcutAsync;
 
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
 
@@ -34,14 +37,14 @@ public class ShortcutUtil {
     /**
      * @return shortcut id generated from shortcut name
      */
-    public static String generateShortcutId(String shortcutName){
+    public static String generateShortcutId(String shortcutName) {
         return ShortcutPojo.SCHEME + shortcutName.toLowerCase(Locale.ROOT);
     }
 
     /**
      * @return true if shortcuts are enabled in settings and android version is higher or equals android 8
      */
-    public static boolean areShortcutsEnabled(Context context){
+    public static boolean areShortcutsEnabled(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                 prefs.getBoolean("enable-shortcuts", true);
@@ -51,7 +54,7 @@ public class ShortcutUtil {
     /**
      * Save all oreo shortcuts to DB
      */
-    public static void addAllShortcuts(Context context){
+    public static void addAllShortcuts(Context context) {
         new SaveAllOreoShortcutsAsync(context).execute();
     }
 
@@ -59,14 +62,14 @@ public class ShortcutUtil {
      * Save single shortcut to DB via pin request
      */
     @TargetApi(Build.VERSION_CODES.O)
-    public static void addShortcut(Context context, Intent intent){
+    public static void addShortcut(Context context, Intent intent) {
         new SaveSingleOreoShortcutAsync(context, intent).execute();
     }
 
     /**
      * Remove all shortcuts saved in the database
      */
-    public static void removeAllShortcuts(Context context){
+    public static void removeAllShortcuts(Context context) {
         DBHelper.removeAllShortcuts(context);
     }
 
@@ -75,14 +78,14 @@ public class ShortcutUtil {
      */
     @TargetApi(Build.VERSION_CODES.O)
     public static List<ShortcutInfo> getAllShortcuts(Context context) {
-        return getShortcut(context, null);
+        return getShortcuts(context, null);
     }
 
     /**
      * @return all shortcuts for given package name
      */
     @TargetApi(Build.VERSION_CODES.O)
-    public static List<ShortcutInfo> getShortcut(Context context, String packageName) {
+    public static List<ShortcutInfo> getShortcuts(Context context, String packageName) {
         List<ShortcutInfo> shortcutInfoList = new ArrayList<>();
 
         UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
@@ -91,7 +94,7 @@ public class ShortcutUtil {
         LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
         shortcutQuery.setQueryFlags(FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
 
-        if(!TextUtils.isEmpty(packageName)){
+        if (!TextUtils.isEmpty(packageName)) {
             shortcutQuery.setPackage(packageName);
         }
 
@@ -103,10 +106,44 @@ public class ShortcutUtil {
     }
 
     /**
+     * @return return a specific shortcut for given package name and id
+     */
+    @TargetApi(Build.VERSION_CODES.O)
+    public static ShortcutInfo getShortCut(Context context, String packageName, String shortcutId) {
+        final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+        final UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+
+        if (launcherApps.hasShortcutHostPermission() && !TextUtils.isEmpty(packageName)) {
+            LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
+            query.setPackage(packageName);
+            query.setShortcutIds(Collections.singletonList(shortcutId));
+            query.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+
+            List<android.os.UserHandle> userHandles = launcherApps.getProfiles();
+
+            // find the correct UserHandle and get shortcut
+            for (UserHandle userHandle : userHandles) {
+                if (userManager.isUserRunning(userHandle)) {
+                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
+                    if (shortcuts != null) {
+                        for (ShortcutInfo shortcut : shortcuts) {
+                            if (shortcut.isEnabled()) {
+                                return shortcut;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Create ShortcutPojo from ShortcutInfo
      */
     @TargetApi(Build.VERSION_CODES.O)
-    public static ShortcutRecord createShortcutRecord(Context context, ShortcutInfo shortcutInfo, boolean includePackageName){
+    public static ShortcutRecord createShortcutRecord(Context context, ShortcutInfo shortcutInfo, boolean includePackageName) {
         ShortcutRecord record = new ShortcutRecord();
         record.packageName = shortcutInfo.getPackage();
         record.intentUri = ShortcutPojo.OREO_PREFIX + shortcutInfo.getId();
@@ -114,16 +151,16 @@ public class ShortcutUtil {
         String appName = getAppNameFromPackageName(context, shortcutInfo.getPackage());
 
         if (shortcutInfo.getShortLabel() != null) {
-            if(includePackageName && !TextUtils.isEmpty(appName)){
+            if (includePackageName && !TextUtils.isEmpty(appName)) {
                 record.name = appName + ": " + shortcutInfo.getShortLabel().toString();
             } else {
                 record.name = shortcutInfo.getShortLabel().toString();
             }
         } else if (shortcutInfo.getLongLabel() != null) {
-            if(includePackageName && !TextUtils.isEmpty(appName)){
+            if (includePackageName && !TextUtils.isEmpty(appName)) {
                 record.name = appName + ": " + shortcutInfo.getLongLabel().toString();
             } else {
-                record.name =shortcutInfo.getLongLabel().toString();
+                record.name = shortcutInfo.getLongLabel().toString();
             }
         } else {
             Log.d(TAG, "Invalid shortcut for " + record.packageName + ", ignoring");
@@ -134,7 +171,6 @@ public class ShortcutUtil {
     }
 
     /**
-     *
      * @return App name from package name
      */
     public static String getAppNameFromPackageName(Context context, String Packagename) {
@@ -148,7 +184,6 @@ public class ShortcutUtil {
             return "";
         }
     }
-
 
 
 }


### PR DESCRIPTION
(Oreo) shortcuts were not considering app icons from icon packs.
This will be fixed with this pull request, e.g. a firefox shortcut before:
![Screenshot_20210320-112652_KISS_Launcher](https://user-images.githubusercontent.com/3027783/111867269-2c281200-8973-11eb-9ae6-5a5c5a98592d.png)

and with this fix: 
![Screenshot_20210320-112529_Debug_KISS_launcher](https://user-images.githubusercontent.com/3027783/111867271-31855c80-8973-11eb-8328-15071474164e.png)

Changes in details are following:
IconsHandler.java
- now calls mIconPack.getComponentDrawable with maximum parameters, everything else will be handled by implementation itself

SystemIconPack.java:
- if icon for componentName can't be found, it tries to load by package name only before falling back to generic icon

ShortcutsResult.java
- do not load icons at all if "icons-hide" is true
- try to load icon from ShortcutInfo first (for oreo shortcuts)
- always get ShortcutInfo for Oreo shortcuts the same way (ShortCutUtil)
- uses getDrawableIconForPackage instead of getActivityIcon to consider icon packs

