### PR TITLE
improve notification listener

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
+++ b/app/src/main/java/fr/neamar/kiss/notification/NotificationListener.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss.notification;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -33,18 +34,22 @@ public class NotificationListener extends NotificationListenerService {
         super.onListenerConnected();
         Log.i(TAG, "Notification listener connected");
 
+        refreshAllNotifications();
+    }
+
+    private void refreshAllNotifications() {
         // Build a map of notifications currently displayed,
         // ordered per package
         StatusBarNotification[] sbns = getActiveNotifications();
         Map<String, Set<String>> notificationsByPackage = new HashMap<>();
         for (StatusBarNotification sbn : sbns) {
-            if(isNotificationTrivial(sbn.getNotification())) {
+            if (isNotificationTrivial(sbn)) {
                 continue;
             }
 
             String packageName = sbn.getPackageName();
             if (!notificationsByPackage.containsKey(packageName)) {
-                notificationsByPackage.put(packageName, new HashSet<String>());
+                notificationsByPackage.put(packageName, new HashSet<>());
             }
 
             notificationsByPackage.get(packageName).add(Integer.toString(sbn.getId()));
@@ -66,6 +71,8 @@ public class NotificationListener extends NotificationListenerService {
         }
 
         editor.apply();
+
+        Log.v(TAG, "Refreshed all notifications for " + allKeys.toString());
     }
 
     @Override
@@ -80,45 +87,53 @@ public class NotificationListener extends NotificationListenerService {
         for (String packageName : packages) {
             editor.remove(packageName);
         }
+
         editor.apply();
+
+        Log.v(TAG, "Removed all notifications for " + packages.toString());
 
         super.onListenerDisconnected();
     }
 
     @Override
+    public void onNotificationRankingUpdate(RankingMap rankingMap) {
+        super.onNotificationRankingUpdate(rankingMap);
+
+        refreshAllNotifications();
+    }
+
+    @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
-        if(isNotificationTrivial(sbn.getNotification())) {
+        if (isNotificationTrivial(sbn)) {
             return;
         }
 
         Set<String> currentNotifications = getCurrentNotificationsForPackage(sbn.getPackageName());
+        if (currentNotifications.add(Integer.toString(sbn.getId()))) {
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putStringSet(sbn.getPackageName(), currentNotifications);
+            editor.apply();
 
-        currentNotifications.add(Integer.toString(sbn.getId()));
-        prefs.edit().putStringSet(sbn.getPackageName(), currentNotifications).apply();
-
-        Log.v(TAG, "Added notification for " + sbn.getPackageName() + ": " + currentNotifications.toString());
+            Log.v(TAG, "Added notification for " + sbn.getPackageName() + ": " + currentNotifications.toString());
+        }
     }
 
     @Override
     public void onNotificationRemoved(StatusBarNotification sbn) {
-        if(isNotificationTrivial(sbn.getNotification())) {
-            return;
-        }
-
         Set<String> currentNotifications = getCurrentNotificationsForPackage(sbn.getPackageName());
 
-        currentNotifications.remove(Integer.toString(sbn.getId()));
+        if (currentNotifications.remove(Integer.toString(sbn.getId()))) {
+            SharedPreferences.Editor editor = prefs.edit();
+            if (currentNotifications.isEmpty()) {
+                // Clean up!
+                editor.remove(sbn.getPackageName());
+            } else {
+                editor.putStringSet(sbn.getPackageName(), currentNotifications);
+            }
+            editor.apply();
 
-        SharedPreferences.Editor editor = prefs.edit();
-        if (currentNotifications.isEmpty()) {
-            // Clean up!
-            editor.remove(sbn.getPackageName());
-        } else {
-            editor.putStringSet(sbn.getPackageName(), currentNotifications);
+            Log.v(TAG, "Removed notification for " + sbn.getPackageName() + ": " + currentNotifications.toString());
         }
-        editor.apply();
-
-        Log.v(TAG, "Removed notification for " + sbn.getPackageName() + ": " + currentNotifications.toString());
     }
 
     public Set<String> getCurrentNotificationsForPackage(String packageName) {
@@ -132,8 +147,37 @@ public class NotificationListener extends NotificationListenerService {
         }
     }
 
-    // Low priority and ongoing notifications should not be displayed
-    public boolean isNotificationTrivial(Notification notification) {
-        return notification.priority <= Notification.PRIORITY_MIN || (notification.flags & Notification.FLAG_ONGOING_EVENT) != 0;
+    /**
+     * Check for trivial notifications.
+     *
+     * From Android O notification channels controls if badges should be displayed.
+     * For older versions and legacy notification channel low priority notifications, ongoing notifications
+     * and group summaries should not be displayed.
+     *
+     * @param sbn
+     * @return true if badge should not be displayed
+     */
+    public boolean isNotificationTrivial(StatusBarNotification sbn) {
+        Notification notification = sbn.getNotification();
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final Ranking mTempRanking = new Ranking();
+            getCurrentRanking().getRanking(sbn.getKey(), mTempRanking);
+            if (!mTempRanking.canShowBadge()) {
+                return true;
+            }
+            if (!mTempRanking.getChannel().getId().equals(NotificationChannel.DEFAULT_CHANNEL_ID)) {
+                return isGroupHeader(notification);
+            }
+        }
+
+        return notification.priority <= Notification.PRIORITY_MIN || (notification.flags & Notification.FLAG_ONGOING_EVENT) != 0 || isGroupHeader(notification);
+    }
+
+    private boolean isGroupHeader(Notification notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            return (notification.flags & Notification.FLAG_GROUP_SUMMARY) != 0;
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Notification badges sometimes seemed a little bit "unstable" to me.
While debugging this on android 10 i came up with following improvements:

- handle group summaries like trivial notifications (api 20 and up)
- respect channel setting: canShowBadge (api 26 and up)
- always try to remove badge on notification remove
- refresh badges also on notification channel changes
- avoid unnecessary preference writes

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
