### PR TITLE
description license

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -9,7 +9,7 @@ KISS is just 250 KB and never connects to the Internet.
 <strong>93% of users that try KISS for a week are still active users after 3 years.</strong>
 -------------------------
 
-AGPLv3+ copylefted libre software means everyone can use, see, change and share at will, with all.
+GPLv3+ copylefted libre software means everyone can use, see, change and share at will, with all.
 <a href="https://github.com/Neamar/KISS">GitHub</a>.
 
 Help, customizations and screenshots.


### PR DESCRIPTION
Metadata mentions the Affero GPL (AGPL) while the repo is under regular GPL.