### PR TITLE
use mavenCentral instead of jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 


### PR DESCRIPTION
JCenter is at end of life: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
use mavenCentral instead
