### PR TITLE
improve widgets resize

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -438,6 +438,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
     protected void onDestroy() {
         super.onDestroy();
         this.unregisterReceiver(this.mReceiver);
+        forwarderManager.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
@@ -6,10 +6,7 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 
-import androidx.annotation.NonNull;
-
 import fr.neamar.kiss.MainActivity;
-import fr.neamar.kiss.utils.Permission;
 
 public class ForwarderManager extends Forwarder {
     private final Widgets widgetsForwarder;
@@ -46,7 +43,6 @@ public class ForwarderManager extends Forwarder {
     }
 
     public void onStart() {
-        widgetsForwarder.onStart();
     }
 
     public void onResume() {
@@ -61,7 +57,6 @@ public class ForwarderManager extends Forwarder {
     }
 
     public void onStop() {
-        widgetsForwarder.onStop();
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -109,5 +104,9 @@ public class ForwarderManager extends Forwarder {
             return true;
         }
         return false;
+    }
+
+    public void onDestroy() {
+        widgetsForwarder.onDestroy();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -60,28 +60,9 @@ class Widgets extends Forwarder {
         widgetArea = mainActivity.findViewById(R.id.widgetLayout);
 
         restoreWidgets();
-    }
 
-    void onStart() {
         // Start listening for widget update
-        try {
-            mAppWidgetHost.startListening();
-        } catch (Resources.NotFoundException e) {
-            // Widgets app was just updated?
-            // See https://github.com/Neamar/KISS/issues/959
-        }
-    }
-
-    void onStop() {
-        // Stop listening for widget update
-        // See https://github.com/Neamar/KISS/issues/744
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-            try {
-                mAppWidgetHost.stopListening();
-            } catch(NullPointerException e) {
-                // Ignore, happens on some shitty widget down the stack trace.
-            }
-        }
+        mAppWidgetHost.startListening();
     }
 
     void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -406,5 +387,9 @@ class Widgets extends Forwarder {
         Resources r = mainActivity.getResources();
 
         return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dip, r.getDisplayMetrics());
+    }
+
+    public void onDestroy() {
+        mAppWidgetHost.stopListening();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -28,6 +28,8 @@ import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.ui.WidgetHost;
 
+import static android.appwidget.AppWidgetProviderInfo.RESIZE_VERTICAL;
+
 class Widgets extends Forwarder {
     private static final int REQUEST_APPWIDGET_PICKED = 9;
     private static final int REQUEST_APPWIDGET_CONFIGURED = 5;
@@ -164,11 +166,7 @@ class Widgets extends Forwarder {
             int id = Integer.parseInt(conf[0]);
             int lineSize = Integer.parseInt(conf[1]);
             idsUsed.add(id);
-            AppWidgetHostView widget = getWidget(id, lineSize);
-            if (widget != null) {
-                // Add the widget into the linearlayout. LayoutParams as specified in getWidget() will be erased, so specify them again
-                widgetArea.addView(widget, LinearLayout.LayoutParams.MATCH_PARENT, widget.getLayoutParams().height);
-            }
+            addWidget(id, lineSize);
         }
 
         // kill zombie widgets
@@ -187,26 +185,20 @@ class Widgets extends Forwarder {
      * add context menu to it
      *
      * @param appWidgetId id of widget to add
+     * @param lineSize    height of widget given in lines
      */
-    private AppWidgetHostView getWidget(int appWidgetId, int lineSize) {
+    private void addWidget(int appWidgetId, int lineSize) {
         AppWidgetProviderInfo appWidgetInfo = mAppWidgetManager.getAppWidgetInfo(appWidgetId);
         if (appWidgetInfo == null) {
             Log.i("Widget", "Unable to retrieve widget by id " + appWidgetId);
-            return null;
+            return;
         }
 
         AppWidgetHostView hostView = mAppWidgetHost.createView(mainActivity, appWidgetId, appWidgetInfo);
 
         int height = (int) (lineSize * getLineHeight());
-        ViewGroup.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, height);
-        hostView.setLayoutParams(params);
-
-        hostView.setMinimumHeight(height);
-
         hostView.setAppWidget(appWidgetId, appWidgetInfo);
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
-            hostView.updateAppWidgetSize(null, appWidgetInfo.minWidth, height, appWidgetInfo.minWidth, height);
-        }
+        setWidgetSize(hostView, height, appWidgetInfo);
 
         hostView.setLongClickable(true);
         hostView.setOnLongClickListener(v -> {
@@ -224,9 +216,13 @@ class Widgets extends Forwarder {
             if (parent.indexOfChild(hostView) == parent.getChildCount() - 1) {
                 menu.findItem(R.id.move_down).setVisible(false);
             }
-            int newLineSize = Math.round(hostView.getLayoutParams().height / getLineHeight()) - 1;
-            if (newLineSize == 0 || (newLineSize * getLineHeight() < appWidgetInfo.minHeight)) {
+            int decreasedLineHeight = getDecreasedLineHeight(hostView);
+            if (preventResizeWidget(decreasedLineHeight, appWidgetInfo)) {
                 menu.findItem(R.id.decrease_size).setVisible(false);
+            }
+            int increasedLineHeight = getIncreasedLineHeight(hostView);
+            if (preventResizeWidget(increasedLineHeight, appWidgetInfo)) {
+                menu.findItem(R.id.increase_size).setVisible(false);
             }
 
             popup.setOnMenuItemClickListener(item -> {
@@ -234,29 +230,17 @@ class Widgets extends Forwarder {
                 switch (item.getItemId()) {
                     case R.id.remove_widget:
                         parent.removeView(widgetWithMenuCurrentlyDisplayed);
+                        mAppWidgetHost.deleteAppWidgetId(widgetWithMenuCurrentlyDisplayed.getAppWidgetId());
                         serializeState();
                         return true;
                     case R.id.increase_size: {
-                        int lineSize1 = Math.round(widgetWithMenuCurrentlyDisplayed.getLayoutParams().height / getLineHeight());
-                        lineSize1++;
-                        ViewGroup.LayoutParams params1 = widgetWithMenuCurrentlyDisplayed.getLayoutParams();
-                        params1.height = (int) (lineSize1 * getLineHeight());
-                        widgetWithMenuCurrentlyDisplayed.setLayoutParams(params1);
-                        serializeState();
+                        int height1 = getIncreasedLineHeight(widgetWithMenuCurrentlyDisplayed);
+                        resizeWidget(widgetWithMenuCurrentlyDisplayed, height1);
                         return true;
                     }
                     case R.id.decrease_size: {
-                        int lineSize1 = Math.round(widgetWithMenuCurrentlyDisplayed.getLayoutParams().height / getLineHeight());
-                        lineSize1--;
-                        AppWidgetProviderInfo appWidgetInfo1 = mAppWidgetManager.getAppWidgetInfo(widgetWithMenuCurrentlyDisplayed.getAppWidgetId());
-                        if (lineSize1 == 0 || (lineSize1 * getLineHeight() < appWidgetInfo1.minHeight)) {
-                            return true;
-                        }
-
-                        ViewGroup.LayoutParams params1 = widgetWithMenuCurrentlyDisplayed.getLayoutParams();
-                        params1.height = (int) (lineSize1 * getLineHeight());
-                        widgetWithMenuCurrentlyDisplayed.setLayoutParams(params1);
-                        serializeState();
+                        int height1 = getDecreasedLineHeight(widgetWithMenuCurrentlyDisplayed);
+                        resizeWidget(widgetWithMenuCurrentlyDisplayed, height1);
                         return true;
                     }
                     case R.id.move_up: {
@@ -288,7 +272,62 @@ class Widgets extends Forwarder {
             return true;
         });
 
-        return hostView;
+        widgetArea.addView(hostView);
+    }
+
+    /**
+     * @param hostView host view of widget
+     * @return decreased line height of host view
+     */
+    private int getDecreasedLineHeight(AppWidgetHostView hostView) {
+        int lineSize = Math.round(hostView.getLayoutParams().height / getLineHeight()) - 1;
+        return (int) (lineSize * getLineHeight());
+    }
+
+    /**
+     * @param hostView host view of widget
+     * @return increased line height of host view
+     */
+    private int getIncreasedLineHeight(AppWidgetHostView hostView) {
+        int lineSize = Math.round(hostView.getLayoutParams().height / getLineHeight()) + 1;
+        return (int) (lineSize * getLineHeight());
+    }
+
+    /**
+     * Set new height to host view of widget.
+     *
+     * @param hostView host view for widget
+     * @param height   height of widget
+     */
+    private void setWidgetSize(AppWidgetHostView hostView, int height, AppWidgetProviderInfo appWidgetInfo) {
+        hostView.setMinimumHeight(height);
+        hostView.setMinimumWidth(Math.min(appWidgetInfo.minWidth, appWidgetInfo.minResizeWidth));
+        ViewGroup.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height);
+        hostView.setLayoutParams(params);
+    }
+
+    /**
+     * @param hostView host view of widget
+     * @param height   new height of widget
+     */
+    private void resizeWidget(AppWidgetHostView hostView, int height) {
+        AppWidgetProviderInfo appWidgetInfo = mAppWidgetManager.getAppWidgetInfo(hostView.getAppWidgetId());
+        if (preventResizeWidget(height, appWidgetInfo)) {
+            return;
+        }
+        setWidgetSize(hostView, height, appWidgetInfo);
+        serializeState();
+    }
+
+    /**
+     * Check if resize of widget is prevented.
+     *
+     * @param height        new height of widget
+     * @param appWidgetInfo
+     * @return true, if widget cannot be resized to given height
+     */
+    private boolean preventResizeWidget(int height, AppWidgetProviderInfo appWidgetInfo) {
+        return height <= 0 || height < Math.min(appWidgetInfo.minHeight, appWidgetInfo.minResizeHeight) || (appWidgetInfo.resizeMode & RESIZE_VERTICAL) != RESIZE_VERTICAL;
     }
 
     /**
@@ -303,10 +342,7 @@ class Widgets extends Forwarder {
         float minWidgetHeight = appWidgetInfo.minHeight;
         float lineHeight = getLineHeight();
         int lineSize = (int) Math.ceil(minWidgetHeight / lineHeight);
-        AppWidgetHostView widget = getWidget(appWidgetId, lineSize);
-        if (widget != null) {
-            widgetArea.addView(widget, LinearLayout.LayoutParams.MATCH_PARENT, widget.getLayoutParams().height);
-        }
+        addWidget(appWidgetId, lineSize);
 
         serializeState();
     }

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetHost.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetHost.java
@@ -4,6 +4,7 @@ import android.appwidget.AppWidgetHost;
 import android.appwidget.AppWidgetHostView;
 import android.appwidget.AppWidgetProviderInfo;
 import android.content.Context;
+import android.content.res.Resources;
 
 public class WidgetHost extends AppWidgetHost {
 
@@ -15,5 +16,28 @@ public class WidgetHost extends AppWidgetHost {
     protected AppWidgetHostView onCreateView(Context context, int appWidgetId, AppWidgetProviderInfo appWidget) {
         // We need to create a custom view to handle long click events
         return new WidgetView(context);
+    }
+
+    @Override
+    public void startListening() {
+        try {
+            super.startListening();
+        } catch (Resources.NotFoundException e) {
+            // Widgets app was just updated?
+            // See https://github.com/Neamar/KISS/issues/959
+        }
+    }
+
+    @Override
+    public void stopListening() {
+        // If stopListening is called during onDestroy the workaround for https://github.com/Neamar/KISS/issues/744 is not needed any more.
+        // This was necessary because stopListening cleared remote views until https://android.googlesource.com/platform/frameworks/base/+/2857f1c783e69461735a51159f9abdb85378e210
+        // which is ok for calls during onDestroy()
+        try {
+            super.stopListening();
+        } catch (NullPointerException e) {
+            // Ignore, happens on some shitty widget down the stack trace.
+        }
+        clearViews();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
@@ -107,8 +107,11 @@ public class WidgetView extends AppWidgetHostView {
         super.onSizeChanged(w, h, oldw, oldh);
 
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
-            updateAppWidgetSize(null, w, h, w, h);
+            // calculate size in dips
+            float density = getResources().getDisplayMetrics().density;
+            int widthDips = (int) (w / density);
+            int heightDips = (int) (h / density);
+            updateAppWidgetSize(null, widthDips, heightDips, widthDips, heightDips);
         }
     }
-
 }

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss.ui;
 
 import android.appwidget.AppWidgetHostView;
 import android.content.Context;
+import android.os.Build;
 import android.view.MotionEvent;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
@@ -36,7 +37,7 @@ public class WidgetView extends AppWidgetHostView {
                 break;
             }
             case MotionEvent.ACTION_MOVE: {
-                if(Math.abs(ev.getX() - xPos) > 5 || Math.abs(ev.getY() - yPos) > 5) {
+                if (Math.abs(ev.getX() - xPos) > 5 || Math.abs(ev.getY() - yPos) > 5) {
                     mHasPerformedLongPress = false;
                     if (mPendingCheckForLongPress != null) {
                         removeCallbacks(mPendingCheckForLongPress);
@@ -100,4 +101,14 @@ public class WidgetView extends AppWidgetHostView {
     public int getDescendantFocusability() {
         return ViewGroup.FOCUS_BLOCK_DESCENDANTS;
     }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+            updateAppWidgetSize(null, w, h, w, h);
+        }
+    }
+
 }


### PR DESCRIPTION
- do not stop updating widgets immediately if activity becomes invisible (fixes #1763)
- call `updateAppWidgetSize` on change of size to ensure that widgets always got proper size for layout (fixes #1763)
- call `updateAppWidgetSize` with dimensions in dip
- set proper minimum height and minimum width of hostView
- do not allow resize depending on widgets resize mode
- call `deleteAppWidgetId` on remove of widget to prevent zombie widgets
- if there is no screen space left, widgets are added as small as possible
- encapsule some calculations

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
