### PR TITLE
add support for dynamic shortcuts

### DIFF
--- a/app/src/debug/res/values-de/strings.xml
+++ b/app/src/debug/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="app_name">Debug KISS launcher</string>
+</resources>

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -1,6 +1,5 @@
 package fr.neamar.kiss;
 
-import android.annotation.TargetApi;
 import android.app.KeyguardManager;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -420,37 +419,45 @@ public class DataHandler extends BroadcastReceiver
         return (pojo != null) ? pojo.getName() : "???";
     }
 
-    public boolean addShortcut(ShortcutRecord record) {
-        Log.d(TAG, "Adding shortcut for " + record.packageName);
-        return DBHelper.insertShortcut(this.context, record);
-    }
-
-    @TargetApi(Build.VERSION_CODES.O)
-    public void addShortcut(String packageName) {
-
+    /**
+     * Update stored shortcut info for all shortcuts of given packageName.
+     *
+     * @param packageName package name
+     */
+    public void updateShortcuts(String packageName) {
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return;
         }
 
         List<ShortcutInfo> shortcuts;
         try {
-            shortcuts = ShortcutUtil.getShortcut(context, packageName);
+            shortcuts = ShortcutUtil.getShortcuts(context, packageName);
         } catch (SecurityException | IllegalStateException e) {
             e.printStackTrace();
             return;
         }
 
-        for (ShortcutInfo shortcutInfo : shortcuts) {
-            // Create Pojo
-            ShortcutRecord record = ShortcutUtil.createShortcutRecord(context, shortcutInfo, true);
-            if (record == null) {
-                continue;
-            }
-            // Add shortcut to the DataHandler
-            addShortcut(record);
+        updateShortcuts(packageName, shortcuts);
+    }
+
+    /**
+     * Update stored shortcut info for given shortcuts.
+     *
+     * @param packageName package name
+     */
+    public void updateShortcuts(String packageName, List<ShortcutInfo> shortcuts) {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
         }
 
-        if (!shortcuts.isEmpty() && this.getShortcutsProvider() != null) {
+        Log.d(TAG, "Updating shortcuts for " + packageName);
+
+        boolean shortcutsUpdated = false;
+        for (ShortcutInfo shortcutInfo : shortcuts) {
+            shortcutsUpdated |= updateShortcut(shortcutInfo);
+        }
+
+        if (shortcutsUpdated && this.getShortcutsProvider() != null) {
             this.getShortcutsProvider().reload();
         }
     }
@@ -459,16 +466,79 @@ public class DataHandler extends BroadcastReceiver
         DBHelper.clearHistory(this.context);
     }
 
+    /**
+     * Remove shortcut for given {@link ShortcutPojo}
+     * This is used for remove of shortcut from gui.
+     *
+     * @param shortcut shortcut to be removed
+     */
     public void removeShortcut(ShortcutPojo shortcut) {
-        // Also remove shortcut from favorites
-        removeFromFavorites(shortcut.id);
-        DBHelper.removeShortcut(this.context, shortcut);
-
+        removeShortcut(shortcut.id, shortcut.packageName, shortcut.intentUri);
         if (this.getShortcutsProvider() != null) {
             this.getShortcutsProvider().reload();
         }
     }
 
+    /**
+     * Update DB with given {@link ShortcutRecord}.
+     *
+     * @param shortcutInfo the shortcut to update.
+     * @return true if update was successful
+     */
+    public boolean updateShortcut(ShortcutInfo shortcutInfo) {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return false;
+        }
+        String componentName = ShortcutUtil.getComponentName(context, shortcutInfo);
+
+        // if related package is excluded from KISS then the shortcut must be excluded too
+        Set<String> excludedAppList = getExcluded();
+        if (excludedAppList.contains(componentName)) {
+            return false;
+        }
+
+        // Create Pojo
+        ShortcutRecord shortcut = ShortcutUtil.createShortcutRecord(context, shortcutInfo, !shortcutInfo.isPinned());
+
+        if (shortcut == null) {
+            return false;
+        }
+        if (shortcutInfo.isEnabled()) {
+            Log.d(TAG, "Adding shortcut for " + shortcut.packageName);
+
+            // if related package name is excluded from history, shortcut must be excluded from history too
+            Set<String> excludedFromHistoryAppList = getExcludedFromHistory();
+            if (excludedFromHistoryAppList.contains(componentName)) {
+                addToExcludedFromHistory(shortcut);
+            }
+
+            return DBHelper.insertShortcut(this.context, shortcut);
+        } else {
+            String id = ShortcutUtil.generateShortcutId(shortcut.name);
+            removeShortcut(id, shortcut.packageName, shortcut.intentUri);
+            return true;
+        }
+    }
+
+    /**
+     * Remove given shortcut from favorites and from DB
+     *
+     * @param id          KISS shortcut id, same as {@link ShortcutPojo#id}
+     * @param packageName package name, same as {@link ShortcutPojo#packageName}
+     * @param intentUri   intent to be called, same as {@link ShortcutPojo#intentUri}
+     */
+    private void removeShortcut(String id, String packageName, String intentUri) {
+        Log.d(TAG, "Removing shortcut for " + packageName);
+        // Also remove shortcut from favorites
+        removeFromFavorites(id);
+        DBHelper.removeShortcut(this.context, packageName, intentUri);
+    }
+
+    /**
+     * Removes all stored shortcuts for given packageName.
+     *
+     * @param packageName
+     */
     public void removeShortcuts(String packageName) {
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return;
@@ -547,6 +617,16 @@ public class DataHandler extends BroadcastReceiver
         app.setExcludedFromHistory(true);
     }
 
+    private void addToExcludedFromHistory(ShortcutRecord shortcut) {
+        // The set needs to be cloned and then edited,
+        // modifying in place is not supported by putStringSet()
+        Set<String> excluded = new HashSet<>(getExcludedFromHistory());
+        // Add given shortcut to being excluded from history
+        String id = ShortcutUtil.generateShortcutId(shortcut.name);
+        excluded.add(id);
+        PreferenceManager.getDefaultSharedPreferences(context).edit().putStringSet("excluded-apps-from-history", excluded).apply();
+    }
+
     public void removeFromExcludedFromHistory(AppPojo app) {
         // The set needs to be cloned and then edited,
         // modifying in place is not supported by putStringSet()
@@ -591,7 +671,7 @@ public class DataHandler extends BroadcastReceiver
         app.setExcluded(false);
 
         // Add shortcuts for this app
-        addShortcut(app.packageName);
+        updateShortcuts(app.packageName);
     }
 
     public void removeFromExcluded(String packageName) {

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -33,7 +33,7 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
                 String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
                 KissApplication.getApplication(ctx).getDataHandler().addToHistory(pojoID);
                 // Add shortcut
-                KissApplication.getApplication(ctx).getDataHandler().addShortcut(packageName);
+                KissApplication.getApplication(ctx).getDataHandler().updateShortcuts(packageName);
             }
         }
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -1,6 +1,5 @@
 package fr.neamar.kiss.dataprovider;
 
-import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -28,7 +27,6 @@ import fr.neamar.kiss.utils.UserHandle;
 public class AppProvider extends Provider<AppPojo> {
 
     @Override
-    @SuppressLint("NewApi")
     public void onCreate() {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             // Package installation/uninstallation events for the main
@@ -39,7 +37,7 @@ public class AppProvider extends Provider<AppPojo> {
             final LauncherApps launcher = (LauncherApps) this.getSystemService(Context.LAUNCHER_APPS_SERVICE);
             assert launcher != null;
 
-            launcher.registerCallback(new LauncherApps.Callback() {
+            launcher.registerCallback(new LauncherAppsCallback() {
                 @Override
                 public void onPackageAdded(String packageName, android.os.UserHandle user) {
                     if (!Process.myUserHandle().equals(user)) {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/LauncherAppsCallback.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/LauncherAppsCallback.java
@@ -1,0 +1,49 @@
+package fr.neamar.kiss.dataprovider;
+
+import android.annotation.SuppressLint;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
+import android.os.Build;
+import android.os.UserHandle;
+
+import androidx.annotation.RequiresApi;
+
+import java.util.List;
+
+/**
+ * Empty implementation of LauncherApps.Callback so we do not need to override all methods when
+ * only parts of LauncherApps.Callback are needed.
+ */
+@SuppressLint("NewApi")
+public class LauncherAppsCallback extends LauncherApps.Callback {
+    @Override
+    public void onPackageRemoved(String packageName, UserHandle user) {
+
+    }
+
+    @Override
+    public void onPackageAdded(String packageName, UserHandle user) {
+
+    }
+
+    @Override
+    public void onPackageChanged(String packageName, UserHandle user) {
+
+    }
+
+    @Override
+    public void onPackagesAvailable(String[] packageNames, UserHandle user, boolean replacing) {
+
+    }
+
+    @Override
+    public void onPackagesUnavailable(String[] packageNames, UserHandle user, boolean replacing) {
+
+    }
+
+    @Override
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void onShortcutsChanged(String packageName, List<ShortcutInfo> shortcuts, UserHandle user) {
+    }
+
+}

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ShortcutsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ShortcutsProvider.java
@@ -1,7 +1,14 @@
 package fr.neamar.kiss.dataprovider;
 
+import android.content.Context;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
+import android.os.Build;
 import android.widget.Toast;
 
+import java.util.List;
+
+import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.loader.LoadShortcutsPojos;
 import fr.neamar.kiss.normalizer.StringNormalizer;
@@ -12,6 +19,23 @@ import fr.neamar.kiss.utils.FuzzyScore;
 
 public class ShortcutsProvider extends Provider<ShortcutPojo> {
     private static boolean notifiedKissNotDefaultLauncher = false;
+
+    @Override
+    public void onCreate() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final LauncherApps launcher = (LauncherApps) this.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+            assert launcher != null;
+
+            launcher.registerCallback(new LauncherAppsCallback() {
+                @Override
+                public void onShortcutsChanged(String packageName, List<ShortcutInfo> shortcuts, android.os.UserHandle user) {
+                    KissApplication.getApplication(ShortcutsProvider.this).getDataHandler().updateShortcuts(packageName, shortcuts);
+                }
+            });
+        }
+
+        super.onCreate();
+    }
 
     @Override
     public void reload() {

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.KissApplication;
-import fr.neamar.kiss.pojo.ShortcutPojo;
 
 public class DBHelper {
     private static final String TAG = DBHelper.class.getSimpleName();
@@ -247,9 +246,9 @@ public class DBHelper {
         return true;
     }
 
-    public static void removeShortcut(Context context, ShortcutPojo shortcut) {
+    public static void removeShortcut(Context context, String packageName, String intentUri) {
         SQLiteDatabase db = getDatabase(context);
-        db.delete("shortcuts", "package = ? AND intent_uri = ?", new String[]{shortcut.packageName, shortcut.intentUri});
+        db.delete("shortcuts", "package = ? AND intent_uri = ?", new String[]{packageName, intentUri});
     }
 
     public static void addCustomAppName(Context context, String componentName, String newName) {
@@ -426,7 +425,7 @@ public class DBHelper {
         // Cursor query (String table, String[] columns, String selection,
         // String[] selectionArgs, String groupBy, String having, String
         // orderBy)
-        Cursor cursor = db.query("shortcuts", new String[]{"name", "package", "intent_uri"},
+        Cursor cursor = db.query("shortcuts", new String[]{"_id", "name", "package", "intent_uri"},
                 "package = ?", new String[]{packageName}, null, null, null);
         cursor.moveToFirst();
 
@@ -434,9 +433,10 @@ public class DBHelper {
         while (!cursor.isAfterLast()) {
             ShortcutRecord entry = new ShortcutRecord();
 
-            entry.name = cursor.getString(0);
-            entry.packageName = cursor.getString(1);
-            entry.intentUri = cursor.getString(2);
+            entry.dbId = cursor.getInt(0);
+            entry.name = cursor.getString(1);
+            entry.packageName = cursor.getString(2);
+            entry.intentUri = cursor.getString(3);
 
             records.add(entry);
             cursor.moveToNext();

--- a/app/src/main/java/fr/neamar/kiss/db/ShortcutRecord.java
+++ b/app/src/main/java/fr/neamar/kiss/db/ShortcutRecord.java
@@ -3,8 +3,14 @@ package fr.neamar.kiss.db;
 public class ShortcutRecord {
     public int dbId;
 
+    /**
+     * Visible name of shortcut.
+     */
     public String name;
 
+    /**
+     * The package name of the publisher app.
+     */
     public String packageName;
 
     public String intentUri;

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -2,7 +2,6 @@ package fr.neamar.kiss.result;
 
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
-import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -15,10 +14,7 @@ import android.content.pm.ResolveInfo;
 import android.content.pm.ShortcutInfo;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.UserHandle;
-import android.os.UserManager;
 import android.preference.PreferenceManager;
-import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -29,9 +25,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.List;
 
 import fr.neamar.kiss.DataHandler;
@@ -42,11 +38,8 @@ import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.FuzzyScore;
+import fr.neamar.kiss.utils.ShortcutUtil;
 import fr.neamar.kiss.utils.SpaceTokenizer;
-
-import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
-import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
-import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
 
 public class ShortcutsResult extends Result {
     private final ShortcutPojo shortcutPojo;
@@ -144,28 +137,11 @@ public class ShortcutsResult extends Result {
     public Drawable getDrawable(Context context) {
         Drawable shortcutDrawable = null;
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
-            assert launcherApps != null;
-
-            if (launcherApps.hasShortcutHostPermission() && !TextUtils.isEmpty(shortcutPojo.packageName)) {
-                LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
-                query.setPackage(shortcutPojo.packageName);
-                query.setShortcutIds(Collections.singletonList(shortcutPojo.getOreoId()));
-                query.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
-
-                List<UserHandle> userHandles = launcherApps.getProfiles();
-
-                // Find the correct UserHandle, and retrieve the icon.
-                for (UserHandle userHandle : userHandles) {
-                    try {
-                        List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
-                        if (shortcuts != null && shortcuts.size() > 0) {
-                            shortcutDrawable = launcherApps.getShortcutIconDrawable(shortcuts.get(0), 0);
-                        }
-                    } catch (IllegalStateException ignored) {
-                        // do nothing if user is locked or not running
-                    }
-                }
+            ShortcutInfo shortcutInfo = getShortCut(context);
+            if (shortcutInfo != null) {
+                final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+                assert launcherApps != null;
+                shortcutDrawable = launcherApps.getShortcutIconDrawable(shortcutInfo, 0);
             }
         }
 
@@ -197,7 +173,6 @@ public class ShortcutsResult extends Result {
     @TargetApi(Build.VERSION_CODES.O)
     private void doOreoLaunch(Context context, View v) {
         final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
-        UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
         assert launcherApps != null;
 
         // Only the default launcher is allowed to start shortcuts
@@ -206,32 +181,19 @@ public class ShortcutsResult extends Result {
             return;
         }
 
-        if (!TextUtils.isEmpty(shortcutPojo.packageName)) {
-            LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
-            query.setPackage(shortcutPojo.packageName);
-            query.setShortcutIds(Collections.singletonList(shortcutPojo.getOreoId()));
-            query.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
-
-            List<UserHandle> userHandles = launcherApps.getProfiles();
-
-            // Find the correct UserHandle, and launch the shortcut.
-            for (UserHandle userHandle : userHandles) {
-                if (userManager.isUserRunning(userHandle)) {
-                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
-                    if (shortcuts != null && shortcuts.size() > 0 && shortcuts.get(0).isEnabled()) {
-                        try {
-                            launcherApps.startShortcut(shortcuts.get(0), v.getClipBounds(), null);
-                        } catch(ActivityNotFoundException e) {
-                            Toast.makeText(context, R.string.application_not_found, Toast.LENGTH_LONG).show();
-                        }
-                        return;
-                    }
-                }
-            }
+        ShortcutInfo shortcutInfo = getShortCut(context);
+        if (shortcutInfo != null) {
+            launcherApps.startShortcut(shortcutInfo, v.getClipBounds(), null);
+            return;
         }
 
         // Application removed? Invalid shortcut? Shortcut to an app on an unmounted SD card?
         Toast.makeText(context, R.string.application_not_found, Toast.LENGTH_LONG).show();
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private ShortcutInfo getShortCut(Context context) {
+        return ShortcutUtil.getShortCut(context, shortcutPojo.packageName, shortcutPojo.getOreoId());
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/shortcut/SaveAllOreoShortcutsAsync.java
+++ b/app/src/main/java/fr/neamar/kiss/shortcut/SaveAllOreoShortcutsAsync.java
@@ -6,7 +6,6 @@ import android.content.SharedPreferences;
 import android.content.pm.ShortcutInfo;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.os.UserManager;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.widget.Toast;
@@ -15,16 +14,12 @@ import androidx.annotation.NonNull;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
-import java.util.Set;
 
 import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.dataprovider.ShortcutsProvider;
-import fr.neamar.kiss.db.ShortcutRecord;
-import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.utils.ShortcutUtil;
-import fr.neamar.kiss.utils.UserHandle;
 
 @TargetApi(Build.VERSION_CODES.O)
 public class SaveAllOreoShortcutsAsync extends AsyncTask<Void, Integer, Boolean> {
@@ -71,32 +66,13 @@ public class SaveAllOreoShortcutsAsync extends AsyncTask<Void, Integer, Boolean>
             return null;
         }
 
-        Set<String> excludedAppList = dataHandler.getExcluded();
-        UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
-
+        boolean shortcutsUpdated = false;
         for (ShortcutInfo shortcutInfo : shortcuts) {
-
-            UserHandle user = new UserHandle(manager.getSerialNumberForUser(shortcutInfo.getUserHandle()), shortcutInfo.getUserHandle());
-            boolean isExcluded = excludedAppList.contains(AppPojo.getComponentName(shortcutInfo.getPackage(),
-                    shortcutInfo.getActivity().getClassName(), user));
-
-            // Skip shortcut if app is excluded
-            if (!excludedAppList.isEmpty() &&
-                    isExcluded) {
-                continue;
-            }
-
-            // Create Pojo
-            ShortcutRecord record = ShortcutUtil.createShortcutRecord(context, shortcutInfo, !shortcutInfo.isPinned());
-            if (record == null) {
-                continue;
-            }
-
             // Add shortcut to the DataHandler
-            dataHandler.addShortcut(record);
+            shortcutsUpdated |= dataHandler.updateShortcut(shortcutInfo);
         }
 
-        return true;
+        return shortcutsUpdated;
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/shortcut/SaveSingleOreoShortcutAsync.java
+++ b/app/src/main/java/fr/neamar/kiss/shortcut/SaveSingleOreoShortcutAsync.java
@@ -18,8 +18,6 @@ import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.dataprovider.ShortcutsProvider;
-import fr.neamar.kiss.db.ShortcutRecord;
-import fr.neamar.kiss.utils.ShortcutUtil;
 
 @TargetApi(Build.VERSION_CODES.O)
 public class SaveSingleOreoShortcutAsync extends AsyncTask<Void, Integer, Boolean> {
@@ -53,29 +51,18 @@ public class SaveSingleOreoShortcutAsync extends AsyncTask<Void, Integer, Boolea
             return null;
         }
 
-        // Create Pojo
-        ShortcutRecord record = ShortcutUtil.createShortcutRecord(context, shortcutInfo, false);
-        if (record == null) {
-            return false;
-        }
-
         final DataHandler dataHandler = this.dataHandler.get();
         if (dataHandler == null) {
             cancel(true);
             return null;
         }
 
-        // Add shortcut to the DataHandler
-        if(dataHandler.addShortcut(record)){
-            try {
-                pinItemRequest.accept();
-            }
-            catch(IllegalStateException e) {
-                return false;
-            }
-            return true;
+        if (!pinItemRequest.accept()) {
+            return false;
         }
-        return false;
+
+        // Add shortcut to the DataHandler
+        return dataHandler.updateShortcut(shortcutInfo);
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
@@ -9,21 +9,27 @@ import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.content.pm.ShortcutInfo;
 import android.os.Build;
+import android.os.UserHandle;
 import android.os.UserManager;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.RequiresApi;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.db.ShortcutRecord;
+import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.shortcut.SaveAllOreoShortcutsAsync;
 import fr.neamar.kiss.shortcut.SaveSingleOreoShortcutAsync;
 
+import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST;
 import static android.content.pm.LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED;
 
@@ -75,23 +81,23 @@ public class ShortcutUtil {
      */
     @TargetApi(Build.VERSION_CODES.O)
     public static List<ShortcutInfo> getAllShortcuts(Context context) {
-        return getShortcut(context, null);
+        return getShortcuts(context, null);
     }
 
     /**
      * @return all shortcuts for given package name
      */
     @TargetApi(Build.VERSION_CODES.O)
-    public static List<ShortcutInfo> getShortcut(Context context, String packageName) {
+    public static List<ShortcutInfo> getShortcuts(Context context, String packageName) {
         List<ShortcutInfo> shortcutInfoList = new ArrayList<>();
 
         UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
         LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
 
         LauncherApps.ShortcutQuery shortcutQuery = new LauncherApps.ShortcutQuery();
-        shortcutQuery.setQueryFlags(FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+        shortcutQuery.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
 
-        if(!TextUtils.isEmpty(packageName)){
+        if (!TextUtils.isEmpty(packageName)) {
             shortcutQuery.setPackage(packageName);
         }
 
@@ -103,10 +109,52 @@ public class ShortcutUtil {
     }
 
     /**
+     * @return return a specific shortcut for given package name and id
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    public static ShortcutInfo getShortCut(Context context, String packageName, String shortcutId) {
+        final LauncherApps launcherApps = (LauncherApps) context.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+        final UserManager userManager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+
+        if (launcherApps.hasShortcutHostPermission() && !TextUtils.isEmpty(packageName)) {
+            LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
+            query.setPackage(packageName);
+            query.setShortcutIds(Collections.singletonList(shortcutId));
+            query.setQueryFlags(FLAG_MATCH_DYNAMIC | FLAG_MATCH_MANIFEST | FLAG_MATCH_PINNED);
+
+            List<android.os.UserHandle> userHandles = launcherApps.getProfiles();
+
+            // find the correct UserHandle and get shortcut
+            for (UserHandle userHandle : userHandles) {
+                if (userManager.isUserRunning(userHandle)) {
+                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
+                    if (shortcuts != null) {
+                        for (ShortcutInfo shortcut : shortcuts) {
+                            if (shortcut.isEnabled()) {
+                                return shortcut;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Create ShortcutPojo from ShortcutInfo
      */
     @TargetApi(Build.VERSION_CODES.O)
-    public static ShortcutRecord createShortcutRecord(Context context, ShortcutInfo shortcutInfo, boolean includePackageName){
+    public static ShortcutRecord createShortcutRecord(Context context, ShortcutInfo shortcutInfo, boolean includePackageName) {
+        if (shortcutInfo.hasKeyFieldsOnly()) {
+            // If ShortcutInfo holds only key fields shortcut including data must be fetched
+            shortcutInfo = getShortCut(context, shortcutInfo.getPackage(), shortcutInfo.getId());
+            if (shortcutInfo == null) {
+                return null;
+            }
+        }
+
         ShortcutRecord record = new ShortcutRecord();
         record.packageName = shortcutInfo.getPackage();
         record.intentUri = ShortcutPojo.OREO_PREFIX + shortcutInfo.getId();
@@ -114,16 +162,16 @@ public class ShortcutUtil {
         String appName = getAppNameFromPackageName(context, shortcutInfo.getPackage());
 
         if (shortcutInfo.getShortLabel() != null) {
-            if(includePackageName && !TextUtils.isEmpty(appName)){
+            if (includePackageName && !TextUtils.isEmpty(appName)) {
                 record.name = appName + ": " + shortcutInfo.getShortLabel().toString();
             } else {
                 record.name = shortcutInfo.getShortLabel().toString();
             }
         } else if (shortcutInfo.getLongLabel() != null) {
-            if(includePackageName && !TextUtils.isEmpty(appName)){
+            if (includePackageName && !TextUtils.isEmpty(appName)) {
                 record.name = appName + ": " + shortcutInfo.getLongLabel().toString();
             } else {
-                record.name =shortcutInfo.getLongLabel().toString();
+                record.name = shortcutInfo.getLongLabel().toString();
             }
         } else {
             Log.d(TAG, "Invalid shortcut for " + record.packageName + ", ignoring");
@@ -134,21 +182,29 @@ public class ShortcutUtil {
     }
 
     /**
-     *
      * @return App name from package name
      */
-    public static String getAppNameFromPackageName(Context context, String Packagename) {
+    public static String getAppNameFromPackageName(Context context, String packageName) {
         try {
             PackageManager packageManager = context.getPackageManager();
-            ApplicationInfo info = packageManager.getApplicationInfo(Packagename, PackageManager.GET_META_DATA);
-            String appName = (String) packageManager.getApplicationLabel(info);
-            return appName;
+            ApplicationInfo info = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
+            return (String) packageManager.getApplicationLabel(info);
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
-            return "";
+            return null;
         }
     }
 
-
+    /**
+     * @param context
+     * @param shortcutInfo
+     * @return component name related to {@link ShortcutInfo}.
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    public static String getComponentName(Context context, ShortcutInfo shortcutInfo) {
+        UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+        fr.neamar.kiss.utils.UserHandle user = new fr.neamar.kiss.utils.UserHandle(manager.getSerialNumberForUser(shortcutInfo.getUserHandle()), shortcutInfo.getUserHandle());
+        return AppPojo.getComponentName(shortcutInfo.getPackage(), shortcutInfo.getActivity().getClassName(), user);
+    }
 
 }


### PR DESCRIPTION
- fixes #1761
- query shortcuts now including FLAG_MATCH_DYNAMIC
- allow also remove of shortcuts on changes so dynamic shortcuts can be kept up to date
- update shortcuts on onShortcutsChanged
- move check for excluded shortcuts a little deeper into code so listening on shortcut changes won't recreate shortcuts for excluded apps
- exclude newly added shortcuts from history if enabled in settings

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
