### PR TITLE
fix favorites click

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Favorites.java
@@ -133,10 +133,10 @@ public class Favorites extends Forwarder implements View.OnClickListener, View.O
             if (viewHolder == null) {
                 // If not, build a new one
                 viewHolder = new ViewHolder(Result.fromPojo(mainActivity, favoritePojo), favoritePojo, mainActivity, mainActivity.favoritesBar);
-                viewHolder.view.setOnClickListener(this);
-                viewHolder.view.setOnLongClickListener(this);
-                viewHolder.view.setOnTouchListener(this);
             }
+            viewHolder.view.setOnClickListener(this);
+            viewHolder.view.setOnLongClickListener(this);
+            viewHolder.view.setOnTouchListener(this);
 
             holders.add(viewHolder);
 


### PR DESCRIPTION
- fixes recreation of favorites when different providers are used:
  - on `onFavoriteChanged` method `disposeOf` may be called which resets listeners of view
  - on next `onFavoriteChanged` ViewHolder already exists  and will be reused without setting listeners again
- fixes #1579, #1771, #1781

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
