### PR TITLE
added go to homescreen option for gesture

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -203,6 +203,12 @@ class ExperienceTweaks extends Forwarder {
                     case "display-menu":
                         mainActivity.openContextMenu(mainActivity.menuButton);
                         break;
+                    case "go-to-homescreen":
+                        mainActivity.displayKissBar(false);
+                        if (!shouldShowKeyboard()) {
+                            mainActivity.hideKeyboard();
+                        }
+                        break;
                 }
             }
         });

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -54,6 +54,7 @@
         <item>@string/gesture_apps</item>
         <item>@string/gesture_history</item>
         <item>@string/gesture_menu</item>
+        <item>@string/gesture_homescreen</item>
     </string-array>
     <string-array name="gestureValues" translatable="false">
         <item>do-nothing</item>
@@ -64,6 +65,7 @@
         <item>display-apps</item>
         <item>display-history</item>
         <item>display-menu</item>
+        <item>go-to-homescreen</item>
     </string-array>
     <string-array name="shadowEntries">
         <item>@string/theme_customize_default</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,6 +286,7 @@
     <string name="gesture_notifications">Display notification shade</string>
     <string name="gesture_apps">Display apps list</string>
     <string name="gesture_history">Display history</string>
+    <string name="gesture_homescreen">Go to homescreen</string>
     <string name="small_results">Display smaller results</string>
     <string name="theme_wallpaper">Wallpaper</string>
     <string name="show_subicons">Show app icon on shortcuts</string>


### PR DESCRIPTION
Hi,
I have added a very simple option for a gesture - go to homescreen. Effectively giving the option to "Cancel" and return home from any other gesture.
Best to give an example to explain why: 
I use "swipe left" to open the app list. But, if I need to return to the home screen I need to press the home button to do so. With this "go-to-homescreen" option I can now "swipe right" to cancel what I am doing. For me, this seems a more natural process - and I personally don't use "swipe right" for anything else.

Thanks,
Paul

