### PR TITLE
Fix miss click on menu button

### DIFF
--- a/app/src/main/res/layout/main_kissbar.xml
+++ b/app/src/main/res/layout/main_kissbar.xml
@@ -11,7 +11,7 @@
     <ImageView
         android:id="@+id/whiteLauncherButton"
         android:layout_width="@dimen/launcher_button_width"
-        android:layout_height="@dimen/bar_height"
+        android:layout_height="match_parent"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"


### PR DESCRIPTION
When having the big search bar option enabled, you are able to click the open-menu button while you are already in the menu making the menu re-open while it's already open
![1](https://user-images.githubusercontent.com/62959641/135379634-c669eb93-cb1a-4981-9c19-bfb07c169136.png)
![2](https://user-images.githubusercontent.com/62959641/135379637-7d6feb37-8345-4e9c-ba56-b2c5aa4837b5.png)