### PR TITLE
Option to show history when keyboard is visible in Minimal UI mode

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -184,9 +184,7 @@ class ExperienceTweaks extends Forwarder {
                             // and we're not looking at the app list
                             if (mainActivity.isViewingSearchResults() && mainActivity.searchEditText.getText().toString().isEmpty()) {
                                 if (mainActivity.list.getAdapter() == null || mainActivity.list.getAdapter().isEmpty()) {
-                                    mainActivity.runTask(new HistorySearcher(mainActivity));
-                                    mainActivity.clearButton.setVisibility(View.VISIBLE);
-                                    mainActivity.menuButton.setVisibility(View.INVISIBLE);
+                                    mainActivity.showHistory();
                                 }
                             }
                         }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
@@ -59,6 +59,11 @@ public class ForwarderManager extends Forwarder {
     public void onStop() {
     }
 
+    public void onGlobalLayout()
+    {
+        experienceTweaks.onGlobalLayout();
+    }
+
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         widgetsForwarder.onActivityResult(requestCode, resultCode, data);
     }

--- a/app/src/main/java/fr/neamar/kiss/ui/KeyboardScrollHider.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/KeyboardScrollHider.java
@@ -223,6 +223,10 @@ public class KeyboardScrollHider implements View.OnTouchListener {
         });
     }
 
+    public boolean isScrolled() {
+        return (this.offsetYCurrent - this.offsetYStart) > THRESHOLD;
+    }
+
     public interface KeyboardHandler {
         void showKeyboard();
         void hideKeyboard();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="history_hide_desc">Hide history and intro screen, turn on widgets</string>
     <string name="history_hide_name">Minimalistic UI</string>
     <string name="history_onclick_name">Show history on touch</string>
+    <string name="history_onkeyboard_name">Show history with keyboard</string>
+    <string name="history_onkeyboard_desc">Show history when software keyboard is visible</string>
     <string name="portrait_title">Force portrait mode</string>
     <string name="lwp_touch">Send touch events to wallpaper</string>
     <string name="lwp_drag">Emulate drag event for wallpaper</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -259,6 +259,12 @@
             <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:dependency="history-hide"
+                android:key="history-onkeyboard"
+                android:summary="@string/history_onkeyboard_desc"
+                android:title="@string/history_onkeyboard_name" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
+                android:dependency="history-hide"
                 android:key="favorites-hide"
                 android:title="@string/favorites_hide" />
             <fr.neamar.kiss.preference.SwitchPreference


### PR DESCRIPTION
Heya! I've been loving the launcher so far, but for me one thing was missing. In Minimal UI mode, if your widgets cover the majority of the screen, it's difficult to ever have access to your history.

This is a relatively simple change that pulls up the history when your software keyboard is visible (note: android doesn't include a clean way to do this, so we do so by checking the view height versus root layout height, see https://stackoverflow.com/questions/2150078/how-to-check-visibility-of-software-keyboard-in-android).

https://user-images.githubusercontent.com/1109288/137422706-44859067-393a-4e35-a349-edfd2c004045.mp4

There's one known issue I'd like to resolve before pushing, if anyone has an idea where to look: When the history (shown by keyboard) has been scrolled down, selecting an item simply causes KISS to return to the widget view, without launching the selected item. Doesn't affect history opened via 'open on touch' events. 