### PR TITLE
fix icon pack scale

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
@@ -159,7 +159,7 @@ public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
         int scaledHeight = (int) (h * sanitizedScaleFactor);
         Bitmap defaultBitmap = defaultDrawable.getBitmap();
         if (scaledWidth != w || scaledHeight != h) {
-            canvas.drawBitmap(defaultBitmap, getTransformationMatrix(defaultBitmap, w, h, (w - scaledWidth) / 2f, (h - scaledHeight) / 2f), null);
+            canvas.drawBitmap(defaultBitmap, getTransformationMatrix(defaultBitmap, scaledWidth, scaledHeight, (w - scaledWidth) / 2f, (h - scaledHeight) / 2f), null);
         } else {
             canvas.drawBitmap(defaultBitmap, getResizeMatrix(defaultBitmap, w, h), null);
         }


### PR DESCRIPTION
- fix icons for icon packs with scale
- e.g. meeyo icon pack

before fix background is visible for some icons and icons also are not centered:
![Screenshot_1638965686](https://user-images.githubusercontent.com/3027783/145206927-69d341c5-6dae-4d94-a62a-cc291f8d0ea2.png)
after fix:
![Screenshot_1638965714](https://user-images.githubusercontent.com/3027783/145206951-9bc00483-2220-4e52-90ea-dc0622211f16.png)

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
