### PR TITLE
match icon background behavior to settings

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
+++ b/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
@@ -10,6 +10,7 @@ import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
@@ -215,11 +216,11 @@ public class CustomIconDialog extends DialogFragment {
             if (drawable != null && checkDuplicateDrawable(dSet, drawable)) {
                 addQuickOption(R.string.custom_icon_activity, drawable, quickList);
                 if (iconPack != null && iconPack.hasMask())
-                    addQuickOption(R.string.custom_icon_activity_with_pack, iconPack.applyBackgroundAndMask(context, drawable, true), quickList);
+                    addQuickOption(R.string.custom_icon_activity_with_pack, iconPack.applyBackgroundAndMask(context, drawable, true, Color.WHITE), quickList);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                    addQuickOption(R.string.custom_icon_activity_adaptive, systemPack.applyBackgroundAndMask(context, drawable, true), quickList);
+                    addQuickOption(R.string.custom_icon_activity_adaptive, systemPack.applyBackgroundAndMask(context, drawable, true, Color.WHITE), quickList);
                 if (!DrawableUtils.isAdaptiveIconDrawable(drawable))
-                    addQuickOption(R.string.custom_icon_activity_adaptive_fill, systemPack.applyBackgroundAndMask(context, drawable, false), quickList);
+                    addQuickOption(R.string.custom_icon_activity_adaptive_fill, systemPack.applyBackgroundAndMask(context, drawable, false, Color.TRANSPARENT), quickList);
             }
         }
 
@@ -233,12 +234,12 @@ public class CustomIconDialog extends DialogFragment {
             if (drawable != null && checkDuplicateDrawable(dSet, drawable)) {
                 addQuickOption(R.string.custom_icon_application, drawable, quickList);
                 if (iconPack != null && iconPack.hasMask())
-                    addQuickOption(R.string.custom_icon_application_with_pack, iconPack.applyBackgroundAndMask(context, drawable, true), quickList);
+                    addQuickOption(R.string.custom_icon_application_with_pack, iconPack.applyBackgroundAndMask(context, drawable, true, Color.WHITE), quickList);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                    addQuickOption(R.string.custom_icon_application_adaptive, systemPack.applyBackgroundAndMask(context, drawable, true), quickList);
+                    addQuickOption(R.string.custom_icon_application_adaptive, systemPack.applyBackgroundAndMask(context, drawable, true, Color.WHITE), quickList);
+                if (!DrawableUtils.isAdaptiveIconDrawable(drawable))
+                    addQuickOption(R.string.custom_icon_application_adaptive_fill, systemPack.applyBackgroundAndMask(context, drawable, false, Color.TRANSPARENT), quickList);
             }
-            if (!DrawableUtils.isAdaptiveIconDrawable(drawable))
-                addQuickOption(R.string.custom_icon_application_adaptive_fill, systemPack.applyBackgroundAndMask(context, drawable, false), quickList);
         }
 
         // add Activity BadgedIcon
@@ -250,11 +251,11 @@ public class CustomIconDialog extends DialogFragment {
                 if (drawable != null && checkDuplicateDrawable(dSet, drawable)) {
                     addQuickOption(R.string.custom_icon_badged, drawable, quickList);
                     if (iconPack != null && iconPack.hasMask())
-                        addQuickOption(R.string.custom_icon_badged_with_pack, iconPack.applyBackgroundAndMask(context, drawable, true), quickList);
+                        addQuickOption(R.string.custom_icon_badged_with_pack, iconPack.applyBackgroundAndMask(context, drawable, true, Color.WHITE), quickList);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                        addQuickOption(R.string.custom_icon_badged_adaptive, systemPack.applyBackgroundAndMask(context, drawable, true), quickList);
+                        addQuickOption(R.string.custom_icon_badged_adaptive, systemPack.applyBackgroundAndMask(context, drawable, true, Color.WHITE), quickList);
                     if (!DrawableUtils.isAdaptiveIconDrawable(drawable))
-                        addQuickOption(R.string.custom_icon_badged_adaptive_fill, systemPack.applyBackgroundAndMask(context, drawable, false), quickList);
+                        addQuickOption(R.string.custom_icon_badged_adaptive_fill, systemPack.applyBackgroundAndMask(context, drawable, false, Color.TRANSPARENT), quickList);
                 }
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.preference.PreferenceManager;
@@ -147,8 +148,9 @@ public class IconsHandler {
         // Search in cache
         {
             Drawable cacheIcon = cacheGetDrawable(cacheKey);
-            if (cacheIcon != null)
+            if (cacheIcon != null) {
                 return cacheIcon;
+            }
         }
 
         Drawable drawable = null;
@@ -182,13 +184,13 @@ public class IconsHandler {
     public Drawable applyIconMask(@NonNull Context ctx, @NonNull Drawable drawable, @NonNull UserHandle userHandle) {
         if (mIconPack != null && mIconPack.hasMask() && userHandle.isCurrentUser()) {
             // if the icon pack has a mask, use that instead of the adaptive shape
-            return mIconPack.applyBackgroundAndMask(ctx, drawable, false);
+            return mIconPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
         } else if (DrawableUtils.isAdaptiveIconDrawable(drawable) || mForceAdaptive) {
             // use adaptive shape
-            return mSystemPack.applyBackgroundAndMask(ctx, drawable, true);
+            return mSystemPack.applyBackgroundAndMask(ctx, drawable, true, Color.WHITE);
         } else if (mForceShape) {
             // use adaptive shape
-            return mSystemPack.applyBackgroundAndMask(ctx, drawable, false);
+            return mSystemPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
         } else {
             return drawable;
         }
@@ -199,13 +201,13 @@ public class IconsHandler {
 
         if (mContactPackMask && mIconPack != null && mIconPack.hasMask()) {
             // if the icon pack has a mask, use that instead of the adaptive shape
-            return mIconPack.applyBackgroundAndMask(ctx, drawable, false);
+            return mIconPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
         } else if (DrawableUtils.isAdaptiveIconDrawable(drawable)) {
             // use adaptive shape
-            return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, true);
+            return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, true, Color.WHITE);
         } else {
             // use adaptive shape
-            return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, false);
+            return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, false, Color.TRANSPARENT);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/icons/IconPack.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPack.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -26,7 +27,7 @@ public interface IconPack<DrawableInfo> {
     Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName, @NonNull UserHandle userHandle);
 
     @NonNull
-    Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable defaultBitmap, boolean fitInside);
+    Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable icon, boolean fitInside, @ColorInt int backgroundColor);
 
     @Nullable
     Collection<DrawableInfo> getDrawableList();

--- a/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
@@ -17,6 +17,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.Log;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -124,18 +125,18 @@ public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
 
     @NonNull
     @Override
-    public Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable systemIcon, boolean fitInside) {
-        if (systemIcon instanceof BitmapDrawable) {
-            return generateBitmap((BitmapDrawable) systemIcon, ctx);
+    public Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable icon, boolean fitInside, @ColorInt int backgroundColor) {
+        if (icon instanceof BitmapDrawable) {
+            return generateBitmap((BitmapDrawable) icon, ctx);
         }
 
         Bitmap bitmap;
-        if (systemIcon.getIntrinsicWidth() <= 0 || systemIcon.getIntrinsicHeight() <= 0)
+        if (icon.getIntrinsicWidth() <= 0 || icon.getIntrinsicHeight() <= 0)
             bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888); // Single color bitmap will be created of 1x1 pixel
         else
-            bitmap = Bitmap.createBitmap(systemIcon.getIntrinsicWidth(), systemIcon.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
-        systemIcon.setBounds(0, 0, bitmap.getWidth(), bitmap.getHeight());
-        systemIcon.draw(new Canvas(bitmap));
+            bitmap = Bitmap.createBitmap(icon.getIntrinsicWidth(), icon.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        icon.setBounds(0, 0, bitmap.getWidth(), bitmap.getHeight());
+        icon.draw(new Canvas(bitmap));
         return generateBitmap(new BitmapDrawable(ctx.getResources(), bitmap), ctx);
     }
 

--- a/app/src/main/java/fr/neamar/kiss/icons/SystemIconPack.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/SystemIconPack.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.util.Log;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -111,8 +112,8 @@ public class SystemIconPack implements IconPack<Void> {
 
     @NonNull
     @Override
-    public Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable icon, boolean fitInside) {
-        return DrawableUtils.applyIconMaskShape(ctx, icon, mAdaptiveShape, fitInside);
+    public Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable icon, boolean fitInside, @ColorInt int backgroundColor) {
+        return DrawableUtils.applyIconMaskShape(ctx, icon, mAdaptiveShape, fitInside, backgroundColor);
     }
 
     @Nullable

--- a/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
@@ -51,7 +52,7 @@ public class TagDummyResult extends Result {
             shape.setSize(barSize, barSize);
             float rad = barSize / 2.3f;
             shape.setCornerRadii(new float[]{rad, rad, rad, rad, rad, rad, rad, rad});
-            shape.setColor(0xFFffffff);
+            shape.setColor(Color.WHITE);
 
             gBackground = new InsetDrawable(shape, inset);
         }
@@ -78,7 +79,7 @@ public class TagDummyResult extends Result {
         rectF.inset(1.f, 1.f);
 
         // draw a white rounded background
-        paint.setColor(0xFFffffff);
+        paint.setColor(Color.WHITE);
         canvas.drawRoundRect(rectF, width / 2.4f, height / 2.4f, paint);
 
         int codepoint = pojo.getName().codePointAt(0);
@@ -110,10 +111,10 @@ public class TagDummyResult extends Result {
         // we can't draw images (emoticons and symbols) using SRC_IN with transparent color, the result is a square
         if (drawAsHole) {
             // write text with "transparent" (create a hole in the background)
-            paint.setColor(0);
+            paint.setColor(Color.TRANSPARENT);
             paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         } else {
-            paint.setColor(0xFFffffff);
+            paint.setColor(Color.WHITE);
         }
 
         // draw the letter in the center

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -63,14 +63,6 @@ public class DrawableUtils {
         return bitmap;
     }
 
-    public static Drawable applyIconMaskShape(Context ctx, Drawable icon, int shape, boolean fitInside) {
-        return applyIconMaskShape(ctx, icon, shape, fitInside, Color.WHITE);
-    }
-
-    public static Drawable applyIconMaskShape(Context ctx, Drawable icon, int shape, @ColorInt int backgroundColor) {
-        return applyIconMaskShape(ctx, icon, shape, false, backgroundColor);
-    }
-
     /**
      * Get percent of icon to use as margin. We use this to avoid clipping the image.
      *
@@ -99,9 +91,17 @@ public class DrawableUtils {
 
     /**
      * Handle adaptive icons for compatible devices
+     *
+     * @param ctx             {@link Context}
+     * @param icon            the {@link Drawable} to shape
+     * @param shape           shape to use
+     * @param fitInside       for non {@link AdaptiveIconDrawable}, the icon is resized so it fits in shape
+     * @param backgroundColor color used as background for non {@link AdaptiveIconDrawable}
+     * @return shaped icon
      */
+    @NonNull
     @SuppressLint("NewApi")
-    public static Drawable applyIconMaskShape(Context ctx, Drawable icon, int shape, boolean fitInside, @ColorInt int backgroundColor) {
+    public static Drawable applyIconMaskShape(@NonNull Context ctx, @NonNull Drawable icon, int shape, boolean fitInside, @ColorInt int backgroundColor) {
         if (shape == SHAPE_SYSTEM)
             return icon;
         if (shape == SHAPE_TEARDROP_RND)
@@ -175,7 +175,7 @@ public class DrawableUtils {
 
             outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
             outputCanvas = new Canvas(outputBitmap);
-            outputPaint.setColor(0xFF000000);
+            outputPaint.setColor(Color.BLACK);
 
             setIconShape(outputCanvas, outputPaint, shape);
         }


### PR DESCRIPTION
changes related to #1828, realizes proposed solution number 2
- if "force icon background" is enabled, not adaptive icons will be resized and drawn onto white background as described (like before)
- if "force background shape" is enabled, shape will also be applied to non adaptive icons, like before. But background will not be changed to white any more (the white background wasn't obvious from setting itself)
- some colors were replaced with Color constant
<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
