### PR TITLE
catch exceptions when starting shortcuts

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss.result;
 
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -197,8 +198,11 @@ public class ShortcutsResult extends Result {
 
         ShortcutInfo shortcutInfo = getShortCut(context);
         if (shortcutInfo != null) {
-            launcherApps.startShortcut(shortcutInfo, v.getClipBounds(), null);
-            return;
+            try {
+                launcherApps.startShortcut(shortcutInfo, v.getClipBounds(), null);
+                return;
+            } catch (ActivityNotFoundException | IllegalStateException ignored) {
+            }
         }
 
         // Application removed? Invalid shortcut? Shortcut to an app on an unmounted SD card?


### PR DESCRIPTION
Catch exceptions thrown by startShortcut and show proper toast message.
As it's already done for pre oreo shortcuts.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
