### PR TITLE
simplify adding of favorites on first start

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/utils/PackageManagerUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/PackageManagerUtils.java
@@ -78,7 +78,7 @@ public class PackageManagerUtils {
      */
     public static ComponentName getComponentName(Context context, Intent intent) {
         ResolveInfo resolveInfo = getBestResolve(context, intent);
-        if (resolveInfo != null) {
+        if (resolveInfo != null && resolveInfo.activityInfo != null) {
             return new ComponentName(resolveInfo.activityInfo.packageName, resolveInfo.activityInfo.name);
         }
         return null;


### PR DESCRIPTION
- during debugging it happened sometimes that on first start after install some favorites were missing, e.g. for firefox browser
- reason is that some apps have more than one activity for launching intents, but we need the one that's opening the app from the launcher
- existing logic can be simplified with available tools: `PackageManagerUtils.getComponentName`, `PackageManagerUtils.getLaunchingComponent`
- now system itself can provide the launching component, so there's no need for custom `packageName` checks any more
- affected packages were e.g.
  - old dialer `com.google.android.dialer`
  - chrome `com.android.chrome`
  - firefox `org.mozilla.firefox`
  - firefox klar `org.mozilla.klar`
  - opera `com.opera.browser`
  - probably some more

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
