### PR TITLE
fix default excludes

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -563,7 +563,7 @@ public class DataHandler extends BroadcastReceiver
         Set<String> excluded = PreferenceManager.getDefaultSharedPreferences(context).getStringSet("excluded-apps-from-history", null);
         if (excluded == null) {
             excluded = new HashSet<>();
-            excluded.add(context.getPackageName());
+            excluded.add("app://" + AppPojo.getComponentName(context.getPackageName(), MainActivity.class.getName(), new UserHandle()));
         }
         return excluded;
     }
@@ -573,7 +573,7 @@ public class DataHandler extends BroadcastReceiver
         Set<String> excluded = PreferenceManager.getDefaultSharedPreferences(context).getStringSet("excluded-apps", null);
         if (excluded == null) {
             excluded = new HashSet<>();
-            excluded.add(context.getPackageName());
+            excluded.add(AppPojo.getComponentName(context.getPackageName(), MainActivity.class.getName(), new UserHandle()));
         }
         return excluded;
     }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedAppsPreference.java
@@ -23,7 +23,7 @@ public class ResetExcludedAppsPreference extends DialogPreference {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
-                    .putStringSet("excluded-apps", new HashSet<String>()).apply();
+                    .putStringSet("excluded-apps", null).apply();
             KissApplication.getApplication(getContext()).getDataHandler().getAppProvider().reload();
             Toast.makeText(getContext(), R.string.excluded_app_list_erased, Toast.LENGTH_LONG).show();
         }

--- a/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedFromHistoryAppsPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/ResetExcludedFromHistoryAppsPreference.java
@@ -9,6 +9,7 @@ import android.widget.Toast;
 
 import java.util.HashSet;
 
+import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 
 public class ResetExcludedFromHistoryAppsPreference extends DialogPreference {
@@ -22,7 +23,8 @@ public class ResetExcludedFromHistoryAppsPreference extends DialogPreference {
         super.onClick(dialog, which);
         if (which == DialogInterface.BUTTON_POSITIVE) {
             PreferenceManager.getDefaultSharedPreferences(getContext()).edit()
-                    .putStringSet("excluded-apps-from-history", new HashSet<String>()).apply();
+                    .putStringSet("excluded-apps-from-history", null).apply();
+            KissApplication.getApplication(getContext()).getDataHandler().getAppProvider().reload(); // reload because it's cached in AppPojo#excludedFromHistory
             Toast.makeText(getContext(), R.string.excluded_app_list_erased, Toast.LENGTH_LONG).show();
         }
     }


### PR DESCRIPTION
add proper strings to default excludes and reset to null instead of empty set so default will then be used again.

- during debugging it came up that default app exclude was not working
- because only package name was added, but all checks for exclusion works on component name
- also reset didn't work - default was ignored after reset of excluded apps

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
