### PR TITLE
Possibility to show excluded apps in search.

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -4,10 +4,12 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.pm.LauncherApps;
 import android.os.Build;
 import android.os.Process;
 import android.os.UserManager;
+import android.preference.PreferenceManager;
 
 import androidx.annotation.RequiresApi;
 
@@ -139,7 +141,7 @@ public class AppProvider extends Provider<AppPojo> {
     @Override
     public void requestResults(String query, Searcher searcher) {
         StringNormalizer.Result queryNormalized = StringNormalizer.normalizeWithResult(query, false);
-
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         if (queryNormalized.codePoints.length == 0) {
             return;
         }
@@ -149,7 +151,7 @@ public class AppProvider extends Provider<AppPojo> {
         boolean match;
 
         for (AppPojo pojo : pojos) {
-            if(pojo.isExcluded()) {
+            if(pojo.isExcluded() && !prefs.getBoolean("enable-excluded-apps", false)) {
                 continue;
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,4 +326,5 @@
     <string name="shape_teardrop_random">Teardrop random</string>
     <string name="shape_octagon">Octagon</string>
     <string name="shape_hexagon">Hexagon</string>
+    <string name="excluded_apps_toggle">Show excluded apps in search</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -423,6 +423,10 @@
             android:defaultValue="true"
             android:key="enable-search"
             android:title="@string/search_provider_toggle" />
+        <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
+                android:key="enable-excluded-apps"
+                android:title="@string/excluded_apps_toggle" />
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/search_name" android:key="web-providers">
             <fr.neamar.kiss.preference.AddSearchProviderPreference


### PR DESCRIPTION
Hello,

i had the idea to show the excluded apps in the kiss search.
I like my app list to only show the apps i use most of the time, so i exclude apps i don't use that often(once a year).
The problem was when the situations arrived when i needed the app i excluded,i had to include it first to open it.
I want to have the possibility to search for excluded apps, so the app list stays small but i still can use the apps that i don't need that often.

Therefore i added a new setting in the search category and modified the appprovider.