### PR TITLE
Add launch an app gesture preference

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -419,6 +419,11 @@ public class DataHandler extends BroadcastReceiver
         return (pojo != null) ? pojo.getName() : "???";
     }
 
+    @Nullable
+    public Pojo getItemById(String id) {
+        return getPojo(id);
+    }
+
     /**
      * Update stored shortcut info for all shortcuts of given packageName.
      *

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -22,8 +22,11 @@ import android.widget.ImageView;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
+import fr.neamar.kiss.pojo.Pojo;
+import fr.neamar.kiss.result.Result;
 import fr.neamar.kiss.searcher.HistorySearcher;
 import fr.neamar.kiss.searcher.NullSearcher;
 import fr.neamar.kiss.searcher.Searcher;
@@ -78,10 +81,10 @@ class ExperienceTweaks extends Forwarder {
                 // Double tap disabled: display history directly
                 if(!prefs.getBoolean("double-tap", false)) {
                     if (prefs.getBoolean("history-onclick", false)) {
-                        doAction("display-history");
+                        doAction("single-tap", "display-history");
                     }
                     else if(isMinimalisticModeEnabledForFavorites()) {
-                        doAction("display-favorites");
+                        doAction("single-tap", "display-favorites");
                     }
                 }
                 return super.onSingleTapUp(e);
@@ -92,10 +95,10 @@ class ExperienceTweaks extends Forwarder {
                 // Double tap enabled: wait to confirm this is indeed a single tap, not a double tap
                 if(prefs.getBoolean("double-tap", false)) {
                     if (prefs.getBoolean("history-onclick", false)) {
-                        doAction("display-history");
+                        doAction("single-tap", "display-history");
                     }
                     else if(isMinimalisticModeEnabledForFavorites()) {
-                        doAction("display-favorites");
+                        doAction("single-tap", "display-favorites");
                     }
                 }
 
@@ -104,7 +107,7 @@ class ExperienceTweaks extends Forwarder {
 
             @Override
             public void onLongPress(MotionEvent e) {
-                doAction(prefs.getString("gesture-long-press", "do-nothing"));
+                doAction("long-press", prefs.getString("gesture-long-press", "do-nothing"));
 
                 super.onLongPress(e);
             }
@@ -147,21 +150,21 @@ class ExperienceTweaks extends Forwarder {
                 float directionX = e2.getX() - e1.getX();
                 if (Math.abs(directionX) > Math.abs(directionY)) {
                     if (directionX > 0) {
-                        doAction(prefs.getString("gesture-right", "display-apps"));
+                        doAction("gesture-right", prefs.getString("gesture-right", "display-apps"));
                     } else {
-                        doAction(prefs.getString("gesture-left", "display-apps"));
+                        doAction("gesture-left", prefs.getString("gesture-left", "display-apps"));
                     }
                 } else {
                     if (directionY > 0) {
-                        doAction(prefs.getString("gesture-down", "display-notifications"));
+                        doAction("gesture-down", prefs.getString("gesture-down", "display-notifications"));
                     } else {
-                        doAction(prefs.getString("gesture-up", "display-keyboard"));
+                        doAction("gesture-up", prefs.getString("gesture-up", "display-keyboard"));
                     }
                 }
                 return true;
             }
 
-            private void doAction(String action) {
+            private void doAction(String source, String action) {
                 switch (action) {
                     case "display-notifications":
                         displayNotificationDrawer();
@@ -210,6 +213,16 @@ class ExperienceTweaks extends Forwarder {
                             mainActivity.hideKeyboard();
                         }
                         break;
+                    case "launch-pojo": {
+                        String launchId = prefs.getString(source + "-launch-id", "");
+                        Pojo item = KissApplication.getApplication(mainActivity).getDataHandler().getItemById(launchId);
+                        if (item != null) {
+                            // don't send null parent if (item instanceof ContactsPojo)
+                            Result result = Result.fromPojo(null, item);
+                            result.fastLaunch(mainActivity, mainEmptyView);
+                        }
+                        break;
+                    }
                 }
             }
         });

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -107,7 +107,7 @@ class ExperienceTweaks extends Forwarder {
 
             @Override
             public void onLongPress(MotionEvent e) {
-                doAction("long-press", prefs.getString("gesture-long-press", "do-nothing"));
+                doAction("gesture-long-press", prefs.getString("gesture-long-press", "do-nothing"));
 
                 super.onLongPress(e);
             }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -55,6 +55,7 @@
         <item>@string/gesture_history</item>
         <item>@string/gesture_menu</item>
         <item>@string/gesture_homescreen</item>
+        <item>@string/gesture_launch_pojo</item>
     </string-array>
     <string-array name="gestureValues" translatable="false">
         <item>do-nothing</item>
@@ -66,6 +67,7 @@
         <item>display-history</item>
         <item>display-menu</item>
         <item>go-to-homescreen</item>
+        <item>launch-pojo</item>
     </string-array>
     <string-array name="shadowEntries">
         <item>@string/theme_customize_default</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="gesture_apps">Display apps list</string>
     <string name="gesture_history">Display history</string>
     <string name="gesture_homescreen">Go to homescreen</string>
+    <string name="gesture_launch_pojo">Launch…</string>
     <string name="small_results">Display smaller results</string>
     <string name="theme_wallpaper">Wallpaper</string>
     <string name="show_subicons">Show app icon on shortcuts</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -292,11 +292,6 @@
                 android:key="gesture-up"
                 android:title="@string/gesture_up_name" />
             <ListPreference
-                android:defaultValue="none"
-                android:key="gesture-up-launch-id"
-                android:enabled="false"
-                android:title="@string/gesture_launch_pojo" />
-            <ListPreference
                 android:defaultValue="display-notifications"
                 android:entries="@array/gestureEntries"
                 android:entryValues="@array/gestureValues"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -292,6 +292,11 @@
                 android:key="gesture-up"
                 android:title="@string/gesture_up_name" />
             <ListPreference
+                android:defaultValue="none"
+                android:key="gesture-up-launch-id"
+                android:enabled="false"
+                android:title="@string/gesture_launch_pojo" />
+            <ListPreference
                 android:defaultValue="display-notifications"
                 android:entries="@array/gestureEntries"
                 android:entryValues="@array/gestureValues"


### PR DESCRIPTION
Add a "Run an app" option to gestures

fix #1886

* [x] swipe up
* [x] swipe right
* [x] swipe down
* [x] swipe left
* [x] long press

# How I implemented it / How it works
## In Settings
1. generate the list of entries (apps) that can be run and store them in `ItemToRunListContent`
2. monitor preferences from `PREF_LISTS_WITH_DEPENDENCY` for changes and test if value is `launch-pojo`
3. when test triggered insert a new preference named `R.string.gesture_launch_pojo` right after the one changed. Use the key with `-launch-id` appended

## In Launcher
1. when a gesture is detected execute `doAction` with the source of the action as the preference key
2. if action is `launch-pojo` get POJO id from preference with key [source+"-launch-id"]
3. generate a result for the pojo and launch the result