### PR TITLE
improve icon pack handling

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -186,7 +186,7 @@ public class IconsHandler {
             // if the icon pack has a mask, use that instead of the adaptive shape
             return mIconPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
         } else if (DrawableUtils.isAdaptiveIconDrawable(drawable) || mForceAdaptive) {
-            // use adaptive shape
+            // use adaptive shape (with white background for non adaptive icons)
             return mSystemPack.applyBackgroundAndMask(ctx, drawable, true, Color.WHITE);
         } else if (mForceShape) {
             // use adaptive shape
@@ -203,7 +203,7 @@ public class IconsHandler {
             // if the icon pack has a mask, use that instead of the adaptive shape
             return mIconPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
         } else if (DrawableUtils.isAdaptiveIconDrawable(drawable)) {
-            // use adaptive shape
+            // use adaptive shape (with white background for non adaptive icons)
             return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, true, Color.WHITE);
         } else {
             // use adaptive shape


### PR DESCRIPTION
- apply all masking to icons: not only mask but also backImage and frontImage
- always use FILTER_BITMAP_FLAG for drawing bitmaps
- use existing methods to convert AdaptiveIconDrawable to BitmapDrawable
- catch NumberFormatException when parsing scale

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
