### PR TITLE
More granular result size preference

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -164,7 +164,7 @@ public class SettingsActivity extends PreferenceActivity implements
         } else {
             // Run synchronously to ensure preferences can be restored from state
             runnable.run();
-            synchronized (SettingsActivity.this) {
+            synchronized (SettingsActivity.class) {
                 if (ItemToRunListContent == null)
                     ItemToRunListContent = generateItemToRunListContent(this);
 
@@ -227,7 +227,7 @@ public class SettingsActivity extends PreferenceActivity implements
         if (ItemToRunListContent == null) {
             AsyncTask.execute(() -> {
                 Pair<CharSequence[], CharSequence[]> content = generateItemToRunListContent(this);
-                synchronized (SettingsActivity.this) {
+                synchronized (SettingsActivity.class) {
                     if (ItemToRunListContent == null)
                         ItemToRunListContent = content;
                 }
@@ -239,7 +239,7 @@ public class SettingsActivity extends PreferenceActivity implements
     }
 
     private void updateItemToRunList(String key) {
-        synchronized (SettingsActivity.this) {
+        synchronized (SettingsActivity.class) {
             if (ItemToRunListContent != null)
                 updateListPrefDependency(key, prefs.getString(key, null), "launch-pojo", key + "-launch-id", ItemToRunListContent);
         }
@@ -262,13 +262,11 @@ public class SettingsActivity extends PreferenceActivity implements
 
         if (prefEntryToRun instanceof ListPreference) {
             if (enableValue.equals(dependOnValue)) {
-                synchronized (SettingsActivity.this) {
-                    if (listContent != null) {
-                        CharSequence[] entries = listContent.first;
-                        CharSequence[] entryValues = listContent.second;
-                        ((ListPreference) prefEntryToRun).setEntries(entries);
-                        ((ListPreference) prefEntryToRun).setEntryValues(entryValues);
-                    }
+                if (listContent != null) {
+                    CharSequence[] entries = listContent.first;
+                    CharSequence[] entryValues = listContent.second;
+                    ((ListPreference) prefEntryToRun).setEntries(entries);
+                    ((ListPreference) prefEntryToRun).setEntryValues(entryValues);
                 }
             } else {
                 getParent(prefEntryToRun).removePreference(prefEntryToRun);

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -58,7 +58,7 @@ public class SettingsActivity extends PreferenceActivity implements
             + " pref-rounded-list pref-rounded-bars pref-swap-kiss-button-with-menu pref-hide-circle history-hide"
             + " enable-favorites-bar notification-bar-color black-notification-icons icons-pack theme-shadow"
             + " theme-separator theme-result-color large-favorites-bar pref-hide-search-bar-hint theme-wallpaper"
-            + " theme-bar-color";
+            + " theme-bar-color results-size";
     // Those settings require a restart of the settings
     final static private String settingsRequiringRestartForSettingsActivity = "theme force-portrait";
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.forwarder;
 
+import android.annotation.SuppressLint;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -9,6 +10,8 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
+
+import androidx.annotation.StyleableRes;
 
 import java.util.List;
 
@@ -231,6 +234,7 @@ class InterfaceTweaks extends Forwarder {
 
     private int getSearchBackgroundColor() {
         // get theme shadow color
+        @SuppressLint("ResourceType") @StyleableRes
         int[] attrs = new int[]{R.attr.searchBackgroundColor /* index 0 */};
         TypedArray ta = mainActivity.obtainStyledAttributes(attrs);
         int shadowColor = ta.getColor(0, Color.BLACK);

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -47,7 +47,21 @@ class InterfaceTweaks extends Forwarder {
 
         UIColors.applyOverlay(mainActivity, prefs);
 
-        mainActivity.getTheme().applyStyle(prefs.getBoolean("small-results", false) ? R.style.OverlayResultSizeSmall : R.style.OverlayResultSizeStandard, true);
+        switch (prefs.getString("results-size", "")) {
+            case "smallest":
+                mainActivity.getTheme().applyStyle(R.style.OverlayResultSizeSmallest, true);
+                break;
+            case "small":
+                mainActivity.getTheme().applyStyle(R.style.OverlayResultSizeSmall, true);
+                break;
+            case "medium":
+                mainActivity.getTheme().applyStyle(R.style.OverlayResultSizeMedium, true);
+                break;
+            case "default":
+            default:
+                mainActivity.getTheme().applyStyle(R.style.OverlayResultSizeStandard, true);
+                break;
+        }
     }
 
     void onCreate() {

--- a/app/src/main/java/fr/neamar/kiss/forwarder/LiveWallpaper.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/LiveWallpaper.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.forwarder;
 
+import android.annotation.SuppressLint;
 import android.app.WallpaperManager;
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -10,6 +11,8 @@ import android.view.VelocityTracker;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.Transformation;
+
+import androidx.annotation.StyleableRes;
 
 import fr.neamar.kiss.MainActivity;
 
@@ -29,6 +32,7 @@ class LiveWallpaper extends Forwarder {
         super(mainActivity);
         TypedValue typedValue = new TypedValue();
         mainActivity.getTheme().resolveAttribute(android.R.attr.windowShowWallpaper, typedValue, true);
+        @SuppressLint("ResourceType")
         TypedArray a = mainActivity.obtainStyledAttributes(typedValue.resourceId, new int[]{android.R.attr.windowShowWallpaper});
         wallpaperIsVisible = a.getBoolean(0, true);
         a.recycle();

--- a/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/AddSearchProviderPreference.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.preference;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -15,6 +16,8 @@ import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.Toast;
+
+import androidx.annotation.StyleableRes;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -64,7 +67,7 @@ public class AddSearchProviderPreference extends DialogPreference {
         String theme = prefs.getString("theme", "light");
         //if theme is light, change the text color
         if (!theme.contains("dark")) {
-
+            @SuppressLint("ResourceType") @StyleableRes
             int[] attrs = {android.R.attr.textColor};
             TypedArray ta = getContext().obtainStyledAttributes(R.style.AppThemeLight, attrs);
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.result;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -27,6 +28,8 @@ import java.util.List;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.annotation.StyleableRes;
+
 import fr.neamar.kiss.BuildConfig;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
@@ -400,6 +403,7 @@ public abstract class Result {
      *
      */
     int getThemeFillColor(Context context) {
+        @SuppressLint("ResourceType") @StyleableRes
         int[] attrs = new int[]{R.attr.resultColor /* index 0 */};
         TypedArray ta = context.obtainStyledAttributes(attrs);
         int color = ta.getColor(0, Color.WHITE);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -121,6 +121,20 @@
     <string name="gesture_hide_keyboard">Hide keyboard</string>
     <string name="gesture_quicksettings">Display quick settings</string>
 
+    <string-array name="resultsSizeEntries">
+        <item>Default</item>
+        <item>Medium</item>
+        <item>Small</item>
+        <item>Smallest</item>
+    </string-array>
+
+    <string-array name="resultsSizeValues" translatable="false">
+        <item>default</item>
+        <item>medium</item>
+        <item>small</item>
+        <item>smallest</item>
+    </string-array>
+
     <!-- Names for DrawableUtils.SHAPE_*    -->
     <string-array name="adaptiveEntries">
         <item>@string/shape_system_default</item>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,12 +11,23 @@
     <dimen name="result_subtitle_size">14sp</dimen>
     <dimen name="result_button_height">56dp</dimen>
 
-    <dimen name="result_icon_size_small">24dp</dimen>
-    <dimen name="result_subicon_size_small">10dp</dimen>
-    <dimen name="result_title_size_small">15sp</dimen>
-    <dimen name="result_subtitle_size_small">10sp</dimen>
-    <dimen name="result_button_height_small">34dp</dimen>
+    <dimen name="result_icon_size_medium">40dp</dimen>
+    <dimen name="result_subicon_size_medium">16dp</dimen>
+    <dimen name="result_title_size_medium">17sp</dimen>
+    <dimen name="result_subtitle_size_medium">12sp</dimen>
+    <dimen name="result_button_height_medium">49dp</dimen>
 
+    <dimen name="result_icon_size_small">32dp</dimen>
+    <dimen name="result_subicon_size_small">13dp</dimen>
+    <dimen name="result_title_size_small">16sp</dimen>
+    <dimen name="result_subtitle_size_small">11sp</dimen>
+    <dimen name="result_button_height_small">41dp</dimen>
+
+    <dimen name="result_icon_size_smallest">24dp</dimen>
+    <dimen name="result_subicon_size_smallest">10dp</dimen>
+    <dimen name="result_title_size_smallest">15sp</dimen>
+    <dimen name="result_subtitle_size_smallest">10sp</dimen>
+    <dimen name="result_button_height_smallest">34dp</dimen>
 
     <dimen name="result_margin_left">10dp</dimen>
     <dimen name="result_margin_right">10dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,7 @@
     <string name="gesture_homescreen">Go to homescreen</string>
     <string name="gesture_launch_pojo">Launch…</string>
     <string name="small_results">Display smaller results</string>
+    <string name="results_size">Results display size</string>
     <string name="theme_wallpaper">Wallpaper</string>
     <string name="show_subicons">Show app icon on shortcuts</string>
     <string name="custom_name_rename">Rename</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -165,12 +165,28 @@
         <item name="resultButtonHeight">@dimen/result_button_height</item>
     </style>
 
+    <style name="OverlayResultSizeMedium">
+        <item name="resultIconSize">@dimen/result_icon_size_medium</item>
+        <item name="resultSubIconSize">@dimen/result_subicon_size_medium</item>
+        <item name="resultTitleSize">@dimen/result_title_size_medium</item>
+        <item name="resultSubtitleSize">@dimen/result_subtitle_size_medium</item>
+        <item name="resultButtonHeight">@dimen/result_button_height_medium</item>
+    </style>
+
     <style name="OverlayResultSizeSmall">
         <item name="resultIconSize">@dimen/result_icon_size_small</item>
         <item name="resultSubIconSize">@dimen/result_subicon_size_small</item>
         <item name="resultTitleSize">@dimen/result_title_size_small</item>
         <item name="resultSubtitleSize">@dimen/result_subtitle_size_small</item>
         <item name="resultButtonHeight">@dimen/result_button_height_small</item>
+    </style>
+
+    <style name="OverlayResultSizeSmallest">
+        <item name="resultIconSize">@dimen/result_icon_size_smallest</item>
+        <item name="resultSubIconSize">@dimen/result_subicon_size_smallest</item>
+        <item name="resultTitleSize">@dimen/result_title_size_smallest</item>
+        <item name="resultSubtitleSize">@dimen/result_subtitle_size_smallest</item>
+        <item name="resultButtonHeight">@dimen/result_button_height_smallest</item>
     </style>
 
     <style name="OverlayBarColorLight">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -141,10 +141,12 @@
                 android:summary="%s"
                 android:title="@string/theme_bar_color" />
         </PreferenceScreen>
-        <fr.neamar.kiss.preference.SwitchPreference
-            android:defaultValue="false"
-            android:key="small-results"
-            android:title="@string/small_results" />
+        <ListPreference
+            android:defaultValue="default"
+            android:entries="@array/resultsSizeEntries"
+            android:entryValues="@array/resultsSizeValues"
+            android:key="results-size"
+            android:title="@string/results_size"/>
 
         <PreferenceCategory android:title="@string/icons_category" android:key="icons-section">
             <ListPreference


### PR DESCRIPTION
KISS went with the mainActivity.getTheme().applyStyle route for tweaking the interface.
This does look way better in code, but needs xml styles for each size option.
I added a list preference with Smallest, Small, Medium, Default options.

fix #1849

I also went ahead and suppressed the lint ResourceType errors. Can't find any other way to get rid of them :grin: 