### PR TITLE
Select widgets through text list prompt.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     -->
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.BIND_APPWIDGET" />
 
     <uses-feature
         android:name="android.hardware.telephony"

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -148,10 +148,9 @@ class Widgets extends Forwarder {
                                         // directly call onActivityResult with the selected/newly-created id.
                                         t.onActivityResult(REQUEST_APPWIDGET_PICKED, Activity.RESULT_OK, new Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, id));
                                     } else {
-                                        List<AppWidgetProviderInfo> infos = mAppWidgetManager.getInstalledProviders();
                                         Intent intent = new Intent(AppWidgetManager.ACTION_APPWIDGET_BIND);
                                         intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, id);
-                                        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, infos.get(0).provider);
+                                        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, provider.provider);
                                         // This is the options bundle described in the preceding section.
                                         // TODO handle this correctly
                                         //intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_OPTIONS, infos.get(0));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="search_provider_error_exists">A provider with this name already exists</string>
     <string name="history_mode_name">History mode</string>
     <string name="history_mode_desc">Select how history should be sorted</string>
+    <string name="widget_text_mode_desc">Use a text menu to select widgets</string>
+    <string name="widget_text_mode_name">Widget Text mode</string>
     <string name="root_mode_desc">If available use it to hibernate apps</string>
     <string name="root_mode_name">Root mode</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -460,6 +460,11 @@
             android:key="enable-notifications"
             android:dialogMessage="@string/notification_dialog"
             android:title="@string/notification_support" />
+        <fr.neamar.kiss.preference.SwitchPreference
+            android:defaultValue="false"
+            android:key="widget-text-mode"
+            android:summary="@string/widget_text_mode_desc"
+            android:title="@string/widget_text_mode_name" />
         <fr.neamar.kiss.preference.DefaultLauncherPreference
             android:dialogMessage="@string/default_launcher_warn"
             android:key="default-launcher"


### PR DESCRIPTION
TL;DR Xiaomi/MIUI widget picker is broken. Therefore provide a very simple string list to select from instead.

Workaround for: https://github.com/Neamar/KISS/issues/1733 (and maybe some more)


Since this issue mainly concerns Xiaomi/MIUI devices I decided it would be best to have the widget selection through a String list only if the new preference `widget-text-mode` is explicitly set to true (default: false).

I took as reference: https://developer.android.com/guide/topics/appwidgets/host (which explains the need for the new permission `BIND_APPWIDGET`) and https://stackoverflow.com/questions/14000415/binding-widgets-in-custom-launcher

There are two TODOs left, handle the deny of the `BIND_APPWIDGET` permission
and I did not further investigate passing `EXTRA_APPWIDGET_OPTIONS`.
Maybe the input/prompt can be beatified as well, eg. a search in the list of options, but I thought getting the workaround working is more important first.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
