### PR TITLE
fix update of shortcuts

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -102,7 +102,7 @@ public class DataHandler extends BroadcastReceiver
 
         // Some basic providers are defined directly,
         // as we don't need the overhead of a service for them
-        // Those providers dong't expose a service connection,
+        // Those providers don't expose a service connection,
         // and you can't bind / unbind to them dynamically.
         ProviderEntry calculatorEntry = new ProviderEntry();
         calculatorEntry.provider = new CalculatorProvider();
@@ -681,6 +681,10 @@ public class DataHandler extends BroadcastReceiver
             for (ShortcutRecord shortcut : shortcutsList) {
                 String id = ShortcutUtil.generateShortcutId(shortcut.name);
                 excluded.remove(id);
+            }
+            // Refresh shortcuts
+            if (!shortcutsList.isEmpty() && this.getShortcutsProvider() != null) {
+                this.getShortcutsProvider().reload();
             }
         }
 

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -26,15 +26,14 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
                 KissApplication.getApplication(ctx).getDataHandler().updateShortcuts(packageName);
             } else {
                 Intent launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(packageName);
-                if (launchIntent == null) {//for some plugin app
-                    return;
-                }
-
-                // Add new package to history
-                if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
-                    String className = launchIntent.getComponent().getClassName();
-                    String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
-                    KissApplication.getApplication(ctx).getDataHandler().addToHistory(pojoID);
+                // launchIntent can be null for some plugin app
+                if (launchIntent != null) {
+                    // Add new package to history
+                    if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
+                        String className = launchIntent.getComponent().getClassName();
+                        String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
+                        KissApplication.getApplication(ctx).getDataHandler().addToHistory(pojoID);
+                    }
                 }
                 // Add shortcuts
                 KissApplication.getApplication(ctx).getDataHandler().updateAllShortcuts(packageName);

--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -20,25 +20,24 @@ import fr.neamar.kiss.utils.UserHandle;
 public class PackageAddedRemovedHandler extends BroadcastReceiver {
 
     public static void handleEvent(Context ctx, String action, String packageName, UserHandle user, boolean replacing) {
-        if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
-            // Insert into history new packages (not updated ones)
-            if (Intent.ACTION_PACKAGE_ADDED.equals(action)) {
-                if (replacing) {
-                    // Update shortcuts
-                    KissApplication.getApplication(ctx).getDataHandler().updateShortcuts(packageName);
-                } else {
-                    // Add new package to history
-                    Intent launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(packageName);
-                    if (launchIntent == null) {//for some plugin app
-                        return;
-                    }
+        if (Intent.ACTION_PACKAGE_ADDED.equals(action)) {
+            if (replacing) {
+                // Update shortcuts
+                KissApplication.getApplication(ctx).getDataHandler().updateShortcuts(packageName);
+            } else {
+                Intent launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(packageName);
+                if (launchIntent == null) {//for some plugin app
+                    return;
+                }
 
+                // Add new package to history
+                if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean("enable-app-history", true)) {
                     String className = launchIntent.getComponent().getClassName();
                     String pojoID = user.addUserSuffixToString("app://" + packageName + "/" + className, '/');
                     KissApplication.getApplication(ctx).getDataHandler().addToHistory(pojoID);
-                    // Add shortcuts
-                    KissApplication.getApplication(ctx).getDataHandler().updateAllShortcuts(packageName);
                 }
+                // Add shortcuts
+                KissApplication.getApplication(ctx).getDataHandler().updateAllShortcuts(packageName);
             }
         }
 


### PR DESCRIPTION
- `enable-app-history` preference must not affect create or update of shortcuts
- if preference is not set, shortcuts still must be updated or created

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
