### PR TITLE
fix shortcut crashes

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -507,8 +507,8 @@ public class DataHandler extends BroadcastReceiver
      * @param shortcut shortcut to be removed
      */
     public void removeShortcut(ShortcutPojo shortcut) {
-        removeShortcut(shortcut.id, shortcut.packageName, shortcut.intentUri);
-        if (this.getShortcutsProvider() != null) {
+        boolean shortcutUpdated = removeShortcut(shortcut.id, shortcut.packageName, shortcut.intentUri);
+        if (shortcutUpdated && this.getShortcutsProvider() != null) {
             this.getShortcutsProvider().reload();
         }
     }
@@ -564,8 +564,7 @@ public class DataHandler extends BroadcastReceiver
             return DBHelper.insertShortcut(this.context, shortcut);
         } else {
             String id = ShortcutUtil.generateShortcutId(shortcut.name);
-            removeShortcut(id, shortcut.packageName, shortcut.intentUri);
-            return true;
+            return removeShortcut(id, shortcut.packageName, shortcut.intentUri);
         }
     }
 
@@ -575,12 +574,13 @@ public class DataHandler extends BroadcastReceiver
      * @param id          KISS shortcut id, same as {@link ShortcutPojo#id}
      * @param packageName package name, same as {@link ShortcutPojo#packageName}
      * @param intentUri   intent to be called, same as {@link ShortcutPojo#intentUri}
+     * @return true, if shortcut was removed
      */
-    private void removeShortcut(String id, String packageName, String intentUri) {
+    private boolean removeShortcut(String id, String packageName, String intentUri) {
         Log.d(TAG, "Removing shortcut for " + packageName);
         // Also remove shortcut from favorites
         removeFromFavorites(id);
-        DBHelper.removeShortcut(this.context, packageName, intentUri);
+        return DBHelper.removeShortcut(this.context, packageName, intentUri);
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import fr.neamar.kiss.broadcast.ProfileChangedHandler;
 import fr.neamar.kiss.dataprovider.AppProvider;
 import fr.neamar.kiss.dataprovider.ContactsProvider;
 import fr.neamar.kiss.dataprovider.IProvider;
@@ -85,6 +86,12 @@ public class DataHandler extends BroadcastReceiver
 
         Intent i = new Intent(MainActivity.START_LOAD);
         this.context.sendBroadcast(i);
+
+        // Monitor changes for profiles
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            ProfileChangedHandler profileChangedHandler = new ProfileChangedHandler();
+            profileChangedHandler.register(this.context.getApplicationContext());
+        }
 
         // Monitor changes for service preferences (to automatically start and stop services)
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -34,10 +34,6 @@ public class KissApplication extends Application {
         return dataHandler;
     }
 
-    public void setDataHandler(DataHandler newDataHandler) {
-        dataHandler = newDataHandler;
-    }
-
     public RootHandler getRootHandler() {
         if (rootHandler == null) {
             rootHandler = new RootHandler(this);

--- a/app/src/main/java/fr/neamar/kiss/broadcast/ProfileChangedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/ProfileChangedHandler.java
@@ -1,0 +1,72 @@
+package fr.neamar.kiss.broadcast;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.UserManager;
+
+import androidx.annotation.RequiresApi;
+
+import fr.neamar.kiss.DataHandler;
+import fr.neamar.kiss.KissApplication;
+import fr.neamar.kiss.dataprovider.AppProvider;
+import fr.neamar.kiss.dataprovider.ShortcutsProvider;
+import fr.neamar.kiss.utils.UserHandle;
+
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class ProfileChangedHandler extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        if (Intent.ACTION_MANAGED_PROFILE_REMOVED.equals(intent.getAction())) {
+            // Try to clean up app-related data when profile is removed
+            android.os.UserHandle profile = intent.getParcelableExtra(Intent.EXTRA_USER);
+
+            // Package installation/uninstallation events for the main
+            // profile are still handled using PackageAddedRemovedHandler
+            UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+            UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
+
+            DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
+            dataHandler.removeFromExcluded(user);
+            dataHandler.removeFromFavorites(user);
+        }
+
+        if (Intent.ACTION_MANAGED_PROFILE_ADDED.equals(intent.getAction()) ||
+                Intent.ACTION_MANAGED_PROFILE_REMOVED.equals(intent.getAction()) ||
+                Intent.ACTION_USER_UNLOCKED.equals(intent.getAction()) ||
+                Intent.ACTION_PROFILE_ACCESSIBLE.equals(intent.getAction()) ||
+                Intent.ACTION_PROFILE_INACCESSIBLE.equals(intent.getAction())) {
+            DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
+
+            AppProvider appProvider = dataHandler.getAppProvider();
+            if (appProvider != null) {
+                appProvider.reload();
+            }
+            ShortcutsProvider shortcutsProvider = dataHandler.getShortcutsProvider();
+            if (shortcutsProvider != null) {
+                shortcutsProvider.reload();
+            }
+        }
+    }
+
+    public void register(Context context) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_MANAGED_PROFILE_ADDED);
+        filter.addAction(Intent.ACTION_MANAGED_PROFILE_REMOVED);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            filter.addAction(Intent.ACTION_USER_UNLOCKED);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            filter.addAction(Intent.ACTION_PROFILE_ACCESSIBLE);
+            filter.addAction(Intent.ACTION_PROFILE_INACCESSIBLE);
+        }
+
+        context.registerReceiver(this, filter);
+    }
+}

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -1,6 +1,5 @@
 package fr.neamar.kiss.dataprovider;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -11,12 +10,8 @@ import android.os.Process;
 import android.os.UserManager;
 import android.preference.PreferenceManager;
 
-import androidx.annotation.RequiresApi;
-
 import java.util.ArrayList;
-import java.util.Objects;
 
-import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.broadcast.PackageAddedRemovedHandler;
 import fr.neamar.kiss.loader.LoadAppPojos;
 import fr.neamar.kiss.normalizer.StringNormalizer;
@@ -30,7 +25,7 @@ public class AppProvider extends Provider<AppPojo> {
 
     @Override
     public void onCreate() {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             // Package installation/uninstallation events for the main
             // profile are still handled using PackageAddedRemovedHandler itself
             final UserManager manager = (UserManager) this.getSystemService(Context.USER_SERVICE);
@@ -90,28 +85,6 @@ public class AppProvider extends Provider<AppPojo> {
                     }
                 }
             });
-
-            // Try to clean up app-related data when profile is removed
-            IntentFilter filter = new IntentFilter();
-            filter.addAction(Intent.ACTION_MANAGED_PROFILE_ADDED);
-            filter.addAction(Intent.ACTION_MANAGED_PROFILE_REMOVED);
-            this.registerReceiver(new BroadcastReceiver() {
-                @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-                @Override
-                public void onReceive(Context context, Intent intent) {
-                    if (Objects.equals(intent.getAction(), Intent.ACTION_MANAGED_PROFILE_ADDED)) {
-                        AppProvider.this.reload();
-                    } else if (Objects.equals(intent.getAction(), Intent.ACTION_MANAGED_PROFILE_REMOVED)) {
-                        android.os.UserHandle profile = intent.getParcelableExtra(Intent.EXTRA_USER);
-
-                        UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
-
-                        KissApplication.getApplication(context).getDataHandler().removeFromExcluded(user);
-                        KissApplication.getApplication(context).getDataHandler().removeFromFavorites(user);
-                        AppProvider.this.reload();
-                    }
-                }
-            }, filter);
         }
 
         // Get notified when app changes on standard user profile

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
@@ -1,6 +1,8 @@
 package fr.neamar.kiss.loader;
 
 import android.content.Context;
+import android.content.pm.ShortcutInfo;
+import android.os.Build;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,10 +39,22 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutPojo> {
             pojo.setName(shortcutRecord.name);
             pojo.setTags(tagsHandler.getTags(pojo.id));
 
-            pojos.add(pojo);
+            if (isExistingShortcut(pojo)) {
+                pojos.add(pojo);
+            }
         }
 
         return pojos;
+    }
+
+    private boolean isExistingShortcut(ShortcutPojo pojo) {
+        if (pojo.isOreoShortcut()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                ShortcutInfo shortcutInfo = ShortcutUtil.getShortCut(context.get(), pojo.packageName, pojo.getOreoId());
+                return shortcutInfo != null;
+            }
+        }
+        return true;
     }
 
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/ShortcutUtil.java
@@ -128,7 +128,7 @@ public class ShortcutUtil {
 
             // find the correct UserHandle and get shortcut
             for (UserHandle userHandle : userHandles) {
-                if (userManager.isUserRunning(userHandle)) {
+                if (userManager.isUserRunning(userHandle) && userManager.isUserUnlocked(userHandle)) {
                     List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, userHandle);
                     if (shortcuts != null) {
                         for (ShortcutInfo shortcut : shortcuts) {


### PR DESCRIPTION
- fixes #1965
- check if user is unlocked before accessing shortcuts
- add new broadcast receiver to refresh providers if user/profile changes
- reduce number of reloads on shortcut changes
- do not show invalid shortcuts any more

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
