### PR TITLE
Add brave in default search engine list

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -34,6 +34,7 @@
     </string-array>
     <string-array name="defaultSearchProviders" tools:ignore="InconsistentArrays">
         <item>Bing|https://www.bing.com/search?q=%s</item>
+        <item>Brave|https://search.brave.com/search?q=%s</item>
         <item>Ecosia|https://www.ecosia.org/search?q=%s</item>
         <item>DuckDuckGo|https://start.duckduckgo.com/?q=%s</item>
         <item>Google|https://encrypted.google.com/search?q=%s</item>


### PR DESCRIPTION
Brave is a good alternative search engine that is not affected by bing censorship, unlike duckduckgo and ecosia

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
