### PR TITLE
fix work profile app icons

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/broadcast/ProfileChangedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/ProfileChangedHandler.java
@@ -39,7 +39,9 @@ public class ProfileChangedHandler extends BroadcastReceiver {
                 Intent.ACTION_MANAGED_PROFILE_REMOVED.equals(intent.getAction()) ||
                 Intent.ACTION_USER_UNLOCKED.equals(intent.getAction()) ||
                 Intent.ACTION_PROFILE_ACCESSIBLE.equals(intent.getAction()) ||
-                Intent.ACTION_PROFILE_INACCESSIBLE.equals(intent.getAction())) {
+                Intent.ACTION_PROFILE_INACCESSIBLE.equals(intent.getAction()) ||
+                Intent.ACTION_MANAGED_PROFILE_AVAILABLE.equals(intent.getAction()) ||
+                Intent.ACTION_MANAGED_PROFILE_UNAVAILABLE.equals(intent.getAction())) {
             DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
 
             AppProvider appProvider = dataHandler.getAppProvider();

--- a/app/src/main/java/fr/neamar/kiss/icons/IconPack.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPack.java
@@ -11,8 +11,6 @@ import androidx.annotation.Nullable;
 
 import java.util.Collection;
 
-import fr.neamar.kiss.utils.UserHandle;
-
 public interface IconPack<DrawableInfo> {
 
     @NonNull
@@ -21,10 +19,7 @@ public interface IconPack<DrawableInfo> {
     void load(PackageManager packageManager);
 
     @Nullable
-    Drawable getComponentDrawable(String componentName);
-
-    @Nullable
-    Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName, @NonNull UserHandle userHandle);
+    Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName);
 
     @NonNull
     Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable icon, boolean fitInside, @ColorInt int backgroundColor);

--- a/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
@@ -39,7 +39,6 @@ import java.util.Random;
 
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.utils.DrawableUtils;
-import fr.neamar.kiss.utils.UserHandle;
 
 public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
     private final static String TAG = IconPackXML.class.getSimpleName();
@@ -109,7 +108,8 @@ public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
     }
 
     @Nullable
-    public Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName, @NonNull UserHandle userHandle) {
+    @Override
+    public Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName) {
         return getComponentDrawable(componentName.toString());
     }
 

--- a/app/src/main/java/fr/neamar/kiss/icons/SystemIconPack.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/SystemIconPack.java
@@ -54,13 +54,7 @@ public class SystemIconPack implements IconPack<Void> {
 
     @Nullable
     @Override
-    public Drawable getComponentDrawable(String componentName) {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName, @NonNull UserHandle userHandle) {
+    public Drawable getComponentDrawable(@NonNull Context ctx, @NonNull ComponentName componentName) {
         Drawable drawable = null;
 
         if (componentName.getPackageName().equals(GoogleCalendarIcon.GOOGLE_CALENDAR)) {
@@ -69,28 +63,8 @@ public class SystemIconPack implements IconPack<Void> {
                 return drawable;
         }
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                LauncherApps launcher = (LauncherApps) ctx.getSystemService(Context.LAUNCHER_APPS_SERVICE);
-                List<LauncherActivityInfo> icons = launcher.getActivityList(componentName.getPackageName(), userHandle.getRealHandle());
-                for (LauncherActivityInfo info : icons) {
-                    if (info.getComponentName().equals(componentName)) {
-                        try {
-                            drawable = info.getBadgedIcon(0);
-                            break;
-                        } catch (SecurityException ignored) {
-                            // https://github.com/Neamar/KISS/issues/1715
-                            // not sure how to avoid it so we catch and ignore
-                        }
-                    }
-                }
-
-                // This should never happen, let's just return the activity icon
-                if (drawable == null)
-                    drawable = ctx.getPackageManager().getActivityIcon(componentName);
-            } else {
-                drawable = ctx.getPackageManager().getActivityIcon(componentName);
-            }
-        } catch (PackageManager.NameNotFoundException | IndexOutOfBoundsException e) {
+            drawable = ctx.getPackageManager().getActivityIcon(componentName);
+        } catch (PackageManager.NameNotFoundException e) {
             Log.e(TAG, "Unable to find component " + componentName.toShortString(), e);
         }
 

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -112,7 +112,7 @@ public class ShortcutsResult extends Result {
                 try {
                     appDrawable = packageManager.getApplicationIcon(shortcutPojo.packageName);
                     if (appDrawable != null)
-                        appDrawable = iconsHandler.applyIconMask(context, appDrawable, new fr.neamar.kiss.utils.UserHandle());
+                        appDrawable = iconsHandler.applyIconMask(context, appDrawable);
                 } catch (PackageManager.NameNotFoundException e) {
                     Log.e(TAG, "Unable to find package " + shortcutPojo.packageName, e);
                 }
@@ -122,7 +122,7 @@ public class ShortcutsResult extends Result {
             if (appDrawable == null) {
                 appDrawable = context.getPackageManager().getDefaultActivityIcon();
                 if (appDrawable != null)
-                    appDrawable = iconsHandler.applyIconMask(context, appDrawable, new fr.neamar.kiss.utils.UserHandle());
+                    appDrawable = iconsHandler.applyIconMask(context, appDrawable);
             }
 
             Drawable shortcutDrawable = getDrawable(context);
@@ -158,7 +158,7 @@ public class ShortcutsResult extends Result {
         }
 
         if (shortcutDrawable != null) {
-            shortcutDrawable = KissApplication.getApplication(context).getIconsHandler().applyIconMask(context, shortcutDrawable, new fr.neamar.kiss.utils.UserHandle());
+            shortcutDrawable = KissApplication.getApplication(context).getIconsHandler().applyIconMask(context, shortcutDrawable);
         }
 
         return shortcutDrawable;


### PR DESCRIPTION
- fixes #2009
- do not use app icons from `LauncherActivityInfo` including the badge any more, this allows icons from icon packs to be used for work profile apps too :smile:
- add profile badge in a dedicated step after icon mask has been applied
- cleanup `IconPack` interface

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
