### PR TITLE
implement call screening service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -149,6 +149,15 @@
                 <action android:name="android.intent.action.PHONE_STATE" />
             </intent-filter>
         </receiver>
+        <service
+            android:name=".broadcast.IncomingCallScreeningService"
+            android:permission="android.permission.BIND_SCREENING_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.telecom.CallScreeningService" />
+            </intent-filter>
+        </service>
+
 
         <service android:name=".dataprovider.AppProvider" />
         <service android:name=".dataprovider.ContactsProvider" />

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -1,5 +1,7 @@
 package fr.neamar.kiss;
 
+import static android.view.HapticFeedbackConstants.LONG_PRESS;
+
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
@@ -61,11 +63,8 @@ import fr.neamar.kiss.ui.BottomPullEffectView;
 import fr.neamar.kiss.ui.KeyboardScrollHider;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.ui.SearchEditText;
-import fr.neamar.kiss.utils.PackageManagerUtils;
 import fr.neamar.kiss.utils.Permission;
 import fr.neamar.kiss.utils.SystemUiVisibilityHelper;
-
-import static android.view.HapticFeedbackConstants.LONG_PRESS;
 
 public class MainActivity extends Activity implements QueryInterface, KeyboardScrollHider.KeyboardHandler, View.OnTouchListener {
 
@@ -366,7 +365,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         this.hider.start();
 
         // Enable/disable phone broadcast receiver
-        PackageManagerUtils.enableComponent(this, IncomingCallHandler.class, prefs.getBoolean("enable-phone-history", false));
+        IncomingCallHandler.setEnabled(this, prefs.getBoolean("enable-phone-history", false));
 
         // Hide the "X" after the text field, instead displaying the menu button
         displayClearOnInput();

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss;
 
 import android.annotation.SuppressLint;
 import android.app.Dialog;
+import android.app.role.RoleManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -47,7 +48,6 @@ import fr.neamar.kiss.preference.ExcludePreferenceScreen;
 import fr.neamar.kiss.preference.PreferenceScreenHelper;
 import fr.neamar.kiss.preference.SwitchPreference;
 import fr.neamar.kiss.searcher.QuerySearcher;
-import fr.neamar.kiss.utils.PackageManagerUtils;
 import fr.neamar.kiss.utils.Permission;
 
 @SuppressWarnings("FragmentInjection")
@@ -570,7 +570,7 @@ public class SettingsActivity extends PreferenceActivity implements
                 Permission.askPermission(Permission.PERMISSION_READ_PHONE_STATE, new Permission.PermissionResultListener() {
                     @Override
                     public void onGranted() {
-                        PackageManagerUtils.enableComponent(SettingsActivity.this, IncomingCallHandler.class, true);
+                        setPhoneHistoryEnabled(true);
                     }
 
                     @Override
@@ -582,7 +582,7 @@ public class SettingsActivity extends PreferenceActivity implements
                     }
                 });
             } else {
-                PackageManagerUtils.enableComponent(this, IncomingCallHandler.class, enabled);
+                setPhoneHistoryEnabled(enabled);
             }
         } else if (key.equalsIgnoreCase("primary-color")) {
             UIColors.clearPrimaryColorCache(this);
@@ -611,6 +611,15 @@ public class SettingsActivity extends PreferenceActivity implements
                 // Kill this activity too, and restart
                 recreate();
             }
+        }
+    }
+
+    private void setPhoneHistoryEnabled(boolean enabled) {
+        IncomingCallHandler.setEnabled(this, enabled);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && enabled) {
+            RoleManager roleManager = (RoleManager) getSystemService(ROLE_SERVICE);
+            Intent intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_CALL_SCREENING);
+            startActivityForResult(intent, 1);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallHandler.java
@@ -3,6 +3,7 @@ package fr.neamar.kiss.broadcast;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 
@@ -10,6 +11,7 @@ import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.dataprovider.ContactsProvider;
 import fr.neamar.kiss.pojo.ContactsPojo;
+import fr.neamar.kiss.utils.PackageManagerUtils;
 
 public class IncomingCallHandler extends BroadcastReceiver {
 
@@ -45,5 +47,14 @@ public class IncomingCallHandler extends BroadcastReceiver {
         } catch (Exception e) {
             Log.e("Phone Receive Error", " " + e);
         }
+    }
+
+    public static void setEnabled(Context context, boolean enabled) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            PackageManagerUtils.enableComponent(context, IncomingCallHandler.class, false);
+        } else {
+            PackageManagerUtils.enableComponent(context, IncomingCallHandler.class, enabled);
+        }
+
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallScreeningService.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/IncomingCallScreeningService.java
@@ -1,0 +1,40 @@
+package fr.neamar.kiss.broadcast;
+
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.telecom.Call;
+import android.telecom.CallScreeningService;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import fr.neamar.kiss.DataHandler;
+import fr.neamar.kiss.KissApplication;
+import fr.neamar.kiss.dataprovider.ContactsProvider;
+import fr.neamar.kiss.pojo.ContactsPojo;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class IncomingCallScreeningService extends CallScreeningService {
+
+    @Override
+    public void onScreenCall(@NonNull Call.Details callDetails) {
+        respondToCall(callDetails, new CallResponse.Builder().build());
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        if (prefs.getBoolean("enable-phone-history", false) && callDetails.getHandle() != null) {
+            String phoneNumber = callDetails.getHandle().getSchemeSpecificPart();
+            if (!TextUtils.isEmpty(phoneNumber)) {
+                DataHandler dataHandler = KissApplication.getApplication(this).getDataHandler();
+                ContactsProvider contactsProvider = dataHandler.getContactsProvider();
+                if (contactsProvider != null) {
+                    ContactsPojo contactPojo = contactsProvider.findByPhone(phoneNumber);
+                    if (contactPojo != null) {
+                        dataHandler.addToHistory(contactPojo.getHistoryId());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/fr/neamar/kiss/utils/Permission.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/Permission.java
@@ -6,12 +6,11 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
+import androidx.annotation.NonNull;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.ListIterator;
-
-import androidx.annotation.NonNull;
-
 
 public class Permission {
     public static final int PERMISSION_READ_CONTACTS = 0;
@@ -21,14 +20,14 @@ public class Permission {
     private static final String[] permissions = {
             Manifest.permission.READ_CONTACTS,
             Manifest.permission.CALL_PHONE,
-            Manifest.permission.READ_PHONE_STATE,
+            Manifest.permission.READ_PHONE_STATE
     };
 
     // Static weak reference to the linked activity, this is sadly required
     // to ensure classes requesting permission can access activity.requestPermission()
     private static WeakReference<Activity> currentActivity = new WeakReference<>(null);
 
-    private static ArrayList<PermissionResultListener> permissionListeners = new ArrayList<>();
+    private static final ArrayList<PermissionResultListener> permissionListeners = new ArrayList<>();
 
     public static boolean checkPermission(Context context, int permission) {
         return Build.VERSION.SDK_INT < Build.VERSION_CODES.M || context.checkSelfPermission(permissions[permission]) == PackageManager.PERMISSION_GRANTED;


### PR DESCRIPTION
- fixes #1294 for Android Q and higher
- when setting is enabled, KISS asks to get "Caller ID & spam app" for accessing phone number
![2022-12-28 14_42_07-Emulator - KISS](https://user-images.githubusercontent.com/3027783/209823222-ba132a04-bd91-4dd1-8df8-6b8386f15b6d.png)

- see https://support.google.com/googleplay/android-developer/answer/9888170
 -- phone number is sensitive information and google is restricting access to sensitive information (READ_CALL_LOG) more and more over years
 -- as KISS is no dialer and not everyone may want KISS as assist app, adding READ_CALL_LOG permission won't help much -- adding READ_CALL_LOG may also trigger complicated review process by google which may lead to KISS beeing rejected from play store
 -- easiest solution is implemtating a CallScreeningService, so KISS can be selected as "Caller ID & spam app" to access phone number

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
