### PR TITLE
fix fuzzy score

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -129,8 +129,6 @@ public class AppProvider extends Provider<AppPojo> {
         }
 
         FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
-        FuzzyScore.MatchInfo matchInfo;
-        boolean match;
 
         for (AppPojo pojo : pojos) {
             // exclude apps from results
@@ -142,17 +140,13 @@ public class AppProvider extends Provider<AppPojo> {
                 continue;
             }
 
-            matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
-            match = matchInfo.match;
-            pojo.relevance = matchInfo.score;
+            FuzzyScore.MatchInfo matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
+            boolean match = pojo.updateMatchingRelevance(matchInfo, false);
 
             // check relevance for tags
             if (pojo.getNormalizedTags() != null) {
                 matchInfo = fuzzyScore.match(pojo.getNormalizedTags().codePoints);
-                if (matchInfo.match && (!match || matchInfo.score > pojo.relevance)) {
-                    match = true;
-                    pojo.relevance = matchInfo.score;
-                }
+                match = pojo.updateMatchingRelevance(matchInfo, match);
             }
 
             if (match && !searcher.addResult(pojo)) {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java
@@ -63,29 +63,25 @@ public class ContactsProvider extends Provider<ContactsPojo> {
         }
 
         FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
-        FuzzyScore.MatchInfo matchInfo;
-        boolean match = false;
 
         for (ContactsPojo pojo : pojos) {
+            FuzzyScore.MatchInfo matchInfo;
+            boolean match = false;
+
             if (pojo.normalizedName != null) {
                 matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
-                match = matchInfo.match;
-                pojo.relevance = matchInfo.score;
+                match = pojo.updateMatchingRelevance(matchInfo, match);
             }
 
             if (pojo.normalizedNickname != null) {
                 matchInfo = fuzzyScore.match(pojo.normalizedNickname.codePoints);
-                if (matchInfo.match && (!match || matchInfo.score > pojo.relevance)) {
-                    match = true;
-                    pojo.relevance = matchInfo.score;
-                }
+                match = pojo.updateMatchingRelevance(matchInfo, match);
             }
 
             if (!match && queryNormalized.length() > 2 && pojo.normalizedPhone != null) {
                 // search for the phone number
                 matchInfo = fuzzyScore.match(pojo.normalizedPhone.codePoints);
-                match = matchInfo.match;
-                pojo.relevance = matchInfo.score;
+                match = pojo.updateMatchingRelevance(matchInfo, match);
             }
 
             if (match) {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/ShortcutsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/ShortcutsProvider.java
@@ -14,7 +14,6 @@ import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.loader.LoadShortcutsPojos;
 import fr.neamar.kiss.normalizer.StringNormalizer;
-import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.searcher.Searcher;
 import fr.neamar.kiss.utils.FuzzyScore;
@@ -69,8 +68,6 @@ public class ShortcutsProvider extends Provider<ShortcutPojo> {
         }
 
         FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
-        FuzzyScore.MatchInfo matchInfo;
-        boolean match;
 
         for (ShortcutPojo pojo : pojos) {
             // exclude favorites from results
@@ -78,17 +75,13 @@ public class ShortcutsProvider extends Provider<ShortcutPojo> {
                 continue;
             }
 
-            matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
-            match = matchInfo.match;
-            pojo.relevance = matchInfo.score;
+            FuzzyScore.MatchInfo matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
+            boolean match = pojo.updateMatchingRelevance(matchInfo, false);
 
             // check relevance for tags
             if (pojo.getNormalizedTags() != null) {
                 matchInfo = fuzzyScore.match(pojo.getNormalizedTags().codePoints);
-                if (matchInfo.match && (!match || matchInfo.score > pojo.relevance)) {
-                    match = true;
-                    pojo.relevance = matchInfo.score;
-                }
+                match = pojo.updateMatchingRelevance(matchInfo, match);
             }
 
             if (match && !searcher.addResult(pojo)) {

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SettingsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SettingsProvider.java
@@ -100,19 +100,15 @@ public class SettingsProvider extends SimpleProvider {
         }
 
         FuzzyScore fuzzyScore = new FuzzyScore(queryNormalized.codePoints);
-        FuzzyScore.MatchInfo matchInfo;
-        boolean match;
 
         for (SettingPojo pojo : pojos) {
-            matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
-            match = matchInfo.match;
-            pojo.relevance = matchInfo.score;
+            FuzzyScore.MatchInfo matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
+            boolean match = pojo.updateMatchingRelevance(matchInfo, false);
 
             if (!match) {
                 // Match localized setting name
                 matchInfo = fuzzyScore.match(settingName);
-                match = matchInfo.match;
-                pojo.relevance = matchInfo.score;
+                match = pojo.updateMatchingRelevance(matchInfo, match);
             }
 
             if (match && !searcher.addResult(pojo)) {

--- a/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss.pojo;
 
 import fr.neamar.kiss.normalizer.StringNormalizer;
+import fr.neamar.kiss.utils.FuzzyScore;
 
 public abstract class Pojo {
     public static final String DEFAULT_ID = "(none)";
@@ -70,5 +71,20 @@ public abstract class Pojo {
      */
     public String getFavoriteId() {
         return getHistoryId();
+    }
+
+    /**
+     * Updates relevance of this pojo with score of given {@code matchInfo} if there is a match.
+     *
+     * @param matchInfo used for update
+     * @param matched   flag to indicate if there was already a match before. If {@code matched} is false relevance is always set to {@link fr.neamar.kiss.utils.FuzzyScore.MatchInfo#score}, else it will be only set if {@link fr.neamar.kiss.utils.FuzzyScore.MatchInfo#score} is also higher than current value of relevance.
+     * @return true, if {@link fr.neamar.kiss.utils.FuzzyScore.MatchInfo#match} is true and relevance was updated, else value of {@code matched} is returned as is
+     */
+    public boolean updateMatchingRelevance(FuzzyScore.MatchInfo matchInfo, boolean matched) {
+        if (matchInfo.match && (!matched || matchInfo.score > relevance)) {
+            this.relevance = matchInfo.score;
+            return true;
+        }
+        return matched;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/FuzzyScore.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/FuzzyScore.java
@@ -265,9 +265,7 @@ public class FuzzyScore {
         }
 
         matchInfo.match = patternIdx == patternLength;
-        if (matchInfo.match) {
-            matchInfo.score = score;
-        }
+        matchInfo.score = score;
         return matchInfo;
     }
 


### PR DESCRIPTION
MatchInfo from FuzzyScore is always reused in loops in providers.
This may lead to pojos without match getting pretty high relevance which is wrong.

Problem: score of last match will be reused if there is no match for current pojo.
This will lead to non deterministic results if score is used for additional checks, e.g. https://github.com/Neamar/KISS/blob/5a7f2c6478c788c625a4bcb44ebdb6c37c52458b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java#L147 and https://github.com/Neamar/KISS/blob/5a7f2c6478c788c625a4bcb44ebdb6c37c52458b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java#L152 or https://github.com/Neamar/KISS/blob/5a7f2c6478c788c625a4bcb44ebdb6c37c52458b/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java#L73 and https://github.com/Neamar/KISS/blob/5a7f2c6478c788c625a4bcb44ebdb6c37c52458b/app/src/main/java/fr/neamar/kiss/dataprovider/ContactsProvider.java#L78
Solution: always set MatchInfo.score

For details see FuzzyScoreTest

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
