### PR TITLE
fix blocking of UI thread because of favorites

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -442,8 +442,9 @@ public class AppResult extends Result {
 
     @Override
     public boolean isDrawableDynamic() {
-        // The only dynamic icon is from Google Calendar
-        return GoogleCalendarIcon.GOOGLE_CALENDAR.equals(appPojo.packageName);
+        // drawable may change because of async loading, so return true as long as icon is not cached
+        // another dynamic icon is from Google Calendar
+        return !isDrawableCached()|| GoogleCalendarIcon.GOOGLE_CALENDAR.equals(appPojo.packageName);
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -179,6 +179,12 @@ public class ContactsResult extends CallResult {
     }
 
     @Override
+    public boolean isDrawableDynamic() {
+        // drawable may change because of async loading, so return true as long as icon is not cached
+        return !isDrawableCached();
+    }
+
+    @Override
     public Drawable getDrawable(Context context) {
         synchronized (this) {
             if (isDrawableCached())

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -25,6 +25,7 @@ import android.widget.Toast;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -76,7 +77,7 @@ public abstract class Result {
         else if (pojo instanceof ShortcutPojo)
             return new ShortcutsResult((ShortcutPojo) pojo);
         else if (pojo instanceof TagDummyPojo)
-            return new TagDummyResult((TagDummyPojo)pojo);
+            return new TagDummyResult((TagDummyPojo) pojo);
 
         throw new UnsupportedOperationException("Unable to create a result from POJO");
     }
@@ -105,12 +106,8 @@ public abstract class Result {
     @NonNull
     public View inflateFavorite(@NonNull Context context, @NonNull ViewGroup parent) {
         View favoriteView = LayoutInflater.from(context).inflate(R.layout.favorite_item, parent, false);
-        Drawable drawable = getDrawable(context);
         ImageView favoriteImage = favoriteView.findViewById(R.id.favorite);
-        if (drawable == null)
-            favoriteImage.setImageResource(R.drawable.ic_launcher_white);
-        else
-            favoriteImage.setImageDrawable(drawable);
+        setAsyncDrawable(favoriteImage, R.drawable.ic_launcher_white);
         favoriteView.setContentDescription(pojo.getName());
         return favoriteView;
     }
@@ -131,7 +128,7 @@ public abstract class Result {
     }
 
     boolean displayHighlighted(StringNormalizer.Result normalized, String text, FuzzyScore fuzzyScore,
-                                      TextView view, Context context) {
+                               TextView view, Context context) {
         FuzzyScore.MatchInfo matchInfo = fuzzyScore.match(normalized.codePoints);
 
         if (!matchInfo.match) {
@@ -357,6 +354,10 @@ public abstract class Result {
     }
 
     void setAsyncDrawable(ImageView view) {
+        setAsyncDrawable(view, android.R.color.transparent);
+    }
+
+    void setAsyncDrawable(ImageView view, @DrawableRes int resId) {
         // the ImageView tag will store the async task if it's running
         if (view.getTag() instanceof AsyncSetImage) {
             AsyncSetImage asyncSetImage = (AsyncSetImage) view.getTag();
@@ -377,12 +378,12 @@ public abstract class Result {
             view.setImageDrawable(getDrawable(view.getContext()));
             view.setTag(this);
         } else {
-            view.setTag(createAsyncSetImage(view).execute());
+            view.setTag(createAsyncSetImage(view, resId).execute());
         }
     }
 
-    private AsyncSetImage createAsyncSetImage(ImageView imageView) {
-        return new AsyncSetImage(imageView, this);
+    private AsyncSetImage createAsyncSetImage(ImageView imageView, @DrawableRes int resId) {
+        return new AsyncSetImage(imageView, this, resId);
     }
 
     /**
@@ -424,10 +425,10 @@ public abstract class Result {
         final WeakReference<ImageView> imageViewWeakReference;
         final WeakReference<Result> appResultWeakReference;
 
-        AsyncSetImage(ImageView image, Result result) {
+        AsyncSetImage(ImageView image, Result result, @DrawableRes int resId) {
             super();
             image.setTag(this);
-            image.setImageResource(android.R.color.transparent);
+            image.setImageResource(resId);
             this.imageViewWeakReference = new WeakReference<>(image);
             this.appResultWeakReference = new WeakReference<>(result);
         }


### PR DESCRIPTION
relates to https://github.com/Delta-Icons/android/issues/594, https://github.com/Neamar/KISS/issues/1704

Problem: when inflating favorites the method `getDrawable` is called on UI thread. When using icon packs, thead will be blocked until icon pack is loaded, which may take a while for large icon packs, e.g. Delta icon pack.

`load` method is synchronized: https://github.com/Neamar/KISS/blob/def061542359d6bcb8b41d8b31d0707907da07b1/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java#L71
`isLoaded` method called when getting drawable is synchronized too: https://github.com/Neamar/KISS/blob/def061542359d6bcb8b41d8b31d0707907da07b1/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java#L67

Solution: load drawables for favorites async to unblock UI thread
- use existing `setAsyncDrawable` method
- show kiss circle while loading instead of transparent color

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
