### PR TITLE
fix custom icons crash

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
+++ b/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
@@ -42,7 +42,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.icons.IconPackXML;
 import fr.neamar.kiss.icons.SystemIconPack;
 import fr.neamar.kiss.normalizer.StringNormalizer;
@@ -59,6 +58,7 @@ public class CustomIconDialog extends DialogFragment {
     private ImageView mPreview;
     private OnDismissListener mOnDismissListener = null;
     private OnConfirmListener mOnConfirmListener = null;
+    private Utilities.AsyncRun mLoadIconsPackTask = null;
 
     public interface OnDismissListener {
         void onDismiss(@NonNull CustomIconDialog dialog);
@@ -84,6 +84,7 @@ public class CustomIconDialog extends DialogFragment {
 
     @Override
     public void onDismiss(@NonNull DialogInterface dialog) {
+        cancelLoadIconsPackTask();
         if (mOnDismissListener != null)
             mOnDismissListener.onDismiss(this);
         super.onDismiss(dialog);
@@ -167,6 +168,7 @@ public class CustomIconDialog extends DialogFragment {
         {
             View button = view.findViewById(android.R.id.button1);
             button.setOnClickListener(v -> {
+                cancelLoadIconsPackTask();
                 if (mOnConfirmListener != null) {
                     mOnConfirmListener.onConfirm(mSelectedDrawable);
                 }
@@ -196,11 +198,20 @@ public class CustomIconDialog extends DialogFragment {
         }
 
         IconPackXML iconPack = iconsHandler.getCustomIconPack();
-        Utilities.runAsync((t) -> iconPack.loadDrawables(context.getPackageManager()), (t) -> {
-            Activity activity = Utilities.getActivity(context);
-            if (activity != null)
-                refreshList();
-        });
+        if (iconPack != null) {
+            cancelLoadIconsPackTask();
+            mLoadIconsPackTask = Utilities.runAsync((task) -> {
+                if (task == mLoadIconsPackTask) {
+                    iconPack.loadDrawables(context.getPackageManager());
+                }
+            }, (task) -> {
+                if (!task.isCancelled() && task == mLoadIconsPackTask) {
+                    Activity activity = Utilities.getActivity(context);
+                    if (activity != null)
+                        refreshList();
+                }
+            });
+        }
 
         SystemIconPack systemPack = iconsHandler.getSystemIconPack();
 
@@ -295,8 +306,8 @@ public class CustomIconDialog extends DialogFragment {
     private void refreshList() {
         mIconData.clear();
         IconsHandler iconsHandler = KissApplication.getApplication(getActivity()).getIconsHandler();
-        IconPack iconPack = iconsHandler.getCustomIconPack();
-        if (iconPack instanceof IconPackXML) {
+        IconPackXML iconPack = iconsHandler.getCustomIconPack();
+        if (iconPack != null) {
             Collection<IconPackXML.DrawableInfo> drawables = ((IconPackXML) iconPack).getDrawableList();
             if (drawables != null) {
                 StringNormalizer.Result normalized = StringNormalizer.normalizeWithResult(mSearch.getText(), true);
@@ -473,4 +484,15 @@ public class CustomIconDialog extends DialogFragment {
             }
         }
     }
+
+    /**
+     * Cancel running {@link CustomIconDialog#mLoadIconsPackTask} and set to null.
+     */
+    private void cancelLoadIconsPackTask() {
+        if (mLoadIconsPackTask != null) {
+            mLoadIconsPackTask.cancel();
+            mLoadIconsPackTask = null;
+        }
+    }
+
 }


### PR DESCRIPTION
 - cancel loading of drawables when `CustomIconDialog` is closed (similar to `IconsHandler#loadIconsPack`)
- fixes #2075

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
