### PR TITLE
fix blocking of UI thread because of shortcuts

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -28,6 +28,7 @@ import androidx.annotation.RequiresApi;
 
 import java.net.URISyntaxException;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
 
 import fr.neamar.kiss.DataHandler;
 import fr.neamar.kiss.IconsHandler;
@@ -41,12 +42,15 @@ import fr.neamar.kiss.utils.FuzzyScore;
 import fr.neamar.kiss.utils.PackageManagerUtils;
 import fr.neamar.kiss.utils.ShortcutUtil;
 import fr.neamar.kiss.utils.SpaceTokenizer;
+import fr.neamar.kiss.utils.Utilities;
 
 public class ShortcutsResult extends Result {
 
     private static final String TAG = ShortcutsResult.class.getSimpleName();
 
     private final ShortcutPojo shortcutPojo;
+
+    private Utilities.AsyncRun mLoadIconTask = null;
 
     ShortcutsResult(ShortcutPojo shortcutPojo) {
         super(shortcutPojo);
@@ -81,57 +85,87 @@ public class ShortcutsResult extends Result {
         final ImageView appIcon = view.findViewById(R.id.item_app_icon);
 
         if (!prefs.getBoolean("icons-hide", false)) {
-            // Retrieve icon for this shortcut
-            Drawable appDrawable = null;
-            IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
-
-            if (shortcutPojo.isOreoShortcut()) {
-                // Retrieve activity icon from oreo shortcut
-                appDrawable = getDrawableFromOreoShortcut(context);
+            if (mLoadIconTask != null) {
+                mLoadIconTask.cancel();
             }
 
-            if (appDrawable == null) {
-                // Retrieve activity icon by intent URI
-                try {
-                    Intent intent = Intent.parseUri(shortcutPojo.intentUri, 0);
-                    ComponentName componentName = PackageManagerUtils.getComponentName(context, intent);
-                    if (componentName != null) {
-                        appDrawable = iconsHandler.getDrawableIconForPackage(PackageManagerUtils.getLaunchingComponent(context, componentName), new fr.neamar.kiss.utils.UserHandle());
-                    }
-                } catch (NullPointerException e) {
-                    Log.e(TAG, "Unable to get activity icon for '" + shortcutPojo.getName() + "'", e);
-                } catch (URISyntaxException e) {
-                    Log.e(TAG, "Unable to parse uri for '" + shortcutPojo.getName() + "'", e);
-                }
-            }
+            boolean subIconVisible = prefs.getBoolean("subicon-visible", true);
 
-            if (appDrawable == null) {
-                // Retrieve app icon (no Oreo shortcut or a shortcut from an activity that was removed from an installed app)
-                appDrawable = PackageManagerUtils.getApplicationIcon(context, shortcutPojo.packageName);
-                if (appDrawable != null) {
-                    appDrawable = iconsHandler.applyIconMask(context, appDrawable);
-                }
-            }
+            AtomicReference<Drawable> appDrawable = new AtomicReference<>(null);
+            AtomicReference<Drawable> shortcutDrawable = new AtomicReference<>(null);
 
-            Drawable shortcutDrawable = getDrawable(context);
-
-            if (shortcutDrawable != null) {
-                shortcutIcon.setImageDrawable(shortcutDrawable);
-                appIcon.setImageDrawable(appDrawable);
+            // Prepare
+            shortcutIcon.setImageResource(android.R.color.transparent);
+            if (subIconVisible) {
+                appIcon.setVisibility(View.VISIBLE);
+                appIcon.setImageResource(android.R.color.transparent);
             } else {
-                // No icon for this shortcut, use app icon
-                shortcutIcon.setImageDrawable(appDrawable);
-                appIcon.setImageResource(android.R.drawable.ic_menu_send);
-            }
-            if (!prefs.getBoolean("subicon-visible", true)) {
                 appIcon.setVisibility(View.GONE);
             }
+
+            mLoadIconTask = Utilities.runAsync((task) -> {
+                if (task == mLoadIconTask) {
+                    // Retrieve icon for this shortcut
+                    appDrawable.set(getAppDrawable(context));
+                    shortcutDrawable.set(getDrawable(context));
+                }
+            }, (task) -> {
+                if (!task.isCancelled() && task == mLoadIconTask) {
+                    // set icons
+                    if (shortcutDrawable.get() != null) {
+                        shortcutIcon.setImageDrawable(shortcutDrawable.get());
+                        if (subIconVisible) {
+                            appIcon.setImageDrawable(appDrawable.get());
+                        }
+                    } else {
+                        // No icon for this shortcut, use app icon
+                        shortcutIcon.setImageDrawable(appDrawable.get());
+                        if (subIconVisible) {
+                            appIcon.setImageResource(android.R.drawable.ic_menu_send);
+                        }
+                    }
+                }
+            });
         } else {
             appIcon.setImageDrawable(null);
             shortcutIcon.setImageDrawable(null);
         }
 
         return view;
+    }
+
+    private Drawable getAppDrawable(Context context) {
+        Drawable appDrawable = null;
+        IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
+
+        if (shortcutPojo.isOreoShortcut()) {
+            // Retrieve activity icon from oreo shortcut
+            appDrawable = getDrawableFromOreoShortcut(context);
+        }
+
+        if (appDrawable == null) {
+            // Retrieve activity icon by intent URI
+            try {
+                Intent intent = Intent.parseUri(shortcutPojo.intentUri, 0);
+                ComponentName componentName = PackageManagerUtils.getComponentName(context, intent);
+                if (componentName != null) {
+                    appDrawable = iconsHandler.getDrawableIconForPackage(PackageManagerUtils.getLaunchingComponent(context, componentName), new fr.neamar.kiss.utils.UserHandle());
+                }
+            } catch (NullPointerException e) {
+                Log.e(TAG, "Unable to get activity icon for '" + shortcutPojo.getName() + "'", e);
+            } catch (URISyntaxException e) {
+                Log.e(TAG, "Unable to parse uri for '" + shortcutPojo.getName() + "'", e);
+            }
+        }
+
+        if (appDrawable == null) {
+            // Retrieve app icon (no Oreo shortcut or a shortcut from an activity that was removed from an installed app)
+            appDrawable = PackageManagerUtils.getApplicationIcon(context, shortcutPojo.packageName);
+            if (appDrawable != null) {
+                appDrawable = iconsHandler.applyIconMask(context, appDrawable);
+            }
+        }
+        return appDrawable;
     }
 
     public Drawable getDrawable(Context context) {


### PR DESCRIPTION
relates to https://github.com/Delta-Icons/android/issues/594, https://github.com/Neamar/KISS/issues/1704

Problem: when inflating favorites the method `getDrawable` is called on UI thread. When using icon packs, thead will be blocked until icon pack is loaded, which may take a while for large icon packs, e.g. Delta icon pack.

`load` method is synchronized: https://github.com/Neamar/KISS/blob/def061542359d6bcb8b41d8b31d0707907da07b1/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java#L71
`isLoaded` method called when getting drawable is synchronized too: https://github.com/Neamar/KISS/blob/def061542359d6bcb8b41d8b31d0707907da07b1/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java#L67

Solution: load drawables for shortcuts async to unblock UI thread
- use existing `Utilities.AsyncRun` method
- show transparent color while loading, similar to apps

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
