### PR TITLE
fix icon packs with mask

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -243,19 +243,16 @@ public class IconsHandler {
     public Drawable applyContactMask(@NonNull Context ctx, @NonNull Drawable drawable) {
         final int shape = getContactsShape();
 
-        if (DrawableUtils.isAdaptiveIconDrawable(drawable)) {
-            // use adaptive shape (with white background for non adaptive icons)
-            drawable = DrawableUtils.applyIconMaskShape(ctx, drawable, shape, true, Color.WHITE);
-        } else {
-            // use adaptive shape
-            drawable = DrawableUtils.applyIconMaskShape(ctx, drawable, shape, false, Color.TRANSPARENT);
-        }
-
         if (mContactPackMask && mIconPack != null && mIconPack.hasMask()) {
             // if the icon pack has a mask, use that instead of the adaptive shape
-            drawable = mIconPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
+            return mIconPack.applyBackgroundAndMask(ctx, drawable, false, Color.TRANSPARENT);
+        } else if (DrawableUtils.isAdaptiveIconDrawable(drawable)) {
+            // use adaptive shape (with white background for non adaptive icons)
+            return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, true, Color.WHITE);
+        } else {
+            // use adaptive shape
+            return DrawableUtils.applyIconMaskShape(ctx, drawable, shape, false, Color.TRANSPARENT);
         }
-        return drawable;
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
@@ -183,10 +183,6 @@ public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
     @NonNull
     @Override
     public Drawable applyBackgroundAndMask(@NonNull Context ctx, @NonNull Drawable icon, boolean fitInside, @ColorInt int backgroundColor) {
-        if (DrawableUtils.isAdaptiveIconDrawable(icon)) {
-            // convert AdaptiveIconDrawable to BitmapDrawable, use SHAPE_SQUARE so icon pack can be applied correctly
-            icon = DrawableUtils.applyIconMaskShape(ctx, icon, DrawableUtils.SHAPE_SQUARE, fitInside, Color.WHITE);
-        }
         BitmapDrawable bitmapDrawable = getBitmapDrawable(icon);
         return applyBackgroundAndMask(bitmapDrawable, ctx);
     }
@@ -362,10 +358,16 @@ public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
                             }
                         }
                         //parse <scale> xml tags used as scale factor of original bitmap icon
-                        else if (xpp.getName().equals("scale") && xpp.getAttributeCount() > 0 && xpp.getAttributeName(0).equals("factor")) {
-                            try {
-                                scaleFactor = Float.parseFloat(xpp.getAttributeValue(0));
-                            } catch (NumberFormatException ignored) {
+                        else if (xpp.getName().equals("scale")) {
+                            String factor = xpp.getAttributeValue(null, "factor");
+                            if (factor == null && xpp.getAttributeCount() > 0) {
+                                factor = xpp.getAttributeValue(0);
+                            }
+                            if (factor != null) {
+                                try {
+                                    scaleFactor = Float.parseFloat(factor);
+                                } catch (NumberFormatException ignored) {
+                                }
                             }
                         }
                         //parse <item> xml tags for custom icons


### PR DESCRIPTION
- fixes #2088 and hopefully #1863
- do not apply icon pack mask, background, ... to icons from icon pack
- apply icon pack mask only to icons **not** from icon pack
- harden parsing of scale tag: first read from attribute "factor" then read first attribute
- remove unnecessary conversion of adaptive drawables

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
