### PR TITLE
Make cursor in Search bar invisible

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -134,6 +134,7 @@
             android:layout_toEndOf="@id/leftHandSideButtonsWrapper"
             android:layout_toRightOf="@id/leftHandSideButtonsWrapper"
             android:background="@android:color/transparent"
+            android:cursorVisible="false"
             android:hint="@string/ui_search_hint"
             android:imeOptions="flagNoExtractUi|actionSearch"
             android:importantForAutofill="no"


### PR DESCRIPTION
Prevent blinking cursor on home screen from showing.  This commit could be improved in the future by only showing blinking cursor in search bar when keyboard is visible.