### PR TITLE
fix icon errors

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
+++ b/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
@@ -480,7 +480,9 @@ public class CustomIconDialog extends DialogFragment {
                 if (loader != null)
                     loader.cancel(true);
                 loader = new AsyncLoad(this);
-                loader.execute(content);
+                // use AsyncTask.SERIAL_EXECUTOR explicitly for now
+                // TODO: make execution parallel if needed/possible
+                loader.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR, content);
             }
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -206,7 +206,9 @@ public class IconsHandler {
             return null;
 
         drawable = applyBadge(drawable, userHandle);
-        storeDrawable(cacheGetFileName(cacheKey), drawable);
+        if (useCache) {
+            storeDrawable(cacheGetFileName(cacheKey), drawable);
+        }
         return drawable;
     }
 
@@ -465,7 +467,7 @@ public class IconsHandler {
      * clears cache for custom icon ids
      */
     private void clearCustomIconIdCache() {
-        synchronized (IconsHandler.class) {
+        synchronized (this) {
             customIconIds = null;
         }
     }
@@ -478,7 +480,7 @@ public class IconsHandler {
      */
     private Map<String, Long> getCustomIconIds() {
         if (customIconIds == null) {
-            synchronized (IconsHandler.class) {
+            synchronized (this) {
                 if (customIconIds == null) {
                     customIconIds = new HashMap<>();
                     Map<String, AppRecord> appData = DBHelper.getCustomAppData(ctx);

--- a/app/src/main/java/fr/neamar/kiss/KissApplication.java
+++ b/app/src/main/java/fr/neamar/kiss/KissApplication.java
@@ -14,10 +14,10 @@ public class KissApplication extends Application {
      * Setting this value to 0 removes all animations
      */
     public static final int TOUCH_DELAY = 120;
-    private DataHandler dataHandler;
-    private RootHandler rootHandler;
-    private IconsHandler iconsPackHandler;
-    private final IconPackCache mIconPackCache = new IconPackCache();;
+    private volatile DataHandler dataHandler;
+    private volatile RootHandler rootHandler;
+    private volatile IconsHandler iconsPackHandler;
+    private final IconPackCache mIconPackCache = new IconPackCache();
 
     public static KissApplication getApplication(Context context) {
         return (KissApplication) context.getApplicationContext();
@@ -29,14 +29,22 @@ public class KissApplication extends Application {
 
     public DataHandler getDataHandler() {
         if (dataHandler == null) {
-            dataHandler = new DataHandler(this);
+            synchronized (this) {
+                if (dataHandler == null) {
+                    dataHandler = new DataHandler(this);
+                }
+            }
         }
         return dataHandler;
     }
 
     public RootHandler getRootHandler() {
         if (rootHandler == null) {
-            rootHandler = new RootHandler(this);
+            synchronized (this) {
+                if (rootHandler == null) {
+                    rootHandler = new RootHandler(this);
+                }
+            }
         }
         return rootHandler;
     }
@@ -46,10 +54,8 @@ public class KissApplication extends Application {
     }
 
     public void initDataHandler() {
-        if (dataHandler == null) {
-            dataHandler = new DataHandler(this);
-        }
-        else if(dataHandler.allProvidersHaveLoaded) {
+        DataHandler dataHandler = getDataHandler();
+        if (dataHandler != null && dataHandler.allProvidersHaveLoaded) {
             // Already loaded! We still need to fire the FULL_LOAD event
             Intent i = new Intent(MainActivity.FULL_LOAD_OVER);
             sendBroadcast(i);
@@ -58,7 +64,11 @@ public class KissApplication extends Application {
 
     public IconsHandler getIconsHandler() {
         if (iconsPackHandler == null) {
-            iconsPackHandler = new IconsHandler(this);
+            synchronized (this) {
+                if (iconsPackHandler == null) {
+                    iconsPackHandler = new IconsHandler(this);
+                }
+            }
         }
 
         return iconsPackHandler;

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -378,7 +378,9 @@ public abstract class Result {
             view.setImageDrawable(getDrawable(view.getContext()));
             view.setTag(this);
         } else {
-            view.setTag(createAsyncSetImage(view, resId).execute());
+            // use AsyncTask.SERIAL_EXECUTOR explicitly for now
+            // TODO: make execution parallel if needed/possible
+            view.setTag(createAsyncSetImage(view, resId).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR));
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -3,13 +3,11 @@ package fr.neamar.kiss.utils;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
-import android.graphics.Shader.TileMode;
 import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
@@ -96,6 +94,7 @@ public class DrawableUtils {
 
     /**
      * Handle adaptive icons for compatible devices
+     * Synchronized because class fields like {@link DrawableUtils#PAINT} are reused for every call, which may result in unexpected behaviour if method is called in from different threads running parallel.
      *
      * @param ctx             {@link Context}
      * @param icon            the {@link Drawable} to shape
@@ -106,7 +105,7 @@ public class DrawableUtils {
      */
     @NonNull
     @SuppressLint("NewApi")
-    public static Drawable applyIconMaskShape(@NonNull Context ctx, @NonNull Drawable icon, int shape, boolean fitInside, @ColorInt int backgroundColor) {
+    public synchronized static Drawable applyIconMaskShape(@NonNull Context ctx, @NonNull Drawable icon, int shape, boolean fitInside, @ColorInt int backgroundColor) {
         if (shape == SHAPE_SYSTEM && !hasDeviceConfiguredMask())
             // if no icon mask can be configured for device, then use icon as is
             return icon;
@@ -123,33 +122,31 @@ public class DrawableUtils {
             Drawable bgDrawable = adaptiveIcon.getBackground();
             Drawable fgDrawable = adaptiveIcon.getForeground();
 
-            int layerSize = Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 108f, ctx.getResources().getDisplayMetrics()));
-            int iconSize = Math.round(layerSize / (1 + 2 * AdaptiveIconDrawable.getExtraInsetFraction()));
+            int iconSize = icon.getIntrinsicHeight();
+            if (iconSize <= 0) {
+                iconSize = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 72f, ctx.getResources().getDisplayMetrics());
+            }
+            int layerSize = (int) (iconSize * (1 + 2 * AdaptiveIconDrawable.getExtraInsetFraction()));
             int layerOffset = (layerSize - iconSize) / 2;
 
-            // Create a bitmap of the icon to use it as the shader of the outputBitmap
-            Bitmap iconBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
-            Canvas iconCanvas = new Canvas(iconBitmap);
+            outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
+            outputCanvas = new Canvas(outputBitmap);
+            outputPaint.setColor(backgroundColor);
+
+            setIconShape(outputCanvas, outputPaint, shape);
 
             // Stretch adaptive layers because they are 108dp and the icon size is 48dp
             if (bgDrawable != null) {
                 bgDrawable.setBounds(-layerOffset, -layerOffset, iconSize + layerOffset, iconSize + layerOffset);
-                bgDrawable.draw(iconCanvas);
+                bgDrawable.draw(outputCanvas);
             }
 
             if (fgDrawable != null) {
                 fgDrawable.setBounds(-layerOffset, -layerOffset, iconSize + layerOffset, iconSize + layerOffset);
-                fgDrawable.draw(iconCanvas);
+                fgDrawable.draw(outputCanvas);
             }
-
-            outputBitmap = Bitmap.createBitmap(iconSize, iconSize, Bitmap.Config.ARGB_8888);
-            outputCanvas = new Canvas(outputBitmap);
-
-            outputPaint.setShader(new BitmapShader(iconBitmap, TileMode.CLAMP, TileMode.CLAMP));
-            setIconShape(outputCanvas, outputPaint, shape);
-            outputPaint.setShader(null);
         }
-        // If icon is not adaptive, put it in a white canvas to make it have a unified shape
+        // If icon is not adaptive, put it in a colored canvas to make it have a unified shape
         else if (icon != null) {
             // Shrink icon fit inside the shape
             int iconSize;
@@ -170,11 +167,11 @@ public class DrawableUtils {
             outputCanvas = new Canvas(outputBitmap);
             outputPaint.setColor(backgroundColor);
 
+            setIconShape(outputCanvas, outputPaint, shape);
+
             // Shrink icon so that it fits the shape
             int bottomRightCorner = iconSize - iconOffset;
             icon.setBounds(iconOffset, iconOffset, bottomRightCorner, bottomRightCorner);
-
-            setIconShape(outputCanvas, outputPaint, shape);
             icon.draw(outputCanvas);
         } else {
             int iconSize = ctx.getResources().getDimensionPixelSize(R.dimen.result_icon_size);
@@ -190,12 +187,13 @@ public class DrawableUtils {
 
     /**
      * Set the shape of adaptive icons
+     * Synchronized because class fields like {@link DrawableUtils#SHAPE_PATH} and {@link DrawableUtils#RECT_F} are reused for every call, which may result in unexpected behaviour if method is called in from different threads running parallel.
      *
      * @param shape type of shape: DrawableUtils.SHAPE_*
      */
-    private static void setIconShape(Canvas canvas, Paint paint, int shape) {
+    private synchronized static void setIconShape(Canvas canvas, Paint paint, int shape) {
         int iconSize = canvas.getHeight();
-        Path path = SHAPE_PATH;
+        final Path path = SHAPE_PATH;
         path.rewind();
 
         switch (shape) {
@@ -204,7 +202,7 @@ public class DrawableUtils {
                     // get icon mask for device
                     AdaptiveIconDrawable drawable = new AdaptiveIconDrawable(new ColorDrawable(Color.BLACK), new ColorDrawable(Color.BLACK));
                     drawable.setBounds(0, 0, iconSize, iconSize);
-                    path = drawable.getIconMask();
+                    path.set(drawable.getIconMask());
                 } else {
                     // This should never happen, use rect so nothing is clipped
                     path.addRect(0f, 0f, iconSize, iconSize, Path.Direction.CCW);


### PR DESCRIPTION
- hopefully fixes #2083
- run some `AsyncTask` in serial explicitely for now: for defined behaviour (already default for most android versions)
- do not write drawables to cache if it is not necessary
- get rid of shader used for drawing adaptive icons: not necessary as icons can be drawn as is
- make some more methods thread-safe:
  - necessary if class fields are used
  - prevent singleton objects from being instantiated multiple times

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
