### PR TITLE
[DRAFT] [WIP] Feat: share text to KISS

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,6 +73,11 @@
             <intent-filter>
                 <action android:name="android.content.pm.action.CONFIRM_PIN_SHORTCUT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
             <meta-data
                 android:name="com.android.systemui.action_assist_icon"
                 android:resource="@drawable/ic_launcher" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
             <intent-filter>
                 <action android:name="android.content.pm.action.CONFIRM_PIN_SHORTCUT" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:label="@string/ui_search_hint">
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -379,21 +379,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             searchEditText.requestFocus();
         }
 
-        // Pasting shared text from Sharesheet via intent-filter into kiss search bar
-        Intent receivedIntent = getIntent();
-        String receivedIntentAction = receivedIntent.getAction();
-        String receivedIntentType = receivedIntent.getType();
-        if (Intent.ACTION_SEND.equals(action) && receivedIntentType != null && "text/plain".equals(receivedIntentType)) {
-            hideKeyboard();
-            String sharedText = receivedIntent.getStringExtra(Intent.EXTRA_TEXT);
-            // making sure the shared text is not an empty string
-            if (sharedText != null && sharedText.trim().length() > 0) {
-                searchEditText.setText(sharedText);
-            } else {
-                Toast.makeText(this, R.string.shared_text_empty, Toast.LENGTH_SHORT).show();
-            }
-        }
-
         /*
          * Defer everything else to the forwarders
          */
@@ -454,6 +439,21 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         }
 
         forwarderManager.onResume();
+
+        // Pasting shared text via intent-filter into kiss search bar
+        Intent receivedIntent = getIntent();
+        String receivedIntentAction = receivedIntent.getAction();
+        String receivedIntentType = receivedIntent.getType();
+        if (Intent.ACTION_SEND.equals(receivedIntentAction) && "text/plain".equals(receivedIntentType)) {
+            hideKeyboard();
+            String sharedText = receivedIntent.getStringExtra(Intent.EXTRA_TEXT);
+            // making sure the shared text is not an empty string
+            if (sharedText != null && !TextUtils.isEmpty(sharedText.trim())) {
+                searchEditText.setText(sharedText);
+            } else {
+                Toast.makeText(this, R.string.shared_text_empty, Toast.LENGTH_SHORT).show();
+            }
+        }
 
         super.onResume();
     }

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -40,6 +40,7 @@ import android.widget.AdapterView;
 import android.widget.PopupWindow;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
@@ -375,6 +376,21 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         // For devices with hardware keyboards, give focus to search field.
         if(getResources().getConfiguration().keyboard == Configuration.KEYBOARD_QWERTY || getResources().getConfiguration().keyboard == Configuration.KEYBOARD_12KEY) {
             searchEditText.requestFocus();
+        }
+
+        // Pasting shared text from Sharesheet via intent-filter into kiss search bar
+        Intent receivedIntent = getIntent();
+        String receivedIntentAction = receivedIntent.getAction();
+        String receivedIntentType = receivedIntent.getType();
+        if (Intent.ACTION_SEND.equals(action) && receivedIntentType != null && "text/plain".equals(receivedIntentType)) {
+            hideKeyboard();
+            String sharedText = receivedIntent.getStringExtra(Intent.EXTRA_TEXT);
+            // making sure the shared text is not an empty string
+            if (sharedText != null && sharedText.trim().length() > 0) {
+                searchEditText.setText(sharedText);
+            } else {
+                Toast.makeText(this, "", Toast.LENGTH_SHORT).show();
+            }
         }
 
         /*

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -51,6 +51,7 @@ import fr.neamar.kiss.broadcast.IncomingCallHandler;
 import fr.neamar.kiss.dataprovider.simpleprovider.SearchProvider;
 import fr.neamar.kiss.forwarder.ForwarderManager;
 import fr.neamar.kiss.pojo.SearchPojo;
+import fr.neamar.kiss.R;
 import fr.neamar.kiss.result.Result;
 import fr.neamar.kiss.searcher.ApplicationsSearcher;
 import fr.neamar.kiss.searcher.HistorySearcher;
@@ -389,7 +390,7 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             if (sharedText != null && sharedText.trim().length() > 0) {
                 searchEditText.setText(sharedText);
             } else {
-                Toast.makeText(this, "", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.shared_text_empty, Toast.LENGTH_SHORT).show();
             }
         }
 

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -61,6 +61,7 @@
     <string name="settings_tethering">Tethering</string>
     <string name="menu_wallpaper">Perbarui wallpaper…</string>
     <string name="application_not_found">Ups... gagal menjalankan apl tersebut.</string>
+    <string name="shared_text_empty">Ups... text-nya ternyata kosong.</string>
     <string name="history_erased">Riwayat dihapus.</string>
     <string name="favorites_erased">Favorit dihapus.</string>
     <string name="menu_favorites_add">Tambahkan ke favorit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="settings_display">Display</string>
     <string name="menu_wallpaper">Update wallpaper…</string>
     <string name="application_not_found">Whoops… unable to launch that app.</string>
+    <string name="shared_text_empty">Whoops… text is actually empty.</string>
     <string name="history_erased">History erased.</string>
     <string name="favorites_erased">Favorites erased.</string>
     <string name="menu_favorites_add">Add to favorites</string>


### PR DESCRIPTION
## Summary: New feature proposal for sharing text from anywhere into KISS search bar for quicker searching experience


### General Idea

This is a **WIP** proposal to streamline the user experience of searching using KISS launcher. It works by sharing texts 
 (or web links) from almost anywhere on the phone into the KISS launcher's search bar via android's [Sharesheet].
<br/>

### Background

I can't say for sure that i can speak for every user, but based on my experience in using KISS for almost every web (or play store, google maps  location, local e-commerce, etc) search, i always find it a bit tedious and too repetitive to highlight the text i want, tap the "Copy" option, open KISS, long-tap KISS search input, and finally tap the "Paste" option before picking the search engine i want to search it with.
<br/>

### Why not just use the "Web Search" option in the highlighted text's context menu?

The "Web Search" option only uses the default search engine of the current browser i'm using. And when outside of browser environment, i only get the "Google App" option, which is frustrating to say the least. For context, i frequently jump between search engines and also between browsers. I have more than 3 search engines that i use daily for cross-referencing sources and comparing SEO results. I have more than 2 browsers for different needs (i have not set a default browser so i can always pick whichever i want everytime i search) as i don't want to mix up the browsing history (e.g. personal searches, workplace searches, people borrowing my phone for quick searches, etc).
<br/>

### Why not use DuckDuckGo's Bangs?

DDG's Bangs requires inclusion of pre-determined non-customizable prefix text to the search keyword, which would mean more hoops to jump through than i currently have to do. Besides , this problem is already solved by KISS launcher's list of search provider. The fewer steps one has to make the better and KISS launcher is already a huge step in the right direction, just needs one more :)
<br/>

### What changes code-wise?

* `AndroidManifest.xml`: added `intent-filter` for registering KISS launcher as a sharing option in context menus.
* `MainActivity.java`: added handler inside `onCreate` for the received `Intent.EXTRA_TEXT` and setting the text value of `searchEditText` with it; complete with error toast fallback.
* `strings.xml (EN)` + `strings-.xml (IN)`: added error message text and 1 translation for my native language (the correct country code is  `ID` and  not `IN` btw :P ).
<br/>

### Have you tested it yourself? Where are the screenshots?

I haven't. That's why this PR is labeled as **[DRAFT] [WIP]**. I don't have access to a powerful enough machine to run Android Studio to build and test it myself for now. I even made these proposed changes directly from this website :zany_face: . I am still going to finish this PR, just not now. **If anybody is also interested in this proposed feature and _DO_ can build and test it as soon as it takes, please do share the results here**. :bow: 
<br/>

### So what now?

I will build and test it myself when i have a suitable hardware for it. No exact time that i can tell, but i will commit to this, because i need this, except if this PR is deemed unsuitable by the maintainers. Then i would (probably) keep this fork a little longer. In the meantime i accept reviews, critiques, and suggestions. I will do as best as i can to get this PR acceptable.
<br/>

**Terima kasih atas perhatian dan pertimbangannya**
**Matur nuwun** :pray:

<!-- Links -->
[Sharesheet]: <https://developer.android.com/static/images/training/sharing/sharesheet_api29.png>
