### PR TITLE
reduce number of provider reloads

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/broadcast/PackageAddedRemovedHandler.java
@@ -34,18 +34,22 @@ public class PackageAddedRemovedHandler extends BroadcastReceiver {
             }
         }
 
-        if (Intent.ACTION_PACKAGE_REMOVED.equals(action) && !replacing) {
-            // Remove all installed shortcuts
-            KissApplication.getApplication(ctx).getDataHandler().removeShortcuts(packageName);
-            KissApplication.getApplication(ctx).getDataHandler().removeFromExcluded(packageName);
-        }
-
         KissApplication.getApplication(ctx).resetIconsHandler();
 
-        // Reload application list
-        KissApplication.getApplication(ctx).getDataHandler().reloadApps();
-        // reload shortcuts
-        KissApplication.getApplication(ctx).getDataHandler().reloadShortcuts();
+        if (Intent.ACTION_PACKAGE_REMOVED.equals(action)) {
+            if (!replacing) {
+                // Reload application list
+                KissApplication.getApplication(ctx).getDataHandler().reloadApps();
+                // Remove all installed shortcuts
+                KissApplication.getApplication(ctx).getDataHandler().removeShortcuts(packageName);
+                KissApplication.getApplication(ctx).getDataHandler().removeFromExcluded(packageName);
+            }
+        } else {
+            // Reload application list
+            KissApplication.getApplication(ctx).getDataHandler().reloadApps();
+            // Reload shortcuts
+            KissApplication.getApplication(ctx).getDataHandler().reloadShortcuts();
+        }
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
@@ -57,7 +57,7 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutPojo> {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             List<ShortcutInfo> shortcutInfos = ShortcutUtil.getAllShortcuts(context);
             for (ShortcutInfo shortcutInfo : shortcutInfos) {
-                if (isShortcutVisible(context, shortcutInfo, excludedApps, excludedShortcutApps, visibleShortcutIds)) {
+                if (ShortcutUtil.isShortcutVisible(context, shortcutInfo, excludedApps, excludedShortcutApps, visibleShortcutIds)) {
                     ShortcutRecord shortcutRecord = ShortcutUtil.createShortcutRecord(context, shortcutInfo, !shortcutInfo.isPinned());
                     if (shortcutRecord != null) {
                         ShortcutPojo pojo = createPojo(shortcutRecord, tagsHandler, ShortcutUtil.getComponentName(context, shortcutInfo), shortcutInfo.isPinned(), shortcutInfo.isDynamic());
@@ -75,25 +75,5 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutPojo> {
         pojo.setName(shortcutRecord.name);
         pojo.setTags(tagsHandler.getTags(pojo.id));
         return pojo;
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    private boolean isShortcutVisible(Context context, ShortcutInfo shortcutInfo, Set<String> excludedApps, Set<String> excludedShortcutApps, Set<String> visibleShortcutIds) {
-        if (!shortcutInfo.isEnabled()) {
-            return false;
-        }
-        String packageName = shortcutInfo.getPackage();
-        String componentName = ShortcutUtil.getComponentName(context, shortcutInfo);
-
-        // if related package is excluded from KISS then the shortcut must be excluded too
-        boolean isExcluded = excludedApps.contains(componentName) || excludedShortcutApps.contains(packageName);
-        if (isExcluded) {
-            return false;
-        }
-
-        if (shortcutInfo.isPinned()) {
-            return visibleShortcutIds.contains(shortcutInfo.getId());
-        }
-        return true;
     }
 }


### PR DESCRIPTION
Reduce number of provider reloads to reduce flickering/refreshing:
- if any shortcuts or packages are excluded, there is no need to reload shortcuts for package
- if a package gets replaced, reload needs to be done only once
- related to #2113

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
