### PR TITLE
fix NPE

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/utils/PackageManagerUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/PackageManagerUtils.java
@@ -136,13 +136,10 @@ public class PackageManagerUtils {
      * @param uri
      * @return intent
      */
-    public static Intent createUriIntent(Uri uri) {
-        if (uri.isAbsolute() && uri.getSchemeSpecificPart().length() > 2) {
-            Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            return intent;
-        }
-        return null;
+    public static @NonNull Intent createUriIntent(Uri uri) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        return intent;
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/utils/URIUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/URIUtils.java
@@ -36,8 +36,8 @@ public class URIUtils {
     public static URIValidity isValidUri(final @NotNull String query, final @NotNull Context context) {
         if (!URLUtil.isValidUrl(query)) {
             Uri uri = Uri.parse(query);
-            Intent intent = PackageManagerUtils.createUriIntent(uri);
-            if (intent != null) {
+            if (uri.isAbsolute() && uri.getSchemeSpecificPart().length() > 2) {
+                Intent intent = PackageManagerUtils.createUriIntent(uri);
                 final PackageManager packageManager = context.getPackageManager();
                 final List<ResolveInfo> receiverList = packageManager.queryIntentActivities(intent,
                         PackageManager.MATCH_DEFAULT_ONLY);


### PR DESCRIPTION
- make `PackageManagerUtils.createUriIntent` return non null intent to prevent `SearchResult` from throwing NPE

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
