### PR TITLE
allow all icons for custom icons

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -327,15 +328,14 @@ public class IconsHandler {
     }
 
     private void storeDrawable(File drawableFile, Drawable drawable) {
-        if (drawable instanceof BitmapDrawable) {
-            FileOutputStream fos;
-            try {
-                fos = new FileOutputStream(drawableFile);
-                ((BitmapDrawable) drawable).getBitmap().compress(CompressFormat.PNG, 100, fos);
+        // convert any drawable to bitmap that can be stored
+        Bitmap bitmap = DrawableUtils.drawableToBitmap(drawable);
+        if (bitmap != null) {
+            try (FileOutputStream fos = new FileOutputStream(drawableFile)) {
+                bitmap.compress(CompressFormat.PNG, 100, fos);
                 fos.flush();
-                fos.close();
             } catch (Exception e) {
-                Log.e(TAG, "Unable to store drawable in cache " + e);
+                Log.e(TAG, "Unable to store drawable in cache ", e);
             }
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
+++ b/app/src/main/java/fr/neamar/kiss/icons/IconPackXML.java
@@ -167,21 +167,12 @@ public class IconPackXML implements IconPack<IconPackXML.DrawableInfo> {
      * @param icon any {@link Drawable}
      * @return a {@link BitmapDrawable}
      */
-    public BitmapDrawable getBitmapDrawable(Drawable icon) {
+    private BitmapDrawable getBitmapDrawable(Drawable icon) {
         if (icon instanceof BitmapDrawable) {
             return (BitmapDrawable) icon;
         }
 
-        final Canvas canvas = new Canvas();
-        canvas.setDrawFilter(new PaintFlagsDrawFilter(0, Paint.FILTER_BITMAP_FLAG | Paint.ANTI_ALIAS_FLAG));
-        Bitmap bitmap;
-        if (icon.getIntrinsicWidth() <= 0 || icon.getIntrinsicHeight() <= 0)
-            bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888); // Single color bitmap will be created of 1x1 pixel
-        else
-            bitmap = Bitmap.createBitmap(icon.getIntrinsicWidth(), icon.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
-        canvas.setBitmap(bitmap);
-        icon.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
-        icon.draw(canvas);
+        Bitmap bitmap = DrawableUtils.drawableToBitmap(icon);
         return new BitmapDrawable(packResources, bitmap);
     }
 

--- a/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/DrawableUtils.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.PaintFlagsDrawFilter;
 import android.graphics.Path;
 import android.graphics.RectF;
 import android.graphics.drawable.AdaptiveIconDrawable;
@@ -43,8 +44,6 @@ public class DrawableUtils {
 
     // https://stackoverflow.com/questions/3035692/how-to-convert-a-drawable-to-a-bitmap
     public static Bitmap drawableToBitmap(@NonNull Drawable drawable) {
-        Bitmap bitmap;
-
         if (drawable instanceof BitmapDrawable) {
             BitmapDrawable bitmapDrawable = (BitmapDrawable) drawable;
             if (bitmapDrawable.getBitmap() != null) {
@@ -52,13 +51,16 @@ public class DrawableUtils {
             }
         }
 
+        Bitmap bitmap;
         if (drawable.getIntrinsicWidth() <= 0 || drawable.getIntrinsicHeight() <= 0) {
             bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888); // Single color bitmap will be created of 1x1 pixel
         } else {
             bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
         }
 
-        Canvas canvas = new Canvas(bitmap);
+        final Canvas canvas = new Canvas();
+        canvas.setDrawFilter(new PaintFlagsDrawFilter(0, Paint.FILTER_BITMAP_FLAG | Paint.ANTI_ALIAS_FLAG));
+        canvas.setBitmap(bitmap);
         drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
         drawable.draw(canvas);
         return bitmap;


### PR DESCRIPTION
Fix problems with custom icons from icon packs using adaptive drawables (e.g. LawnIcons)
Adaptive icons should be usable as custom icons too.
- do not check for `BitmapDrawable` explicitely when storing custom icon
- convert any drawable to bitmap
- make `IconPackXML` use `DrawableUtils.drawableToBitmap` too

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
