### PR TITLE
fix crashes when opening settings

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -60,7 +60,12 @@
                 android:key="reset-excluded-from-history-apps"
                 android:order="58"
                 android:title="@string/reset_excluded_from_history_apps_name" />
-            <!-- ResetExcludedAppShortcutsPreference button is added here dynamically (order 59) -->
+            <fr.neamar.kiss.preference.ResetExcludedAppShortcutsPreference
+                android:dialogMessage="@string/reset_excluded_app_shortcuts_warn"
+                android:key="reset-excluded-app-shortcuts"
+                android:order="59"
+                android:title="@string/reset_excluded_app_shortcuts_name" />
+            />
         </PreferenceCategory>
 
     </PreferenceScreen>
@@ -443,8 +448,16 @@
                 android:key="enable-settings"
                 android:order="2"
                 android:title="@string/settings_name" />
-            <!-- Enable shortcuts switch is added here dynamically (order 3) -->
-            <!-- ResetShortcutsPreference is added here dynamically (order 5) -->
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="true"
+                android:key="enable-shortcuts"
+                android:order="3"
+                android:title="@string/shortcuts_name" />
+            <fr.neamar.kiss.preference.ResetShortcutsPreference
+                android:dialogMessage="@string/regenerate_shortcuts_desc"
+                android:key="reset"
+                android:order="5"
+                android:title="@string/regenerate_shortcuts" />
             <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="enable-search"


### PR DESCRIPTION
- prefer removing preferences over adding them (shortcut related)
- override `findPreference` to catch exceptions occuring while preferences are changed dynamically
- fix `removePreference`: some preferences were not removed if preference key is used multiple times, e.g. `reset`
- add some logging

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
