### PR TITLE
improve icon pack experience

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -500,7 +500,7 @@ public class IconsHandler {
             fis.close();
             return drawable;
         } catch (Exception e) {
-            Log.e(TAG, "Unable to get custom icon ", e);
+            Log.e(TAG, "Unable to get custom icon for " + componentName, e);
         }
 
         return null;


### PR DESCRIPTION
- do not resolve drawable names during parsing but only on demand
  - improvement assumes that icon packs provide drawables for all of their components in appfilter.xml
  - icons from icon packs are shown a lot faster
  - parsing of delta icon pack with about 8800 icons takes now ~647ms instead of ~6653,7ms 😄 

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
