### PR TITLE
cancel loading pojos

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -55,6 +55,9 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
             for (android.os.UserHandle profile : manager.getUserProfiles()) {
                 UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
                 for (LauncherActivityInfo activityInfo : launcher.getActivityList(null, profile)) {
+                    if (isCancelled()) {
+                        break;
+                    }
                     ApplicationInfo appInfo = activityInfo.getApplicationInfo();
                     final AppPojo app = createPojo(user, appInfo.packageName, activityInfo.getName(), activityInfo.getLabel(), excludedAppList, excludedFromHistoryAppList, excludedShortcutsAppList);
                     apps.add(app);
@@ -67,6 +70,9 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
             mainIntent.addCategory(Intent.CATEGORY_LAUNCHER);
 
             for (ResolveInfo info : manager.queryIntentActivities(mainIntent, 0)) {
+                if (isCancelled()) {
+                    break;
+                }
                 ApplicationInfo appInfo = info.activityInfo.applicationInfo;
                 final AppPojo app = createPojo(new UserHandle(), appInfo.packageName, info.activityInfo.name, info.loadLabel(manager), excludedAppList, excludedFromHistoryAppList, excludedShortcutsAppList);
                 apps.add(app);

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
@@ -62,7 +62,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                 int photoIdIndex = cur.getColumnIndex(ContactsContract.Contacts.PHOTO_ID);
                 int contactIdIndex = cur.getColumnIndex(ContactsContract.Contacts._ID);
 
-                while (cur.moveToNext()) {
+                while (cur.moveToNext() && !isCancelled()) {
                     String lookupKey = cur.getString(lookupIndex);
                     String name = cur.getString(displayNameIndex);
                     int contactId = cur.getInt(contactIdIndex);
@@ -114,7 +114,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
             if (nickCursor.getCount() > 0) {
                 int lookupKeyIndex = nickCursor.getColumnIndex(ContactsContract.Data.LOOKUP_KEY);
                 int nickNameIndex = nickCursor.getColumnIndex(ContactsContract.CommonDataKinds.Nickname.NAME);
-                while (nickCursor.moveToNext()) {
+                while (nickCursor.moveToNext() && !isCancelled()) {
                     String lookupKey = nickCursor.getString(lookupKeyIndex);
                     String nick = nickCursor.getString(nickNameIndex);
 
@@ -130,7 +130,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
 
         for (Set<ContactsPojo> phones : mapContacts.values()) {
             // Find primary phone and add this one.
-            Boolean hasPrimary = false;
+            boolean hasPrimary = false;
             for (ContactsPojo contact : phones) {
                 if (contact.primary) {
                     contacts.add(contact);

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadPojos.java
@@ -32,7 +32,7 @@ public abstract class LoadPojos<T extends Pojo> extends AsyncTask<Void, Void, Li
     @Override
     protected void onPostExecute(List<T> result) {
         super.onPostExecute(result);
-        if (provider != null) {
+        if (provider != null && !isCancelled()) {
             provider.get().loadOver(result);
         }
     }

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadShortcutsPojos.java
@@ -24,7 +24,7 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutPojo> {
     }
 
     @Override
-    protected List<ShortcutPojo> doInBackground(Void... arg0) {
+    protected List<ShortcutPojo> doInBackground(Void... params) {
         Context context = this.context.get();
         if (context == null) {
             return new ArrayList<>();
@@ -50,6 +50,9 @@ public class LoadShortcutsPojos extends LoadPojos<ShortcutPojo> {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             List<ShortcutInfo> shortcutInfos = ShortcutUtil.getAllShortcuts(context);
             for (ShortcutInfo shortcutInfo : shortcutInfos) {
+                if (isCancelled()) {
+                    break;
+                }
                 if (ShortcutUtil.isShortcutVisible(context, shortcutInfo, excludedApps, excludedShortcutApps)) {
                     ShortcutRecord shortcutRecord = ShortcutUtil.createShortcutRecord(context, shortcutInfo, !shortcutInfo.isPinned());
                     if (shortcutRecord != null) {


### PR DESCRIPTION
- allow cancellation of loading operations
  - helpful if providers are reloaded frequently as done e.g. when SchildiChat updates shortcuts
    - see #1857
    - should mitigate #2169
- add some checks to break cancelled tasks

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
