### PR TITLE
refactor `Searcher#addResult`

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -364,7 +364,7 @@ public class DataHandler extends BroadcastReceiver
 
             List<? extends Pojo> pojos = entry.provider.getPojos();
             if (pojos != null)
-                searcher.addResult(pojos.toArray(new Pojo[0]));
+                searcher.addResults(pojos);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SearchProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/SearchProvider.java
@@ -70,7 +70,7 @@ public class SearchProvider extends SimpleProvider {
 
     @Override
     public void requestResults(String s, Searcher searcher) {
-        searcher.addResult(getResults(s).toArray(new Pojo[0]));
+        searcher.addResults(getResults(s));
     }
 
     private List<Pojo> getResults(String query) {

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -44,13 +44,13 @@ public class ApplicationsSearcher extends Searcher {
         // add apps
         List<AppPojo> pojos = KissApplication.getApplication(activity).getDataHandler().getApplicationsWithoutExcluded();
         if (pojos != null) {
-            this.addResult(getPojosWithoutFavorites(pojos, excludedFavoriteIds).toArray(new Pojo[0]));
+            this.addResults(getPojosWithoutFavorites(pojos, excludedFavoriteIds));
         }
 
         // add pinned shortcuts (PWA, ...)
         List<ShortcutPojo> shortcuts = KissApplication.getApplication(activity).getDataHandler().getPinnedShortcuts();
         if (shortcuts != null) {
-            this.addResult(getPojosWithoutFavorites(shortcuts, excludedFavoriteIds).toArray(new Pojo[0]));
+            this.addResults(getPojosWithoutFavorites(shortcuts, excludedFavoriteIds));
         }
 
         return null;

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -82,7 +82,7 @@ public class HistorySearcher extends Searcher {
             pojos.get(i).relevance = size - i;
         }
 
-        this.addResult(pojos.toArray(new Pojo[0]));
+        this.addResults(pojos);
         return null;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -50,7 +50,7 @@ public class QuerySearcher extends Searcher {
     }
 
     @Override
-    public boolean addResult(Pojo... pojos) {
+    public boolean addResults(List<? extends Pojo> pojos) {
         // Give a boost if item was previously selected for this query
         for (Pojo pojo : pojos) {
             Integer value = knownIds.get(pojo.id);
@@ -60,7 +60,7 @@ public class QuerySearcher extends Searcher {
         }
 
         // call super implementation to update the adapter
-        return super.addResult(pojos);
+        return super.addResults(pojos);
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -54,9 +54,18 @@ public abstract class Searcher extends AsyncTask<Void, Result<?>, Void> {
     }
 
     /**
-     * This is called from the background thread by the providers
+     * Add single pojo to results.
+     * This is called from the background thread by the providers.
      */
-    public boolean addResult(Pojo... pojos) {
+    public final boolean addResult(Pojo pojos) {
+        return addResults(Collections.singletonList(pojos));
+    }
+
+    /**
+     * Add one or more pojos to results.
+     * This is called from the background thread by the providers.
+     */
+    public boolean addResults(List<? extends Pojo> pojos) {
         if (isCancelled())
             return false;
 
@@ -64,9 +73,7 @@ public abstract class Searcher extends AsyncTask<Void, Result<?>, Void> {
         if (activity == null)
             return false;
 
-        Collections.addAll(this.processedPojos, pojos);
-
-        return true;
+        return this.processedPojos.addAll(pojos);
     }
 
     @CallSuper

--- a/app/src/main/java/fr/neamar/kiss/searcher/TagsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/TagsSearcher.java
@@ -1,5 +1,8 @@
 package fr.neamar.kiss.searcher;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.pojo.Pojo;
@@ -15,7 +18,8 @@ public class TagsSearcher extends Searcher {
     }
 
     @Override
-    public boolean addResult(Pojo... pojos) {
+    public boolean addResults(List<? extends Pojo> pojos) {
+        List<Pojo> filteredPojos = new ArrayList<>();
         for (Pojo pojo : pojos) {
             if (!(pojo instanceof PojoWithTags)) {
                 continue;
@@ -29,9 +33,9 @@ public class TagsSearcher extends Searcher {
                 continue;
             }
 
-            super.addResult(pojo);
+            filteredPojos.add(pojoWithTags);
         }
-        return false;
+        return super.addResults(filteredPojos);
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
@@ -1,5 +1,8 @@
 package fr.neamar.kiss.searcher;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.pojo.Pojo;
@@ -13,7 +16,8 @@ public class UntaggedSearcher extends Searcher {
     }
 
     @Override
-    public boolean addResult(Pojo... pojos) {
+    public boolean addResults(List<? extends Pojo> pojos) {
+        List<Pojo> filteredPojos = new ArrayList<>();
         for (Pojo pojo : pojos) {
             if (!(pojo instanceof PojoWithTags)) {
                 continue;
@@ -23,9 +27,9 @@ public class UntaggedSearcher extends Searcher {
                 continue;
             }
 
-            super.addResult(pojo);
+            filteredPojos.add(pojo);
         }
-        return false;
+        return super.addResults(filteredPojos);
     }
 
     @Override


### PR DESCRIPTION
- add new method for handling `List` directly
  - to prefer `Arrays.asList` over `List.toArray`
  - data is often available as list and `Arrays.asList` doesnt need to copy data like `List.toArray`
- change existing method definition, it takes always single pojo now so no `Arrays.asList` needed any more too

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
