### PR TITLE
predictable order of results

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -360,6 +360,7 @@ public class DataHandler extends BroadcastReceiver
      * @param searcher the searcher currently running
      */
     public void requestAllRecords(Searcher searcher) {
+        List<Pojo> collectedPojos = new ArrayList<>();
         for (ProviderEntry entry : this.providers.values()) {
             if (searcher.isCancelled())
                 break;
@@ -367,9 +368,11 @@ public class DataHandler extends BroadcastReceiver
                 continue;
 
             List<? extends Pojo> pojos = entry.provider.getPojos();
-            if (pojos != null)
-                searcher.addResults(pojos);
+            if (pojos != null) {
+                collectedPojos.addAll(pojos);
+            }
         }
+        searcher.addResults(collectedPojos);
     }
 
     /**
@@ -380,11 +383,10 @@ public class DataHandler extends BroadcastReceiver
      *
      * @param context            android context
      * @param itemCount          max number of items to retrieve, total number may be less (search or calls are not returned for instance)
-     * @param historyMode        Recency vs Frecency vs Frequency vs Adaptive vs Alphabetically
      * @param itemsToExcludeById Items to exclude from history by their id
      * @return pojos in recent history
      */
-    public List<Pojo> getHistory(Context context, int itemCount, String historyMode, Set<String> itemsToExcludeById) {
+    public List<Pojo> getHistory(Context context, int itemCount, Set<String> itemsToExcludeById) {
         // Pre-allocate array slots that are likely to be used based on the current maximum item
         // count
         List<Pojo> history = new ArrayList<>(Math.min(itemCount, 256));
@@ -393,9 +395,11 @@ public class DataHandler extends BroadcastReceiver
         int extendedItemCount = itemCount + itemsToExcludeById.size();
 
         // Read history
+        String historyMode = getHistoryMode();
         List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, extendedItemCount, historyMode);
 
         // Find associated items
+        int size = ids.size();
         for (int i = 0; i < ids.size(); i++) {
             // Ask all providers if they know this id
             Pojo pojo = getPojo(ids.get(i).record);
@@ -408,6 +412,7 @@ public class DataHandler extends BroadcastReceiver
                 continue;
             }
 
+            pojo.relevance = size - i;
             history.add(pojo);
 
             // Break if maximum number of items have been retrieved
@@ -417,6 +422,40 @@ public class DataHandler extends BroadcastReceiver
         }
 
         return history;
+    }
+
+    /**
+     * Apply relevance from history to given pojos.
+     *
+     * @param pojos       which needs to have relevance set
+     * @param historyMode
+     */
+    public void applyRelevanceFromHistory(List<? extends Pojo> pojos, String historyMode) {
+        // get length of history, this is needed so there are no entries missed
+        // if only number of displayed elements is used, this will result in parts of entries to be sorted by name
+        int historyLength = getHistoryLength();
+
+        Map<String, Integer> relevance = new HashMap<>();
+        if (!"alphabetically".equals(historyMode)) {
+            List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, historyLength, historyMode);
+            int size = ids.size();
+            for (int i = 0; i < size; i++) {
+                relevance.put(ids.get(i).record, size - i);
+            }
+        }
+
+        for (Pojo pojo : pojos) {
+            Integer calculated = relevance.get(pojo.id);
+            pojo.relevance = calculated != null ? calculated : 0;
+        }
+    }
+
+    /**
+     * @return history mode from settings: Recency vs Frecency vs Frequency vs Adaptive vs Alphabetically
+     */
+    public String getHistoryMode() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return prefs.getString("history-mode", "recency");
     }
 
     public int getHistoryLength() {

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -431,22 +431,28 @@ public class DataHandler extends BroadcastReceiver
      * @param historyMode
      */
     public void applyRelevanceFromHistory(List<? extends Pojo> pojos, String historyMode) {
-        // get length of history, this is needed so there are no entries missed
-        // if only number of displayed elements is used, this will result in parts of entries to be sorted by name
-        int historyLength = getHistoryLength();
+        if ("alphabetically".equals(historyMode)) {
+            // "alphabetically" is special case because relevance needs to be set for all pojos instead of these from history.
+            // This is done by setting all relevance to zero which results in order by name from used comparator.
+            for (Pojo pojo : pojos) {
+                pojo.relevance = 0;
+            }
+        } else {
+            // Get length of history, this is needed so there are no entries missed.
+            // If only number of displayed elements is used, this will result in more entries to be sorted by name.
+            int historyLength = getHistoryLength();
 
-        Map<String, Integer> relevance = new HashMap<>();
-        if (!"alphabetically".equals(historyMode)) {
+            Map<String, Integer> relevance = new HashMap<>();
             List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, historyLength, historyMode);
             int size = ids.size();
             for (int i = 0; i < size; i++) {
                 relevance.put(ids.get(i).record, size - i);
             }
-        }
 
-        for (Pojo pojo : pojos) {
-            Integer calculated = relevance.get(pojo.id);
-            pojo.relevance = calculated != null ? calculated : 0;
+            for (Pojo pojo : pojos) {
+                Integer calculated = relevance.get(pojo.id);
+                pojo.relevance = calculated != null ? calculated : 0;
+            }
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -195,13 +195,11 @@ public class DBHelper {
         // Cursor query (boolean distinct, String table, String[] columns,
         // String selection, String[] selectionArgs, String groupBy, String
         // having, String orderBy, String limit)
-        Cursor cursor = db.query(false, "history", new String[]{"COUNT(*)"}, null, null,
-                null, null, null, null);
-
-        cursor.moveToFirst();
-        int historyLength = cursor.getInt(0);
-        cursor.close();
-        return historyLength;
+        try (Cursor cursor = db.query(false, "history", new String[]{"COUNT(*)"}, null, null,
+                null, null, null, null)) {
+            cursor.moveToFirst();
+            return cursor.getInt(0);
+        }
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/ApplicationsSearcher.java
@@ -10,8 +10,8 @@ import java.util.Set;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.pojo.AppPojo;
-import fr.neamar.kiss.pojo.ReversedNameComparator;
 import fr.neamar.kiss.pojo.Pojo;
+import fr.neamar.kiss.pojo.ReversedNameComparator;
 import fr.neamar.kiss.pojo.ShortcutPojo;
 
 /**
@@ -59,8 +59,13 @@ public class ApplicationsSearcher extends Searcher {
     @Override
     protected void onPostExecute(Void param) {
         super.onPostExecute(param);
+
+        MainActivity activity = activityWeakReference.get();
+        if (activity == null)
+            return;
+
         // Build sections for fast scrolling
-        activityWeakReference.get().adapter.buildSections();
+        activity.adapter.buildSections();
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/searcher/PojoWithTagSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/PojoWithTagSearcher.java
@@ -1,0 +1,77 @@
+package fr.neamar.kiss.searcher;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import fr.neamar.kiss.KissApplication;
+import fr.neamar.kiss.MainActivity;
+import fr.neamar.kiss.pojo.Pojo;
+import fr.neamar.kiss.pojo.PojoWithTags;
+
+/**
+ * Returns a list of all results that match the specified pojo with tags.
+ */
+public abstract class PojoWithTagSearcher extends Searcher {
+
+    private final SharedPreferences prefs;
+
+    public PojoWithTagSearcher(MainActivity activity, String query) {
+        super(activity, query);
+        prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+    }
+
+    @Override
+    protected Void doInBackground(Void... voids) {
+        MainActivity activity = activityWeakReference.get();
+        if (activity == null)
+            return null;
+
+        KissApplication.getApplication(activity).getDataHandler().requestAllRecords(this);
+
+        return null;
+    }
+
+    @Override
+    public boolean addResults(List<? extends Pojo> pojos) {
+        List<Pojo> filteredPojos = new ArrayList<>();
+        for (Pojo pojo : pojos) {
+            if (!(pojo instanceof PojoWithTags)) {
+                continue;
+            }
+            PojoWithTags pojoWithTags = (PojoWithTags) pojo;
+            if (acceptPojo(pojoWithTags)) {
+                filteredPojos.add(pojoWithTags);
+            }
+        }
+
+        MainActivity activity = activityWeakReference.get();
+        if (activity == null) {
+            return false;
+        }
+
+        KissApplication.getApplication(activity).getDataHandler().applyRelevanceFromHistory(filteredPojos, getTaggedResultSortMode());
+
+        return super.addResults(filteredPojos);
+    }
+
+    @NonNull
+    private String getTaggedResultSortMode() {
+        String sortMode = prefs.getString("tagged-result-sort-mode", "default");
+        if ("default".equals(sortMode)) {
+            sortMode = KissApplication.getApplication(activityWeakReference.get()).getDataHandler().getHistoryMode();
+        }
+        return sortMode;
+
+    }
+
+    protected int getMaxResultCount() {
+        return Integer.MAX_VALUE;
+    }
+
+    abstract protected boolean acceptPojo(PojoWithTags pojoWithTags);
+}

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -49,7 +49,7 @@ public abstract class Searcher extends AsyncTask<Void, Result<?>, Void> {
         return new PriorityQueue<>(DEFAULT_MAX_RESULTS, new RelevanceComparator());
     }
 
-    int getMaxResultCount() {
+    protected int getMaxResultCount() {
         return DEFAULT_MAX_RESULTS;
     }
 
@@ -67,10 +67,6 @@ public abstract class Searcher extends AsyncTask<Void, Result<?>, Void> {
      */
     public boolean addResults(List<? extends Pojo> pojos) {
         if (isCancelled())
-            return false;
-
-        MainActivity activity = activityWeakReference.get();
-        if (activity == null)
             return false;
 
         return this.processedPojos.addAll(pojos);

--- a/app/src/main/java/fr/neamar/kiss/searcher/TagsSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/TagsSearcher.java
@@ -1,56 +1,19 @@
 package fr.neamar.kiss.searcher;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
-import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoWithTags;
 
 /**
- * Returns a list of all applications that match the specified tag
+ * Returns a list of all results that match the specified tag
  */
-
-public class TagsSearcher extends Searcher {
+public class TagsSearcher extends PojoWithTagSearcher {
     public TagsSearcher(MainActivity activity, String query) {
         super(activity, query == null ? "<tags>" : query);
     }
 
     @Override
-    public boolean addResults(List<? extends Pojo> pojos) {
-        List<Pojo> filteredPojos = new ArrayList<>();
-        for (Pojo pojo : pojos) {
-            if (!(pojo instanceof PojoWithTags)) {
-                continue;
-            }
-            PojoWithTags pojoWithTags = (PojoWithTags) pojo;
-            if (pojoWithTags.getTags() == null || pojoWithTags.getTags().isEmpty()) {
-                continue;
-            }
-
-            if (!pojoWithTags.getTags().contains(query)) {
-                continue;
-            }
-
-            filteredPojos.add(pojoWithTags);
-        }
-        return super.addResults(filteredPojos);
+    protected boolean acceptPojo(PojoWithTags pojoWithTags) {
+        return pojoWithTags.getTags() != null && pojoWithTags.getTags().contains(query);
     }
 
-    @Override
-    protected Void doInBackground(Void... voids) {
-        MainActivity activity = activityWeakReference.get();
-        if (activity == null)
-            return null;
-
-        KissApplication.getApplication(activity).getDataHandler().requestAllRecords(this);
-
-        return null;
-    }
-
-    @Override
-    int getMaxResultCount() {
-        return 250;
-    }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/UntaggedSearcher.java
@@ -1,46 +1,20 @@
 package fr.neamar.kiss.searcher;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
-import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.PojoWithTags;
 
-public class UntaggedSearcher extends Searcher {
+/**
+ * Returns a list of all results that has no tag
+ */
+public class UntaggedSearcher extends PojoWithTagSearcher {
 
-    public UntaggedSearcher(MainActivity activity )
-    {
-        super( activity, "<untagged>" );
+    public UntaggedSearcher(MainActivity activity) {
+        super(activity, "<untagged>");
     }
 
     @Override
-    public boolean addResults(List<? extends Pojo> pojos) {
-        List<Pojo> filteredPojos = new ArrayList<>();
-        for (Pojo pojo : pojos) {
-            if (!(pojo instanceof PojoWithTags)) {
-                continue;
-            }
-            PojoWithTags pojoWithTags = (PojoWithTags) pojo;
-            if (pojoWithTags.getTags() != null && !pojoWithTags.getTags().isEmpty()) {
-                continue;
-            }
-
-            filteredPojos.add(pojo);
-        }
-        return super.addResults(filteredPojos);
-    }
-
-    @Override
-    protected Void doInBackground(Void... voids) {
-        MainActivity activity = activityWeakReference.get();
-        if (activity == null)
-            return null;
-
-        KissApplication.getApplication(activity).getDataHandler().requestAllRecords(this);
-
-        return null;
+    protected boolean acceptPojo(PojoWithTags pojoWithTags) {
+        return pojoWithTags.getTags() == null || pojoWithTags.getTags().isEmpty();
     }
 
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -32,6 +32,22 @@
         <item>adaptive</item>
         <item>alphabetically</item>
     </string-array>
+    <string-array name="taggedResultSortModeEntries">
+        <item>@string/tagged_result_sort_mode_default</item>
+        <item>@string/history_recency</item>
+        <item>@string/history_frecency</item>
+        <item>@string/history_frequency</item>
+        <item>@string/history_adaptive</item>
+        <item>@string/history_alphabetically</item>
+    </string-array>
+    <string-array name="taggedResultSortModeValues" translatable="false">
+        <item>default</item>
+        <item>recency</item>
+        <item>frecency</item>
+        <item>frequency</item>
+        <item>adaptive</item>
+        <item>alphabetically</item>
+    </string-array>
     <string-array name="defaultSearchProviders" tools:ignore="InconsistentArrays">
         <item>Bing|https://www.bing.com/search?q=%s</item>
         <item>Brave|https://search.brave.com/search?q=%s</item>
@@ -43,10 +59,8 @@
         <item>YouTube|https://www.youtube.com/results?search_query=%s</item>
         <item>Application Stores|market://search?q=%s</item>
     </string-array>
-    <string-array name="toggleTagsDefault">
-    </string-array>
-    <string-array name="favTagsDefault">
-    </string-array>
+    <string-array name="toggleTagsDefault"></string-array>
+    <string-array name="favTagsDefault"></string-array>
     <string-array name="gestureEntries">
         <item>@string/gesture_do_nothing</item>
         <item>@string/gesture_keyboard</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,4 +348,8 @@
     <string name="gesture_menu">Display menu</string>
     <string name="gesture_hide_keyboard">Hide keyboard</string>
     <string name="gesture_quicksettings">Display quick settings</string>
+    <string name="tagged_result_sort_mode_default">Default, like history mode</string>
+    <string name="tagged_result_sort_mode_name">Tagged result sort mode</string>
+    <string name="tagged_result_sort_mode_desc">Select how tagged results should be sorted.</string>
+    <string name="tags_category">Tags</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,6 +350,6 @@
     <string name="gesture_quicksettings">Display quick settings</string>
     <string name="tagged_result_sort_mode_default">Default, like history mode</string>
     <string name="tagged_result_sort_mode_name">Tagged result sort mode</string>
-    <string name="tagged_result_sort_mode_desc">Select how tagged results should be sorted.</string>
+    <string name="tagged_result_sort_mode_desc">Select how results should be sorted when shown by tag</string>
     <string name="tags_category">Tags</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -349,15 +349,47 @@
                 android:key="double-tap"
                 android:title="@string/double_tap_to_lock" />
         </PreferenceCategory>
+        <PreferenceCategory android:title="@string/tags_category">
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="true"
+                android:key="tags-visible"
+                android:title="@string/tags_visible" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
+                android:key="pref-fav-tags-drawable"
+                android:summary="@string/pref_fav_tags_drawable_desc"
+                android:title="@string/pref_fav_tags_drawable" />
+            <PreferenceScreen android:title="@string/screen_toggle_tags">
+                <fr.neamar.kiss.preference.SwitchPreference
+                    android:defaultValue="false"
+                    android:key="pref-tags-menu"
+                    android:title="@string/pref_tags_menu" />
+                <fr.neamar.kiss.preference.SwitchPreference
+                    android:defaultValue="false"
+                    android:key="pref-show-untagged"
+                    android:title="@string/pref_show_untagged" />
+                <fr.neamar.kiss.preference.SwitchPreference
+                    android:defaultValue="false"
+                    android:key="pref-tags-menu-dismiss"
+                    android:title="@string/pref_tags_menu_dismiss" />
+                <MultiSelectListPreference
+                    android:defaultValue="@array/toggleTagsDefault"
+                    android:enabled="false"
+                    android:key="pref-toggle-tags-list"
+                    android:title="@string/loading" />
+            </PreferenceScreen>
+            <ListPreference
+                android:entries="@array/taggedResultSortModeEntries"
+                android:entryValues="@array/taggedResultSortModeValues"
+                android:key="tagged-result-sort-mode"
+                android:summary="@string/tagged_result_sort_mode_desc"
+                android:title="@string/tagged_result_sort_mode_name" />
+        </PreferenceCategory>
         <PreferenceCategory android:title="@string/misc">
             <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="force-portrait"
                 android:title="@string/portrait_title" />
-            <fr.neamar.kiss.preference.SwitchPreference
-                android:defaultValue="true"
-                android:key="tags-visible"
-                android:title="@string/tags_visible" />
             <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="true"
                 android:key="subicon-visible"
@@ -367,11 +399,6 @@
                 android:key="icons-hide"
                 android:summary="@string/icons_hide_desc"
                 android:title="@string/icons_hide_main" />
-            <fr.neamar.kiss.preference.SwitchPreference
-                android:defaultValue="false"
-                android:key="pref-fav-tags-drawable"
-                android:summary="@string/pref_fav_tags_drawable_desc"
-                android:title="@string/pref_fav_tags_drawable" />
             <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="call-contact-on-click"
@@ -410,25 +437,6 @@
                 android:key="wp-animate-sides"
                 android:summary="@string/wp_animate_sides_desc"
                 android:title="@string/wp_animate_sides" />
-        </PreferenceScreen>
-        <PreferenceScreen android:title="@string/screen_toggle_tags">
-            <fr.neamar.kiss.preference.SwitchPreference
-                android:defaultValue="false"
-                android:key="pref-tags-menu"
-                android:title="@string/pref_tags_menu" />
-            <fr.neamar.kiss.preference.SwitchPreference
-                android:defaultValue="false"
-                android:key="pref-show-untagged"
-                android:title="@string/pref_show_untagged" />
-            <fr.neamar.kiss.preference.SwitchPreference
-                android:defaultValue="false"
-                android:key="pref-tags-menu-dismiss"
-                android:title="@string/pref_tags_menu_dismiss" />
-            <MultiSelectListPreference
-                android:defaultValue="@array/toggleTagsDefault"
-                android:enabled="false"
-                android:key="pref-toggle-tags-list"
-                android:title="@string/loading" />
         </PreferenceScreen>
     </PreferenceScreen>
     <PreferenceScreen


### PR DESCRIPTION
- refactor `TagsSearcher` and `UntaggedSearcher` as they have a lot in common
- add method to apply relevance from history to any number of pojo
- when tagged/untagged results are shown order is taken from history by default
- add new preference for setting custom order of tagged/untagged results
- collect all tag related preferences from `KISS Settings -> UX` in a `Tags` category
- fixes #2187, #1609, #1463

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
