### PR TITLE
fix calc

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testImplementation 'org.hamcrest:hamcrest-library:2.1'
 
     errorprone("com.google.errorprone:error_prone_core:2.21.0")
@@ -61,4 +62,8 @@ tasks.withType(JavaCompile).configureEach {
         disable('EmptyBlockTag')
         disable('EmptyCatch')
     }
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
@@ -25,7 +25,7 @@ public class CalculatorProvider extends SimpleProvider {
     public CalculatorProvider() {
         //This should try to match as much as possible without going out of the expression,
         //even if the expression is not actually a computable operation.
-        computableRegexp = Pattern.compile("^[\\-.,\\d+*/^'()%]+$");
+        computableRegexp = Pattern.compile("^[\\-.,\\d+*×x/÷^'()%]+$");
         numberOnlyRegexp = Pattern.compile("^\\+?[.,()\\d]+$");
     }
 

--- a/app/src/test/java/fr/neamar/kiss/utils/calculator/CalculatorTest.java
+++ b/app/src/test/java/fr/neamar/kiss/utils/calculator/CalculatorTest.java
@@ -45,11 +45,18 @@ public class CalculatorTest {
 
 				Arguments.of("(1+1.)", new BigDecimal(2)),
 
+				Arguments.of("2*2", new BigDecimal(4)),
+				Arguments.of("2×2", new BigDecimal(4)),
+				Arguments.of("2x2", new BigDecimal(4)),
+
 				Arguments.of("2*2+1", new BigDecimal(5)),
 				Arguments.of("1+2*2", new BigDecimal(5)),
 				Arguments.of("(1+2)*2", new BigDecimal(6)),
 
 				Arguments.of("(1+2.)*2", new BigDecimal(6)),
+
+				Arguments.of("2/2", new BigDecimal("1")),
+				Arguments.of("2÷2", new BigDecimal("1")),
 
 				Arguments.of("2/2/2", new BigDecimal("0.5")),
 				Arguments.of("2/1/1", new BigDecimal(2)),
@@ -70,7 +77,6 @@ public class CalculatorTest {
 				Arguments.of("(1/10)", new BigDecimal(1).divide(new BigDecimal(10))),
 
 				Arguments.of("-1^2", new BigDecimal(1))
-
 				);
 	}
 


### PR DESCRIPTION
- add back `×x÷` operators for calculator
- fixes regression of fa54a7e
- see #1023

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
