### PR TITLE
[WIP] show keyboard when display history

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -186,6 +186,7 @@ public class ExperienceTweaks extends Forwarder {
                             if (mainActivity.isViewingSearchResults() && TextUtils.isEmpty(mainActivity.searchEditText.getText())) {
                                 if (mainActivity.list.getAdapter() == null || mainActivity.list.getAdapter().isEmpty()) {
                                     mainActivity.showHistory();
+                                    mainActivity.showKeyboard();
                                 }
                             }
                         }


### PR DESCRIPTION
For my user experience this is an improvement. You can only have so many favorites and I like to keep the home screen very minimalistic. I always know what app I want to launch and so I almost always prefer to get to said app by simply typing in the first characters of the app name. The `searchEditText` search bar is a pretty small target compared to the rest of the screen. So, with this change I can click anywhere on the home screen that is not occupied by a widget and get right to typing to search for an app I want to launch. I have found this to be more efficient than having to contort my fingers to reach the search bar at the bottom of the home screen, and searching by name is quicker than scrolling through a long list of history or the whole list of installed apps.

Open to discuss if this would be considered useful for other users and/or should be a new preference option. It is similar in nature to that option: "Show history with keyboard — Show history when software keyboard is visible". Except it's essentially the reverse; to show the software keyboard when history is visible.
