### PR TITLE
fix listening on package change

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/209.txt
+++ b/fastlane/metadata/android/en-US/changelogs/209.txt
@@ -5,3 +5,4 @@
 * Add operators '×x÷' back to the calculator
 * Fix popup menu position for widgets using whole screen
 * Fix reset of custom app name
+* Fix listening on package changes


### PR DESCRIPTION
- use `LauncherApps.Callback` for listening on package changes if available
- use `IntentFilter` only if `LauncherApps.Callback` is not available
- use multiple `IntentFilter`, depending on data scheme
- update providers only if package is not excluded from KISS
- fixes #2056, probably #1810 too

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
