### PR TITLE
Update errorprone to fix compile error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 plugins {
     id 'com.android.application'
-    id 'net.ltgt.errorprone' version '2.0.2'
+    id 'net.ltgt.errorprone' version '3.0.1'
 }
 
 android {


### PR DESCRIPTION
Upgrading from gradle 7.x to gradle 8.x causes the following error with net.ltgt.errorprone version 2.0.2. Updating to 3.0.1 fixes the build error.

```
Execution failed for task ':app:compileDebugJavaWithJavac'.
> org.gradle.api.tasks.compile.ForkOptions
```
<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
