### PR TITLE
Do not hide keyboard when SearchEditText is inactive view

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -621,7 +621,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 if (isKeyboardOpen) {
                     edit.clearFocus();
                     InputMethodManager imm = (InputMethodManager) this.getSystemService(Context.INPUT_METHOD_SERVICE);
-                    imm.hideSoftInputFromWindow(edit.getWindowToken(), 0);
+                    if (imm.isActive(edit)) {
+                        imm.hideSoftInputFromWindow(edit.getWindowToken(), 0);
+                    }
                 }
                 edit.setCursorVisible(!isKeyboardOpen);
             }


### PR DESCRIPTION
This fixes regression from #2280 which may cause the menu of search result items to be cut off after long pressing the item. The problem is that after the keyboard becomes hidden after a long press, the resulting menu may then be moved down which can cause it to be cut off.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
