### PR TITLE
Do not hide keyboard when dispatching touch event

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -618,13 +618,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                 Rect outR = new Rect();
                 edit.getGlobalVisibleRect(outR);
                 Boolean isKeyboardOpen = !outR.contains((int)ev.getRawX(), (int)ev.getRawY());
-                if (isKeyboardOpen) {
-                    edit.clearFocus();
-                    InputMethodManager imm = (InputMethodManager) this.getSystemService(Context.INPUT_METHOD_SERVICE);
-                    if (imm.isActive(edit)) {
-                        imm.hideSoftInputFromWindow(edit.getWindowToken(), 0);
-                    }
-                }
                 edit.setCursorVisible(!isKeyboardOpen);
             }
         }


### PR DESCRIPTION
Fix bug again in UI the cuts off app menu when keyboad is hidden after long press.  Checking if edit view is currently active has been reported to be problematic on some versions of Android.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
