### PR TITLE
Android 15 Private Space Integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 android {
     defaultConfig {
-        compileSdk 34
+        compileSdk 35
     }
     buildFeatures {
         buildConfig = true
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         applicationId 'fr.neamar.kiss'
         minSdkVersion 15
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 211
         versionName "3.21.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     -->
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <!-- To provide access and state handling of the private space -->
+    <uses-permission android:name="android.permission.ACCESS_HIDDEN_PROFILES" />
 
     <uses-feature
         android:name="android.hardware.telephony"
@@ -66,6 +68,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.HOME" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.APP_MARKET" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.ASSIST" />

--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -11,6 +11,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.LauncherApps;
+import android.content.pm.LauncherUserInfo;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -19,6 +21,8 @@ import android.database.DataSetObserver;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.UserHandle;
+import android.os.UserManager;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.text.Editable;
@@ -44,8 +48,11 @@ import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.broadcast.IncomingCallHandler;
@@ -213,6 +220,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
 
                     // Run GC once to free all the garbage accumulated during provider initialization
                     System.gc();
+                } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                    if (intent.getAction().equalsIgnoreCase(Intent.ACTION_PROFILE_AVAILABLE)
+                        || intent.getAction().equalsIgnoreCase(Intent.ACTION_PROFILE_UNAVAILABLE)) {
+                        privateSpaceStateEvent(intent.getParcelableExtra(Intent.EXTRA_USER, UserHandle.class));
+                    }
                 }
 
                 // New provider might mean new favorites
@@ -228,6 +240,12 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             this.registerReceiver(mReceiver, intentFilterLoad, Context.RECEIVER_EXPORTED);
             this.registerReceiver(mReceiver, intentFilterLoadOver, Context.RECEIVER_EXPORTED);
             this.registerReceiver(mReceiver, intentFilterFullLoadOver, Context.RECEIVER_EXPORTED);
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                IntentFilter intentFilterProfileAvailable = new IntentFilter(Intent.ACTION_PROFILE_AVAILABLE);
+                IntentFilter intentFilterProfileUnAvailable = new IntentFilter(Intent.ACTION_PROFILE_UNAVAILABLE);
+                this.registerReceiver(mReceiver, intentFilterProfileAvailable, Context.RECEIVER_EXPORTED);
+                this.registerReceiver(mReceiver, intentFilterProfileUnAvailable, Context.RECEIVER_EXPORTED);
+            }
         }
         else {
             this.registerReceiver(mReceiver, intentFilterLoad);
@@ -402,6 +420,19 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         super.onCreateContextMenu(menu, v, menuInfo);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.menu_main, menu);
+
+        MenuItem privateSpaceItem = menu.findItem(R.id.private_space);
+        if (privateSpaceItem != null) {
+            if ((android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM)
+                || (getPrivateUser() == null)) {
+                privateSpaceItem.setVisible(false);
+            } else if (isPrivateSpaceUnlocked()) {
+                privateSpaceItem.setTitle("Lock Private Space");
+            } else {
+                privateSpaceItem.setTitle("Unlock Private Space");
+            }
+        }
+
         forwarderManager.onCreateContextMenu(menu);
     }
 
@@ -557,6 +588,9 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         } else if (itemId == R.id.preferences) {
             startActivity(new Intent(this, SettingsActivity.class));
             return true;
+        } else if (itemId == R.id.private_space) {
+            switchPrivateSpaceState();
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }
@@ -566,7 +600,6 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.menu_main, menu);
-
         return true;
     }
 
@@ -686,6 +719,64 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             loaderSpinner.animate().cancel();
             loaderSpinner.setAlpha(1);
             loaderSpinner.setVisibility(View.VISIBLE);
+        }
+    }
+
+    @RequiresApi(35)
+    private UserHandle getPrivateUser() {
+        final UserManager manager = (UserManager) this.getSystemService(Context.USER_SERVICE);
+        assert manager != null;
+
+        final LauncherApps launcher = (LauncherApps) this.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+        assert launcher != null;
+
+        List<UserHandle> users = launcher.getProfiles();
+
+        UserHandle privateUser = null;
+        for (UserHandle user : users) {
+            if (Objects.requireNonNull(launcher.getLauncherUserInfo(user)).getUserType().equalsIgnoreCase(UserManager.USER_TYPE_PROFILE_PRIVATE)) {
+                privateUser = user;
+                break;
+            }
+        }
+        return privateUser;
+    }
+
+    private boolean isPrivateSpaceUnlocked() {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return false;
+        }
+
+        final UserManager manager = (UserManager) this.getSystemService(Context.USER_SERVICE);
+        assert manager != null;
+
+        UserHandle user = getPrivateUser();
+        return !manager.isQuietModeEnabled(user);
+    }
+
+    @RequiresApi(35)
+    private void switchPrivateSpaceState() {
+        final UserManager manager = (UserManager) this.getSystemService(Context.USER_SERVICE);
+        assert manager != null;
+
+        UserHandle user = getPrivateUser();
+        manager.requestQuietModeEnabled(!manager.isQuietModeEnabled(user), user);
+    }
+
+    @RequiresApi(35)
+    private void privateSpaceStateEvent(UserHandle handle) {
+        if (handle == null) {
+            return;
+        }
+
+        final LauncherApps launcher = (LauncherApps) this.getSystemService(Context.LAUNCHER_APPS_SERVICE);
+
+        LauncherUserInfo info = launcher.getLauncherUserInfo(handle);
+        if (info != null) {
+            if (info.getUserType().equalsIgnoreCase(UserManager.USER_TYPE_PROFILE_PRIVATE)) {
+                Log.d(TAG, "Private Space state changed");
+                // TODO: Check if private space state changed and change app view accordingly
+            }
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -672,6 +672,8 @@ public class SettingsActivity extends PreferenceActivity implements
                 }
             } else if ("selected-contact-mime-types".equals(key)) {
                 getDataHandler().reloadContactsProvider();
+            } else if ("disable-private-space-shortcuts".equals(key)) {
+                getDataHandler().reloadShortcuts();
             }
         }
 

--- a/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadAppPojos.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.LauncherActivityInfo;
 import android.content.pm.LauncherApps;
+import android.content.pm.LauncherUserInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
@@ -55,6 +56,10 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
 
             // Handle multi-profile support introduced in Android 5 (#542)
             for (android.os.UserHandle profile : manager.getUserProfiles()) {
+                LauncherUserInfo info = null;
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                    info = launcherApps.getLauncherUserInfo(profile);
+                }
                 UserHandle user = new UserHandle(manager.getSerialNumberForUser(profile), profile);
                 for (LauncherActivityInfo activityInfo : launcherApps.getActivityList(null, profile)) {
                     if (isCancelled()) {
@@ -63,7 +68,18 @@ public class LoadAppPojos extends LoadPojos<AppPojo> {
                     ApplicationInfo appInfo = activityInfo.getApplicationInfo();
                     boolean disabled = PackageManagerUtils.isAppSuspended(appInfo) || isQuietModeEnabled(manager, profile);
                     final AppPojo app = createPojo(user, appInfo.packageName, activityInfo.getName(), activityInfo.getLabel(), disabled, excludedAppList, excludedFromHistoryAppList, excludedShortcutsAppList);
-                    apps.add(app);
+                    if ((android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM)
+                        && (info != null)) {
+                        if (!info.getUserType().equalsIgnoreCase(UserManager.USER_TYPE_PROFILE_PRIVATE)) {
+                            apps.add(app);
+                        } else {
+                            if (!isQuietModeEnabled(manager, profile)) {
+                                apps.add(app);
+                            }
+                        }
+                    } else {
+                        apps.add(app);
+                    }
                 }
             }
         } else {

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -17,5 +17,9 @@
         android:id="@+id/settings"
         android:showAsAction="never"
         android:title="@string/menu_settings" />
+    <item
+        android:id="@+id/private_space"
+        android:showAsAction="never"
+        android:title="@string/menu_private_space" />
 
 </menu>

--- a/app/src/main/res/values-v35/themes.xml
+++ b/app/src/main/res/values-v35/themes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- TODO: Remove once activities handle insets. -->
+    <style name="BaseThemeLight" parent="@android:style/Theme.Holo.Light.NoActionBar">
+        <item name="appSelectableItemBackground">?android:attr/selectableItemBackground</item>
+        <item name="android:actionMenuTextColor">@android:color/white</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+    <style name="BaseThemeDark" parent="@android:style/Theme.Holo.NoActionBar">
+        <item name="appSelectableItemBackground">?android:attr/selectableItemBackground</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -357,4 +357,5 @@
     <string name="tagged_result_sort_mode_desc">Select how results should be sorted when shown by tag</string>
     <string name="tags_category">Tags</string>
     <string name="menu_private_space">Private Space</string>
+    <string name="disable_private_space_shortcuts">Disable Private Space app shortcuts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -356,4 +356,5 @@
     <string name="tagged_result_sort_mode_name">Tagged result sort mode</string>
     <string name="tagged_result_sort_mode_desc">Select how results should be sorted when shown by tag</string>
     <string name="tags_category">Tags</string>
+    <string name="menu_private_space">Private Space</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -408,6 +408,10 @@
                 android:defaultValue="false"
                 android:key="call-contact-on-click"
                 android:title="@string/contacts_call_on_click" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="true"
+                android:key="disable-private-space-shortcuts"
+                android:title="@string/disable_private_space_shortcuts" />
         </PreferenceCategory>
         <PreferenceScreen
             android:key="wallpaper-holder"


### PR DESCRIPTION
#2338 

Note that this is a draft and **not** ready for review/merge.

This has the basic functionality for a usable Private Space integration. 

What is supported:

- Unlock and lock the private space by pressing or long pressing the 3 dots in the KISS search bar and then press the applicable unlock/lock private space button.
- Private space apps are shown and openable in the KISS app list/searchable/history.


What is missing (first two bullets as per https://developer.android.com/about/versions/15/behavior-changes-all#private-space-launcher-apps):

 - [ ] "separate launcher container for apps installed in the private space"
 - [ ] "Install Apps" button that launches an implicit intent to install apps into the user's private space".
 - [x] After private space has been disabled, the apps must be removed from the app list, history and search view rather than being greyed out, which is currently the case.
 - [x] Perhaps an option to disable shortcuts from apps in the private space in the KISS search view. It can be annoying if there's an app in both the standard user and the private space that has a lot of shortcuts with shortcuts from both apps showing.

I might work on this on and off for some weekends a head. If someone else is implementing this, let me know so that I don't work on this in vain. If someone wants to continue the work of this PR (in what I would assume a quicker pace than I have time for), I would be fine with that too, just let me know.