### PR TITLE
fix: cannot open some contacts which exist

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
+++ b/app/src/main/java/fr/neamar/kiss/loader/LoadContactsPojos.java
@@ -203,7 +203,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                             boolean primary = phoneCursor.getInt(isPrimaryIndex) != 0;
                             Uri icon = basicContact.getIcon();
 
-                            ContactsPojo contact = new ContactsPojo(pojoScheme + contactId + '/' + phone, lookupKey, icon, primary, starred);
+                            ContactsPojo contact = new ContactsPojo(pojoScheme + contactId + '/' + phone, lookupKey, contactId, icon, primary, starred);
                             setNames(contact, basicContact);
 
                             contact.setPhone(phone, false);
@@ -269,7 +269,7 @@ public class LoadContactsPojos extends LoadPojos<ContactsPojo> {
                             }
                             Uri icon = basicContact.getIcon();
 
-                            ContactsPojo contact = new ContactsPojo(pojoScheme + contactId + '/' + MimeTypeUtils.getShortMimeType(mimeType) + '/' + id, lookupKey, icon, primary, basicRawContact.isStarred());
+                            ContactsPojo contact = new ContactsPojo(pojoScheme + contactId + '/' + MimeTypeUtils.getShortMimeType(mimeType) + '/' + id, lookupKey, contactId, icon, primary, basicRawContact.isStarred());
                             setNames(contact, basicContact);
 
                             ContactData contactData = new ContactData(mimeType, id);

--- a/app/src/main/java/fr/neamar/kiss/pojo/ContactsPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/ContactsPojo.java
@@ -8,6 +8,7 @@ import fr.neamar.kiss.normalizer.StringNormalizer;
 
 public final class ContactsPojo extends Pojo {
     public final String lookupKey;
+    private final long contactId;
 
     public String phone;
     //phone without special characters
@@ -32,9 +33,10 @@ public final class ContactsPojo extends Pojo {
 
     private ContactData contactData;
 
-    public ContactsPojo(String id, String lookupKey, Uri icon, boolean primary, boolean starred) {
+    public ContactsPojo(String id, String lookupKey, long contactId, Uri icon, boolean primary, boolean starred) {
         super(id);
         this.lookupKey = lookupKey;
+        this.contactId = contactId;
         this.icon = icon;
         this.primary = primary;
         this.starred = starred;
@@ -77,6 +79,10 @@ public final class ContactsPojo extends Pojo {
 
     public ContactData getContactData() {
         return contactData;
+    }
+
+    public long getContactId() {
+        return contactId;
     }
 
     public void setNameAlternative(String nameAlternative) {

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -283,8 +283,11 @@ public class ContactsResult extends CallResult<ContactsPojo> {
     private void launchContactView(Context context, View v) {
         Intent viewContact = new Intent(Intent.ACTION_VIEW);
 
-        viewContact.setData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI,
-                String.valueOf(pojo.lookupKey)));
+        Uri contactUri = ContactsContract.Contacts.CONTENT_LOOKUP_URI;
+        contactUri = Uri.withAppendedPath(contactUri, String.valueOf(pojo.lookupKey));
+        contactUri = Uri.withAppendedPath(contactUri, String.valueOf(pojo.getContactId()));
+
+        viewContact.setData(contactUri);
         setSourceBounds(viewContact, v);
         viewContact.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         viewContact.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK);

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -100,9 +100,11 @@ public class ContactsResult extends CallResult<ContactsPojo> {
             contactIcon.setImageDrawable(null);
         }
 
-        contactIcon.assignContactUri(Uri.withAppendedPath(
-                ContactsContract.Contacts.CONTENT_LOOKUP_URI,
-                String.valueOf(pojo.lookupKey)));
+        Uri contactUri = ContactsContract.Contacts.CONTENT_LOOKUP_URI;
+        contactUri = Uri.withAppendedPath(contactUri, String.valueOf(pojo.lookupKey));
+        contactUri = Uri.withAppendedPath(contactUri, String.valueOf(pojo.getContactId()));
+        contactIcon.assignContactUri(contactUri);
+
         contactIcon.setExtraOnClickListener(v -> recordLaunch(v.getContext(), queryInterface));
 
         int primaryColor = UIColors.getPrimaryColor(context);


### PR DESCRIPTION
Hi devs!

Some contacts couldn't be opened, Contacts' app tells they don't exist although they do.
![image](https://github.com/user-attachments/assets/fa2e00c0-48b5-4587-9116-8b2a2e844fdd)

It seems that `lookupKey` isn't (sadly) enough to find some contacts in the app, a `contactId` must be added in order for the Contacts app to find the contact.

As an example, see below.
Each one of them is a `lookupKey` for two different contacts.
```
3038eb17309d0-91e4-4d5c-acfa-ba838536371a..vcf
487e71dd164e-38dd-4825-b693-6dea4475b518..vcf.2399r246-34402A543A3248464450464432
```
I don't know why is one larger than the other, however the shortest one doesn't work (and any contact that long doesn't work).

Giving a head to Contacts' logs, it always opens contacts by appending the `contactId`.
```
content://com.android.contacts/contacts/lookup/3038eb17309d0-91e4-4d5c-acfa-ba838536371a..vcf/93
content://com.android.contacts/contacts/lookup/487e71dd164e-38dd-4825-b693-6dea4475b518..vcf.2399r246-34402A543A3248464450464432/32
```

Furthermore,
>  It can optionally also have a "/" and last known contact ID appended after that. This "complete" format is an important optimization and is highly recommended. 

-- [Android Documentation - CONTENT_LOOKUP_URI](https://developer.android.com/reference/android/provider/ContactsContract.Contacts#CONTENT_LOOKUP_URI).

So I just added the `contactId` on every contact opening.

> [!NOTE]
It fixes #2350.

> [!WARNING]
Tested on the following:
> - [ ] API 26  (Android 8)
> - [x] API 3X (Android 12): contacts open as expected, but I don't have any buggy contact to try the new version
> - [x] API 35 (Android 15)