### PR TITLE
Added "Large" and "Largest" options in "Results display size"

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -69,6 +69,12 @@ public class InterfaceTweaks extends Forwarder {
             case "medium":
                 act.getTheme().applyStyle(R.style.OverlayResultSizeMedium, true);
                 break;
+            case "large":
+                act.getTheme().applyStyle(R.style.OverlayResultSizeLarge, true);
+                break;
+            case "largest":
+                act.getTheme().applyStyle(R.style.OverlayResultSizeLargest, true);
+                break;
             case "default":
             default:
                 act.getTheme().applyStyle(R.style.OverlayResultSizeStandard, true);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -142,6 +142,8 @@
     </string-array>
 
     <string-array name="resultsSizeEntries">
+        <item>@string/results_size_largest</item>
+        <item>@string/results_size_large</item>
         <item>@string/results_size_default</item>
         <item>@string/results_size_medium</item>
         <item>@string/results_size_small</item>
@@ -149,6 +151,8 @@
     </string-array>
 
     <string-array name="resultsSizeValues" translatable="false">
+        <item>largest</item>
+        <item>large</item>
         <item>default</item>
         <item>medium</item>
         <item>small</item>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,20 @@
     <dimen name="icon_margin_top">0dp</dimen>
     <dimen name="icon_margin_bottom">0dp</dimen>
 
+    <dimen name="result_icon_size_largest">65dp</dimen>
+    <dimen name="result_subicon_size_largest">29dp</dimen>
+    <dimen name="result_notification_dot_size_largest">20dp</dimen>
+    <dimen name="result_title_size_largest">22sp</dimen>
+    <dimen name="result_subtitle_size_largest">20sp</dimen>
+    <dimen name="result_height_largest">70dp</dimen>
+
+    <dimen name="result_icon_size_large">56dp</dimen>
+    <dimen name="result_subicon_size_large">24dp</dimen>
+    <dimen name="result_notification_dot_size_large">17dp</dimen>
+    <dimen name="result_title_size_large">19sp</dimen>
+    <dimen name="result_subtitle_size_large">16sp</dimen>
+    <dimen name="result_height_large">63dp</dimen>
+    
     <dimen name="result_icon_size">48dp</dimen>
     <dimen name="result_subicon_size">20dp</dimen>
     <dimen name="result_notification_dot_size">15dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,6 +347,8 @@
     <string name="import_settings_done">Settings imported.</string>
     <string name="import_settings_error">Unable to import settings.</string>
     <string name="results_size_default">Default</string>
+    <string name="results_size_largest">Largest</string>
+    <string name="results_size_large">Large</string>
     <string name="results_size_medium">Medium</string>
     <string name="results_size_small">Small</string>
     <string name="results_size_smallest">Smallest</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -157,6 +157,26 @@
         <item name="android:windowShowWallpaper">false</item>
     </style>
 
+    <style name="OverlayResultSizeLargest">
+        <item name="resultHeight">@dimen/result_height_largest</item>
+        <item name="resultIconSize">@dimen/result_icon_size_largest</item>
+        <item name="resultSubIconSize">@dimen/result_subicon_size_largest</item>
+        <item name="resultNotificationDotSize">@dimen/result_notification_dot_size_largest</item>
+        <item name="resultTitleSize">@dimen/result_title_size_largest</item>
+        <item name="resultSubtitleSize">@dimen/result_subtitle_size_largest</item>
+        <item name="resultButtonHeight">@dimen/result_icon_size_largest</item>
+    </style>
+
+    <style name="OverlayResultSizeLarge">
+        <item name="resultHeight">@dimen/result_height_large</item>
+        <item name="resultIconSize">@dimen/result_icon_size_large</item>
+        <item name="resultSubIconSize">@dimen/result_subicon_size_large</item>
+        <item name="resultNotificationDotSize">@dimen/result_notification_dot_size_large</item>
+        <item name="resultTitleSize">@dimen/result_title_size_large</item>
+        <item name="resultSubtitleSize">@dimen/result_subtitle_size_large</item>
+        <item name="resultButtonHeight">@dimen/result_icon_size_large</item>
+    </style>
+    
     <style name="OverlayResultSizeStandard">
         <item name="resultHeight">@dimen/result_height</item>
         <item name="resultIconSize">@dimen/result_icon_size</item>


### PR DESCRIPTION
<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->

### Description:
Added "Large" and "Largest" options in "Results display size" setting in User Interface tab. I felt as though the "Default" setting was still too small for me, and opted to add in larger options for those who would like them. Comparison and Setting UI changes included in screenshots below.

### Changes:
See comments on each file to see where changes were made

### Screenshots: 
<img src="https://github.com/user-attachments/assets/77725cda-e38c-43ed-ac99-95b5e6c71ff4" height="488.88" width="220">
<p>Default Setting (For Comparison)</p>
<img src="https://github.com/user-attachments/assets/6bb1cfed-1a17-41fb-9cfc-389164300d6e" height="488.88" width="220">
<p>Large Setting</p>
<img src="https://github.com/user-attachments/assets/621c632c-436e-4fd5-9114-f98f104c5c85" height="488.88" width="220">
<p>Largest Setting</p>
<img src="https://github.com/user-attachments/assets/77e7fc33-5438-47c0-837b-90d8ef3a66ac" height="488.88" width="220">
<p>Changes added in Settings UI</p>