### PR TITLE
added autohide keyboard setting and fixed app list resizing when keyboard is hidden

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -965,6 +965,12 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
         systemUiVisibilityHelper.applyScrollSystemUi();
     }
 
+    @Override
+    public boolean isAutohideKeyboardEnabled() {
+        prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        return prefs.getBoolean("autohide-keyboard", true);
+    }
+
     /**
      * Check if history / search or app list is visible
      *

--- a/app/src/main/java/fr/neamar/kiss/ui/KeyboardScrollHider.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/KeyboardScrollHider.java
@@ -9,6 +9,7 @@ import android.view.animation.AccelerateInterpolator;
 
 import androidx.annotation.NonNull;
 
+
 /**
  * Utility class for automatically hiding the keyboard when scrolling down a {@link android.widget.ListView},
  * keeping the position of the finger on the list stable
@@ -162,11 +163,19 @@ public class KeyboardScrollHider implements View.OnTouchListener {
                 this.lastMotionEvent = null;
 
                 if (!this.resizeDone) {
+                    // Hide the keyboard if the user has scrolled down by about half a result item
+                    if (isScrolled()) {
+                        if (this.handler.isAutohideKeyboardEnabled()) {
+                            this.handler.hideKeyboard();
+                        }
+                        this.handler.applyScrollSystemUi();
+                    }
                     ValueAnimator animator = ValueAnimator.ofInt(
                             this.list.getHeight(),
                             this.listParent.getHeight()
                     );
-                    animator.setDuration(250);
+                    // Duration may need increased for better animations but 250 is too high
+                    animator.setDuration(0);
                     animator.setInterpolator(new AccelerateInterpolator());
                     animator.addUpdateListener(animation -> {
                         int height = (int) animation.getAnimatedValue();
@@ -203,12 +212,6 @@ public class KeyboardScrollHider implements View.OnTouchListener {
                 break;
         }
 
-        // Hide the keyboard if the user has scrolled down by about half a result item
-        if (isScrolled()) {
-            this.handler.hideKeyboard();
-            this.handler.applyScrollSystemUi();
-        }
-
         return false;
     }
 
@@ -229,5 +232,7 @@ public class KeyboardScrollHider implements View.OnTouchListener {
         void hideKeyboard();
 
         void applyScrollSystemUi();
+
+        boolean isAutohideKeyboardEnabled();
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,4 +360,5 @@
     <string name="tagged_result_sort_mode_name">Tagged result sort mode</string>
     <string name="tagged_result_sort_mode_desc">Select how results should be sorted when shown by tag</string>
     <string name="tags_category">Tags</string>
+    <string name="autohide_keyboard_title">Autohide keyboard</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -281,6 +281,10 @@
                 android:key="display-keyboard"
                 android:title="@string/keyboard_name" />
             <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="true"
+                android:key="autohide-keyboard"
+                android:title="@string/autohide_keyboard_title" />
+            <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
                 android:key="enable-suggestions-keyboard"
                 android:title="@string/keyboard_suggestions" />


### PR DESCRIPTION
- Added an autohide keyboard setting that will prevent the keyboard from hiding when interacting with the app drawer (Might address #408)
- Fixed the speed placement of the app list resizing when the keyboard is hidden in the app drawer (Related to #2324)

<img width="381" height="786" alt="image" src="https://github.com/user-attachments/assets/30e7e284-fff5-44b9-8878-35573041cf38" />
