### PR TITLE
fix constructor of UserHandle

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/UserHandle.java
@@ -39,14 +39,24 @@ public class UserHandle implements Parcelable {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     public UserHandle(Context context, android.os.UserHandle userHandle) {
-        final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
-        assert manager != null;
-        serial = manager.getSerialNumberForUser(userHandle);
-        handle = userHandle;
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            // OS does not provide any APIs for multi-user support
+            this.serial = 0;
+            this.handle = null;
+        } else if (userHandle != null && Process.myUserHandle().equals(userHandle)) {
+            // For easier processing the current user is also stored as `null`, even
+            // if there is multi-user support
+            this.serial = 0;
+            this.handle = null;
+        } else {
+            final UserManager manager = (UserManager) context.getSystemService(Context.USER_SERVICE);
+            assert manager != null;
+            // Store the given user handle
+            this.serial = manager.getSerialNumberForUser(userHandle);
+            this.handle = userHandle;
+        }
     }
-
 
     protected UserHandle(Parcel in) {
         serial = in.readLong();


### PR DESCRIPTION
- fix `UserHandle(Context context, android.os.UserHandle userHandle)`
  - in case that provided `userHandle` is equal to `Process.myUserHandle()` it should behave same as when `UserHandle(long serial, android.os.UserHandle user)` is used. This is needed to avoid strange behaviour when `addUserSuffixToString` is called, which checks if `handle` is null. In some cases this will append handle 0, in other cases it wouldn't, though it should always be the same.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
