### PR TITLE
Added a new "Automatically open single result" option.

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -284,11 +284,11 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
             }
         });
 
-        // Display empty list view when having no results
         this.adapter.registerDataSetObserver(new DataSetObserver() {
             @Override
             public void onChanged() {
                 super.onChanged();
+                // Display empty list view when having no results
                 if (adapter.isEmpty()) {
                     // Display help text when no results available
                     listContainer.setVisibility(View.GONE);
@@ -299,8 +299,12 @@ public class MainActivity extends Activity implements QueryInterface, KeyboardSc
                     emptyListView.setVisibility(View.GONE);
                 }
 
-                forwarderManager.onDataSetChanged();
+                // Open the first result if there is only a single result and the preference is set.
+                if (prefs.getBoolean("search_open_single_result", false) && adapter.getCount() == 1) {
+                    adapter.onClick(0, searchEditText);
+                }
 
+                forwarderManager.onDataSetChanged();
             }
         });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="ui_empty_3_sub">KISS launcher learns from your habits</string>
     <string name="contacts_name">Contacts</string>
     <string name="contacts_call_on_click">Click to call contacts</string>
+    <string name="search_open_single_result">Automatically open single result</string>
     <string name="search_results_options">Search results</string>
     <string name="search_name">Web search providers</string>
     <string name="search_provider_toggle">Links to web search providers</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -495,6 +495,10 @@
         <PreferenceCategory android:title="@string/misc">
             <fr.neamar.kiss.preference.SwitchPreference
                 android:defaultValue="false"
+                android:key="search_open_single_result"
+                android:title="@string/search_open_single_result" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
                 android:key="always-default-web-search-on-enter"
                 android:title="@string/always_default_web_search_on_enter" />
         </PreferenceCategory>


### PR DESCRIPTION
This adds an option to automatically open a search result if it is the only result.

This feature makes it possible to quickly select search results, however it does make searching the web impossible, because KISS will have probably opened a search result before you finished writing your prompt. It also increases the chances of accidentally opening the wrong app. That is why this feature is disabled by default. 

I am not entirely sure if "Search settings -> Misc." is the best place to put this option, it could also be put under the advanced settings.

Below is a video showing the feature in action.
https://github.com/user-attachments/assets/c3f286c8-1699-434f-ab78-cc7defa92cbb