### PR TITLE
hide status bar color setting on android 15+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         applicationId 'fr.neamar.kiss'
         minSdkVersion 15
-        compileSdk 35
+        compileSdkVersion 35
         targetSdkVersion 35
         versionCode 215
         versionName "3.22.2"
@@ -60,7 +60,7 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.11.4')
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
 
-    errorprone('com.google.errorprone:error_prone_core:2.40.0')
+    errorprone('com.google.errorprone:error_prone_core:2.41.0')
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/SettingsActivity.java
@@ -134,6 +134,9 @@ public class SettingsActivity extends PreferenceActivity implements
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             removePreference("icons-section", DrawableUtils.KEY_THEMED_ICONS);
         }
+        if (Build.VERSION.SDK_INT >=Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            removePreference("colors-section", "notification-bar-color");
+        }
         if (!ShortcutUtil.canDeviceShowShortcuts()) {
             removePreference("exclude_apps_category", "reset-excluded-app-shortcuts");
             removePreference("search-providers", "enable-shortcuts");

--- a/app/src/main/java/fr/neamar/kiss/UIColors.java
+++ b/app/src/main/java/fr/neamar/kiss/UIColors.java
@@ -214,6 +214,9 @@ public class UIColors {
             // Update status bar color
             window.setStatusBarColor(notificationBarColorOverride);
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.setNavigationBarContrastEnforced(false);
+        }
     }
 
     private static void updateThemePrimaryColor(int notificationBarColorOverride, ActionBar actionBar) {
@@ -223,7 +226,9 @@ public class UIColors {
     }
 
     private static int getNotificationBarColor(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            return COLOR_TRANSPARENT;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             // use accent color from system if available
             return getColor(context, "notification-bar-color", getNotificationBarColorRes(context));
         } else {


### PR DESCRIPTION
- edge-to-edge apps doesn't allow coloring of status bar anymore
- so hide setting for status bar color on android 15 and up
- see also https://developer.android.com/design/ui/mobile/guides/layout-and-content/edge-to-edge

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
