### PR TITLE
widget updates

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/PickAppWidgetActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/PickAppWidgetActivity.java
@@ -137,6 +137,9 @@ public class PickAppWidgetActivity extends Activity {
                 if (label == null) {
                     label = providerInfo.label;
                 }
+                if (label == null) {
+                    label = providerInfo.provider.flattenToShortString();
+                }
 
                 // get widget description
                 String description = null;

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetHost.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetHost.java
@@ -9,7 +9,7 @@ import android.util.Log;
 
 public class WidgetHost extends AppWidgetHost {
 
-    private final static String TAG = WidgetHost.class.getSimpleName();
+    private static final String TAG = WidgetHost.class.getSimpleName();
 
     private final WidgetProvidersUpdateCallback mWidgetsUpdateCallback;
 

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
@@ -3,9 +3,13 @@ package fr.neamar.kiss.ui;
 import android.appwidget.AppWidgetHostView;
 import android.content.Context;
 import android.os.Build;
+import android.os.Bundle;
+import android.util.SizeF;
 import android.view.MotionEvent;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
+
+import java.util.Collections;
 
 /**
  * Source: https://github.com/willli666/Android-Trebuchet-Launcher-Standalone/blob/master/src/com/cyanogenmod/trebuchet/LauncherAppWidgetHostView.java
@@ -106,12 +110,16 @@ public class WidgetView extends AppWidgetHostView {
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
         super.onSizeChanged(w, h, oldw, oldh);
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             // calculate size in dips
             float density = getResources().getDisplayMetrics().density;
             int widthDips = (int) (w / density);
             int heightDips = (int) (h / density);
-            updateAppWidgetSize(null, widthDips, heightDips, widthDips, heightDips);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                updateAppWidgetSize(Bundle.EMPTY, Collections.singletonList(new SizeF(widthDips, heightDips)));
+            } else {
+                updateAppWidgetSize(null, widthDips, heightDips, widthDips, heightDips);
+            }
         }
     }
 }


### PR DESCRIPTION
- widget dimensions always must be rounded up to nearest line height, see https://developer.android.com/develop/ui/views/appwidgets#widget-sizing-attributes
- widgets can define `targetCellHeight` which should take precedence over `minHeight` beginning with android 12
- add new widgets a little larger if allowed
- use newer `updateAppWidgetSize` method for setting widget size, should fix #2442

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
