### PR TITLE
Feature: Add Option for Fuzzy/Flexible App Search (e.g. handles typos) (issue #2461)

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/AppProvider.java
@@ -19,9 +19,12 @@ import fr.neamar.kiss.normalizer.StringNormalizer;
 import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.searcher.Searcher;
 import fr.neamar.kiss.utils.UserHandle;
-import fr.neamar.kiss.utils.fuzzy.FuzzyFactory;
 import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
+import fr.neamar.kiss.utils.fuzzy.FuzzyFactory;
+import fr.neamar.kiss.utils.fuzzy.FuzzyScoreV1;
+import fr.neamar.kiss.utils.fuzzy.FuzzyScoreV2;
 import fr.neamar.kiss.utils.fuzzy.MatchInfo;
+
 
 public class AppProvider extends Provider<AppPojo> {
 
@@ -125,31 +128,119 @@ public class AppProvider extends Provider<AppPojo> {
             return;
         }
 
-        FuzzyScore fuzzyScore = FuzzyFactory.createFuzzyScore(this, queryNormalized.codePoints);
+        boolean flexibleFuzzy = prefs.getBoolean("enable-fuzzy-search", false);
 
-        for (AppPojo pojo : getPojos()) {
-            // exclude apps from results
-            if (pojo.isExcluded() && !prefs.getBoolean("enable-excluded-apps", false)) {
-                continue;
+        if (flexibleFuzzy) {
+            // New flexible fuzzy search logic for partial, misspelled queries
+            for (AppPojo pojo : getPojos()) {
+                // exclude apps from results
+                if (pojo.isExcluded() && !prefs.getBoolean("enable-excluded-apps", false)) {
+                    continue;
+                }
+                // exclude favorites from results
+                if (excludedFavoriteIds.contains(pojo.getFavoriteId())) {
+                    continue;
+                }
+
+                // Match against app name
+                int distance = substringLevenshteinDistance(queryNormalized.codePoints, pojo.normalizedName.codePoints);
+                double similarity = 1.0 - (double) distance / queryNormalized.codePoints.length;
+                boolean nameMatch = similarity > 0.6;
+                int relevance = nameMatch ? (int) (similarity * 100) : 0;
+                MatchInfo nameMatchInfo = new MatchInfo(nameMatch, relevance);
+                boolean match = pojo.updateMatchingRelevance(nameMatchInfo, false);
+
+                // Match against tags
+                if (pojo.getNormalizedTags() != null) {
+                    int distanceTags = substringLevenshteinDistance(queryNormalized.codePoints, pojo.getNormalizedTags().codePoints);
+                    double similarityTags = 1.0 - (double) distanceTags / queryNormalized.codePoints.length;
+                    boolean tagsMatch = similarityTags > 0.6;
+                    int relevanceTags = tagsMatch ? (int) (similarityTags * 100) : 0;
+                    MatchInfo tagsMatchInfo = new MatchInfo(tagsMatch, relevanceTags);
+                    match = pojo.updateMatchingRelevance(tagsMatchInfo, match);
+                }
+
+                if (match && !searcher.addResult(pojo)) {
+                    return;
+                }
             }
-            // exclude favorites from results
-            if (excludedFavoriteIds.contains(pojo.getFavoriteId())) {
-                continue;
-            }
+        } else {
+            // Original fuzzy search logic
+            FuzzyScore fuzzyScore = FuzzyFactory.createFuzzyScore(this, queryNormalized.codePoints);
 
-            MatchInfo matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
-            boolean match = pojo.updateMatchingRelevance(matchInfo, false);
+            for (AppPojo pojo : getPojos()) {
+                // exclude apps from results
+                if (pojo.isExcluded() && !prefs.getBoolean("enable-excluded-apps", false)) {
+                    continue;
+                }
+                // exclude favorites from results
+                if (excludedFavoriteIds.contains(pojo.getFavoriteId())) {
+                    continue;
+                }
 
-            // check relevance for tags
-            if (pojo.getNormalizedTags() != null) {
-                matchInfo = fuzzyScore.match(pojo.getNormalizedTags().codePoints);
-                match = pojo.updateMatchingRelevance(matchInfo, match);
-            }
+                MatchInfo matchInfo = fuzzyScore.match(pojo.normalizedName.codePoints);
+                boolean match = pojo.updateMatchingRelevance(matchInfo, false);
 
-            if (match && !searcher.addResult(pojo)) {
-                return;
+                // check relevance for tags
+                if (pojo.getNormalizedTags() != null) {
+                    matchInfo = fuzzyScore.match(pojo.getNormalizedTags().codePoints);
+                    match = pojo.updateMatchingRelevance(matchInfo, match);
+                }
+
+                if (match && !searcher.addResult(pojo)) {
+                    return;
+                }
             }
         }
+    }
+
+    private int substringLevenshteinDistance(int[] s1, int[] s2) {
+        // s1 is the query, s2 is the text to search within
+        int s1Len = s1.length;
+        int s2Len = s2.length;
+
+        if (s1Len == 0) {
+            return 0;
+        }
+
+        int[][] dp = new int[s1Len + 1][s2Len + 1];
+
+        // Initialize first column (cost of deleting query characters)
+        for (int i = 0; i <= s1Len; i++) {
+            dp[i][0] = i;
+        }
+
+        // Initialize first row to 0 (no cost for starting match anywhere in s2)
+        // This is the key difference for substring matching.
+        for (int j = 0; j <= s2Len; j++) {
+            dp[0][j] = 0;
+        }
+
+        // Fill the rest of the matrix
+        for (int i = 1; i <= s1Len; i++) {
+            for (int j = 1; j <= s2Len; j++) {
+                int cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1;
+                dp[i][j] = min(
+                    dp[i - 1][j - 1] + cost,      // Substitution/Match
+                    dp[i - 1][j] + 1,             // Deletion from s1
+                    dp[i][j - 1] + 1              // Insertion into s1
+                );
+            }
+        }
+
+        // The result is the minimum value in the last row
+        int minDistance = s1Len; // Max possible distance
+        for (int j = 0; j <= s2Len; j++) {
+            if (dp[s1Len][j] < minDistance) {
+                minDistance = dp[s1Len][j];
+            }
+        }
+
+        return minDistance;
+    }
+
+    private int min(int a, int b, int c) {
+        return Math.min(a, Math.min(b, c));
     }
 
     public List<AppPojo> getAllApps() {

--- a/app/src/main/java/fr/neamar/kiss/utils/fuzzy/MatchInfo.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/fuzzy/MatchInfo.java
@@ -16,7 +16,7 @@ public class MatchInfo {
     public boolean match;
     final List<Integer> matchedIndices;
 
-    MatchInfo(boolean match, int score) {
+    public MatchInfo(boolean match, int score) {
         this();
         this.match = match;
         this.score = score;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="contacts_name">Contacts</string>
     <string name="contacts_call_on_click">Click to call contacts</string>
     <string name="search_results_options">Search results</string>
+    <string name="fuzzy_search_name">Enable fuzzy search</string>
+    <string name="fuzzy_search_desc">Allow for typos and approximate matching</string>
     <string name="search_name">Web search providers</string>
     <string name="search_provider_toggle">Links to web search providers</string>
     <string name="settings_name">Device settings</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -477,6 +477,12 @@
                 android:key="enable-excluded-apps"
                 android:order="7"
                 android:title="@string/excluded_apps_toggle" />
+            <fr.neamar.kiss.preference.SwitchPreference
+                android:defaultValue="false"
+                android:key="enable-fuzzy-search"
+                android:order="4"
+                android:summary="@string/fuzzy_search_desc"
+                android:title="@string/fuzzy_search_name" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="web-providers"


### PR DESCRIPTION
**What does this PR do?** 

This pull request introduces an optional "fuzzy search" feature to the app search functionality. This allows for more flexible and typo-tolerant app searching. For example, a search for "Qhattsapp" will now correctly match "WhatsApp". 

This addresses issue [Link to the issue, if one exists]. 

**Why is this change being made?** 

The current search algorithm requires an exact match, which can be unforgiving of minor typos. This can slow down users who rely on quick, keyboard-based app launching. 

By implementing a fuzzy search option, we can significantly improve the user experience by making the search more intuitive and forgiving of errors. This change brings KISS Launcher's search capabilities in line with other minimalist launchers that offer similar flexible search algorithms. 

**How is this implemented?** 

*   A new "Enable Fuzzy Search" option has been added to the Search Settings menu. 
*   When enabled, the app search will utilize a fuzzy matching algorithm to find the most relevant application, even with imperfect queries. 
*   When disabled, the launcher will revert to the classic, strict matching algorithm for users who prefer precision. 

**How can this be tested?** 

1.  Navigate to `Settings > Search Settings`. 
2.  Enable the "Fuzzy Search" option. 
3.  Return to the home screen and search for an application with a deliberate typo (e.g., "Gogle" instead of "Google"). 
4.  Verify that the intended application appears as a top result. 
5.  Disable the "Fuzzy Search" option and repeat the search. 
6.  Confirm that the application is not found with the typo.