### PR TITLE
fix settings theme

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/UIColors.java
+++ b/app/src/main/java/fr/neamar/kiss/UIColors.java
@@ -159,6 +159,9 @@ public class UIColors {
             case "disabled":
                 activity.getTheme().applyStyle(R.style.OverlayWallpaperDisabled, true);
                 break;
+            case "disabled-light":
+                activity.getTheme().applyStyle(R.style.OverlayWallpaperDisabledLight, true);
+                break;
         }
 
         String barColor = prefs.getString("theme-bar-color", "default");

--- a/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/InterfaceTweaks.java
@@ -106,7 +106,6 @@ public class InterfaceTweaks extends Forwarder {
             act.setTheme(R.style.SettingThemeDark);
         }
         UIColors.updateThemePrimaryColor(act);
-        UIColors.applyOverlay(act, prefs);
     }
 
     void onCreate() {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -134,11 +134,13 @@
     <string-array name="wallpaperEntries">
         <item>@string/theme_customize_default</item>
         <item>@string/theme_customize_enabled</item>
-        <item>@string/theme_customize_disabled</item>
+        <item>@string/theme_light</item>
+        <item>@string/theme_dark</item>
     </string-array>
     <string-array name="wallpaperValues" translatable="false">
         <item>default</item>
         <item>enabled</item>
+        <item>disabled-light</item>
         <item>disabled</item>
     </string-array>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -156,6 +156,10 @@
         <item name="android:windowBackground">@android:color/black</item>
         <item name="android:windowShowWallpaper">false</item>
     </style>
+    <style name="OverlayWallpaperDisabledLight">
+        <item name="android:windowBackground">@android:color/white</item>
+        <item name="android:windowShowWallpaper">false</item>
+    </style>
 
     <style name="OverlayResultSizeLargest">
         <item name="resultHeight">@dimen/result_height_largest</item>

--- a/fastlane/metadata/android/en-US/changelogs/217.txt
+++ b/fastlane/metadata/android/en-US/changelogs/217.txt
@@ -2,6 +2,7 @@
 * fix widgets not working properly
 * fix widget size not always applied properly beginning with android 12
 * fix history screen closing by itself on refresh
+* fix theme for KISS settings, do not apply advanced theme customisations
 * make internal shortcut id unique to allow multiple shortcuts with same name
 * convert keypad letters to digits during phone number normalization
 * use updated search algorithm by default


### PR DESCRIPTION
- do not apply overlays for `KISS settings` to avoid unreadable text
- `KISS settings > advanced theme customization > wallpaper`: allow to chose also some light (white) background

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
