### PR TITLE
fix call option not showing for phone number

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/PhoneProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/PhoneProvider.java
@@ -2,6 +2,7 @@ package fr.neamar.kiss.dataprovider.simpleprovider;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.util.Patterns;
 
 import java.util.regex.Pattern;
 
@@ -23,7 +24,7 @@ public class PhoneProvider extends SimpleProvider<PhonePojo> {
     @Override
     public void requestResults(String query, Searcher searcher) {
         // Append an item only if query looks like a phone number and device has phone capabilities
-        if (deviceIsPhone && PHONE_PATTERN.matcher(query).find()) {
+        if (deviceIsPhone && (PHONE_PATTERN.matcher(query).matches() || Patterns.PHONE.matcher(query).matches())) {
             searcher.addResult(getResult(query, true));
         }
     }

--- a/fastlane/metadata/android/en-US/changelogs/217.txt
+++ b/fastlane/metadata/android/en-US/changelogs/217.txt
@@ -3,6 +3,7 @@
 * fix widget size not always applied properly beginning with android 12
 * fix history screen closing by itself on refresh
 * fix theme for KISS settings, do not apply advanced theme customisations
+* fix call option not showing for phone number
 * make internal shortcut id unique to allow multiple shortcuts with same name
 * convert keypad letters to digits during phone number normalization
 * use updated search algorithm by default


### PR DESCRIPTION
- use builtin regex for phone number matching, it's more specific than the one from KISS
- fixes #1916

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
