### PR TITLE
encapsulate text watcher

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
+++ b/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
@@ -17,9 +17,7 @@ import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
-import android.text.Editable;
 import android.text.TextUtils;
-import android.text.TextWatcher;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -47,6 +45,7 @@ import fr.neamar.kiss.icons.IconPackXML;
 import fr.neamar.kiss.icons.SystemIconPack;
 import fr.neamar.kiss.normalizer.StringNormalizer;
 import fr.neamar.kiss.utils.DrawableUtils;
+import fr.neamar.kiss.utils.TrimmingTextChangedListener;
 import fr.neamar.kiss.utils.UserHandle;
 import fr.neamar.kiss.utils.Utilities;
 import fr.neamar.kiss.utils.fuzzy.FuzzyFactory;
@@ -131,20 +130,7 @@ public class CustomIconDialog extends DialogFragment {
         });
 
         mSearch = view.findViewById(R.id.search);
-        mSearch.addTextChangedListener(new TextWatcher() {
-            public void afterTextChanged(Editable s) {
-                // Auto left-trim text.
-                if (s.length() > 0 && s.charAt(0) == ' ')
-                    s.delete(0, 1);
-            }
-
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-            }
-
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                mSearch.post(() -> refreshList());
-            }
-        });
+        mSearch.addTextChangedListener(new TrimmingTextChangedListener(changedText -> mSearch.post(this::refreshList), false));
 
         Bundle args = getArguments() != null ? getArguments() : new Bundle();
         @Nullable

--- a/app/src/main/java/fr/neamar/kiss/utils/TrimmingTextChangedListener.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/TrimmingTextChangedListener.java
@@ -1,0 +1,71 @@
+package fr.neamar.kiss.utils;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+
+import androidx.annotation.NonNull;
+
+public class TrimmingTextChangedListener implements TextWatcher {
+
+    private final TextChangedCallback textChangedCallback;
+    private final boolean executeCallbackOnEmpty;
+
+    private String oldText = null;
+
+    public TrimmingTextChangedListener(@NonNull TextChangedCallback textChangedCallback, boolean executeCallbackOnEmpty) {
+        this.textChangedCallback = textChangedCallback;
+        this.executeCallbackOnEmpty = executeCallbackOnEmpty;
+    }
+
+    public void afterTextChanged(Editable s) {
+        int length = s.length();
+
+        // trim all whitespaces from right
+        int end = length;
+        while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+            end--;
+        }
+        // keep last whitespace after char if possible
+        if (end > 0 && end < length) {
+            end++;
+        }
+
+        // trim all whitespaces from left
+        int start = 0;
+        while (start < end && Character.isWhitespace(s.charAt(start))) {
+            start++;
+        }
+
+        if (start > 0 || end < length) {
+            s.replace(0, length, s.subSequence(start, end));
+        } else {
+            // compare with text from before change and execute callback if necessary
+            String text = s.toString().trim();
+            if (!text.equals(oldText) || (executeCallbackOnEmpty && text.isEmpty())) {
+                textChangedCallback.execute(text);
+            }
+        }
+    }
+
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        // remember text before change
+        oldText = s.toString().trim();
+    }
+
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    }
+
+    /**
+     * Callback for when text has changed after trimming whitespaces
+     */
+    @FunctionalInterface
+    public interface TextChangedCallback {
+        /**
+         * Execute callback when text has changed.
+         *
+         * @param changedText changed text
+         */
+        void execute(String changedText);
+    }
+
+}


### PR DESCRIPTION
- use same space trimming logic for search fields

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
