### PR TITLE
unify all async tasks used for image loading

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
+++ b/app/src/main/java/fr/neamar/kiss/CustomIconDialog.java
@@ -59,7 +59,7 @@ public class CustomIconDialog extends DialogFragment {
     private ImageView mPreview;
     private OnDismissListener mOnDismissListener = null;
     private OnConfirmListener mOnConfirmListener = null;
-    private Utilities.AsyncRun mLoadIconsPackTask = null;
+    private Utilities.AsyncRun<Void> mLoadIconsPackTask = null;
 
     public interface OnDismissListener {
         void onDismiss(@NonNull CustomIconDialog dialog);
@@ -178,7 +178,8 @@ public class CustomIconDialog extends DialogFragment {
                 if (task == mLoadIconsPackTask) {
                     iconPack.loadDrawables(context.getPackageManager());
                 }
-            }, (task) -> {
+                return null;
+            }, (task, result) -> {
                 if (!task.isCancelled() && task == mLoadIconsPackTask) {
                     Activity activity = Utilities.getActivity(context);
                     if (activity != null)

--- a/app/src/main/java/fr/neamar/kiss/ExcludeAppSettingsFragment.java
+++ b/app/src/main/java/fr/neamar/kiss/ExcludeAppSettingsFragment.java
@@ -13,7 +13,6 @@ import androidx.preference.SwitchPreference;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -100,14 +99,13 @@ public class ExcludeAppSettingsFragment extends PreferenceFragmentCompat {
     ) {
         final SwitchPreference switchPreference = new SwitchPreference(context);
 
-        AtomicReference<Drawable> icon = new AtomicReference<>(null);
         switchPreference.setIcon(R.drawable.ic_launcher_white);
         Utilities.runAsync((task) -> {
             final ComponentName componentName = new ComponentName(app.packageName, app.activityName);
-            icon.set(iconsHandler.getDrawableIconForPackage(componentName, app.userHandle));
-        }, (task) -> {
+            return iconsHandler.getDrawableIconForPackage(componentName, app.userHandle);
+        }, (task, result) -> {
             if (!task.isCancelled()) {
-                switchPreference.setIcon(icon.get());
+                switchPreference.setIcon((Drawable) result);
             }
         });
 

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -58,7 +58,7 @@ public class IconsHandler {
     private boolean mContactPackMask = false;
     private IconShape mContactsShape = IconShape.SHAPE_SYSTEM;
     private boolean mForceShape = false;
-    private Utilities.AsyncRun mLoadIconsPackTask = null;
+    private Utilities.AsyncRun<Drawable> mLoadIconsPackTask = null;
     private volatile Map<String, Long> customIconIds = null;
 
     public IconsHandler(Context ctx) {
@@ -133,9 +133,11 @@ public class IconsHandler {
             mIconPack = iconPack;
             // start async loading
             mLoadIconsPackTask = Utilities.runAsync((task) -> {
-                if (task == mLoadIconsPackTask)
+                if (task == mLoadIconsPackTask) {
                     iconPack.load(ctx.getPackageManager());
-            }, (task) -> {
+                }
+                return null;
+            }, (task, result) -> {
                 if (!task.isCancelled() && task == mLoadIconsPackTask) {
                     mLoadIconsPackTask = null;
                 }

--- a/app/src/main/java/fr/neamar/kiss/PickAppWidgetActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/PickAppWidgetActivity.java
@@ -82,7 +82,8 @@ public class PickAppWidgetActivity extends AppCompatActivity {
                 }
                 adapterList.add(new ItemWidget(item));
             }
-        }, t -> {
+            return null;
+        }, (task, result) -> {
             progressContainer.setVisibility(View.GONE);
             adapter.setItems(adapterList);
         });
@@ -319,8 +320,7 @@ public class PickAppWidgetActivity extends AppCompatActivity {
     public static class ViewHolder {
         private final int mViewType;
         private final TextView textView;
-        private Utilities.AsyncRun task = null;
-        private Drawable mDrawable = null;
+        private Utilities.AsyncRun<Drawable> task = null;
 
         protected ViewHolder(int viewType, View itemView) {
             itemView.setTag(this);
@@ -348,18 +348,9 @@ public class PickAppWidgetActivity extends AppCompatActivity {
                     icon.setBounds(0, 0, w, h);
                     textView.setCompoundDrawables(null, icon, null, null);
                 }
-                task = Utilities.runAsync(t -> {
-                    Drawable icon = PickAppWidgetActivity.getWidgetPreview(textView.getContext(), widgetInfo.appWidgetInfo);
-                    synchronized (ViewHolder.this) {
-                        mDrawable = icon;
-                    }
-                }, t -> {
+                task = Utilities.runAsync(t -> PickAppWidgetActivity.getWidgetPreview(textView.getContext(), widgetInfo.appWidgetInfo), (t, icon) -> {
                     if (t.isCancelled())
                         return;
-                    final Drawable icon;
-                    synchronized (ViewHolder.this) {
-                        icon = mDrawable != null ? mDrawable : new ColorDrawable(0);
-                    }
                     int w = icon.getIntrinsicWidth();
                     int h = icon.getIntrinsicHeight();
                     float aspect = (w > 0 && h > 0) ? (w / (float) h) : 1f;

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/TagsProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/TagsProvider.java
@@ -1,12 +1,16 @@
 package fr.neamar.kiss.dataprovider.simpleprovider;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import fr.neamar.kiss.pojo.TagDummyPojo;
 import fr.neamar.kiss.searcher.Searcher;
 
 public class TagsProvider extends SimpleProvider<TagDummyPojo> {
     public static final String SCHEME = "kisstag://";
+
+    private final Map<String, TagDummyPojo> pojos = new HashMap<>();
 
     public static String generateUniqueId(String tag) {
         return SCHEME + tag.toLowerCase(Locale.ROOT);
@@ -18,12 +22,19 @@ public class TagsProvider extends SimpleProvider<TagDummyPojo> {
     }
 
     @Override
+    public void reload() {
+        super.reload();
+        pojos.clear();
+    }
+
+    @Override
     public boolean mayFindById(String id) {
         return id.startsWith(SCHEME);
     }
 
     @Override
     public TagDummyPojo findById(String id) {
-        return new TagDummyPojo(id);
+        // keep instances of TagDummyPojo to improve behavior of tags in favorites
+        return pojos.computeIfAbsent(id, TagDummyPojo::new);
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -98,6 +98,7 @@ class Widgets extends Forwarder {
             case Activity.RESULT_OK:
                 if (data != null) {
                     if (!data.getBooleanExtra(PickAppWidgetActivity.EXTRA_WIDGET_BIND_ALLOWED, false)) {
+                        Log.w(TAG, "Widget bind not allowed");
                         requestBindWidget(data);
                         break;
                     }
@@ -464,6 +465,8 @@ class Widgets extends Forwarder {
             if (!isConfigurationOptional(appWidgetInfo)) {
                 configureAppWidget(appWidgetId, appWidgetInfo, REQUEST_APPWIDGET_CONFIGURED);
             }
+        } else {
+            Log.w(TAG, "Add widget not possible");
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -75,9 +75,6 @@ public class AppResult extends ResultWithTags<AppPojo> {
 
         final ImageView appIcon = view.findViewById(R.id.item_app_icon);
         if (!isHideIcons(context)) {
-            if (appIcon.getTag() instanceof ComponentName && className.equals(appIcon.getTag())) {
-                icon = appIcon.getDrawable();
-            }
             this.setAsyncDrawable(appIcon);
         } else {
             appIcon.setImageDrawable(null);
@@ -340,7 +337,9 @@ public class AppResult extends ResultWithTags<AppPojo> {
 
     @Override
     void setDrawableCache(Drawable drawable) {
-        icon = drawable;
+        synchronized (this) {
+            icon = drawable;
+        }
     }
 
     @Override


### PR DESCRIPTION
- unify all async tasks used for image loading
- get rid of `AsyncSetImage`
- reduce duplicated code
- fix synchronization

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
