### PR TITLE
fix preference summary warnings

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/activity_setting">
     <PreferenceScreen
         android:key="history_category"
@@ -118,8 +119,8 @@
             android:entries="@array/themesEntries"
             android:entryValues="@array/themesValues"
             android:key="theme"
-            android:summary="%s"
-            android:title="@string/theme_name" />
+            android:title="@string/theme_name"
+            app:useSimpleSummaryProvider="true" />
         <PreferenceScreen
             android:key="theme-customisation"
             android:title="@string/theme_customisation">
@@ -128,36 +129,36 @@
                 android:entries="@array/shadowEntries"
                 android:entryValues="@array/shadowValues"
                 android:key="theme-shadow"
-                android:summary="%s"
-                android:title="@string/theme_shadow" />
+                android:title="@string/theme_shadow"
+                app:useSimpleSummaryProvider="true" />
             <ListPreference
                 android:defaultValue="default"
                 android:entries="@array/separatorEntries"
                 android:entryValues="@array/separatorValues"
                 android:key="theme-separator"
-                android:summary="%s"
-                android:title="@string/theme_separator" />
+                android:title="@string/theme_separator"
+                app:useSimpleSummaryProvider="true" />
             <ListPreference
                 android:defaultValue="default"
                 android:entries="@array/resultColorEntries"
                 android:entryValues="@array/resultColorValues"
                 android:key="theme-result-color"
-                android:summary="%s"
-                android:title="@string/theme_result_color" />
+                android:title="@string/theme_result_color"
+                app:useSimpleSummaryProvider="true" />
             <ListPreference
                 android:defaultValue="default"
                 android:entries="@array/wallpaperEntries"
                 android:entryValues="@array/wallpaperValues"
                 android:key="theme-wallpaper"
-                android:summary="%s"
-                android:title="@string/theme_wallpaper" />
+                android:title="@string/theme_wallpaper"
+                app:useSimpleSummaryProvider="true" />
             <ListPreference
                 android:defaultValue="default"
                 android:entries="@array/barColorEntries"
                 android:entryValues="@array/barColorValues"
                 android:key="theme-bar-color"
-                android:summary="%s"
-                android:title="@string/theme_bar_color" />
+                android:title="@string/theme_bar_color"
+                app:useSimpleSummaryProvider="true" />
             <SwitchPreference
                 android:key="transparent-search"
                 android:title="@string/transparent_search_bar" />


### PR DESCRIPTION
- set `useSimpleSummaryProvider="true"` instead of `summary="%s"`

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
