### PR TITLE
fix history not always shown with keyboard when enabled in settings

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/MainActivity.java
+++ b/app/src/main/java/fr/neamar/kiss/MainActivity.java
@@ -321,7 +321,6 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
                 displayKissBar(false, false);
             }
             updateSearchRecords(false, changedText);
-            displayClearOnInput();
         }));
 
         // Fixes bug when dropping onto a textEdit widget which can cause a NPE
@@ -438,7 +437,6 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
         // We need to update the history in case an external event created new items
         // (for instance, installed a new app, got a phone call or simply clicked on a favorite)
         updateSearchRecords(false, searchEditText.getText().toString());
-        displayClearOnInput();
 
         if (isViewingAllApps()) {
             displayKissBar(false);
@@ -647,8 +645,12 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
         return super.dispatchTouchEvent(ev);
     }
 
-    public void displayClearOnInput() {
-        if (!TextUtils.isEmpty(searchEditText.getText())) {
+    private void displayClearOnInput() {
+        Searcher.Type lastSearchType = SearchHandler.getInstance().getLastSearchType();
+        if (!TextUtils.isEmpty(searchEditText.getText()) ||
+                (isMinimalisticModeEnabled() && lastSearchType == Searcher.Type.HISTORY) ||
+                (lastSearchType == Searcher.Type.TAGGED) ||
+                (lastSearchType == Searcher.Type.UNTAGGED)) {
             clearButton.setVisibility(View.VISIBLE);
             menuButton.setVisibility(View.INVISIBLE);
         } else {
@@ -824,6 +826,7 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
 
         if (TextUtils.isEmpty(query)) {
             systemUiVisibilityHelper.resetScroll();
+            displayClearOnInput();
         } else {
             search(Searcher.Type.QUERY, query, false);
         }
@@ -831,6 +834,7 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
 
     public void search(@NonNull Searcher.Type type, String query, boolean isRefresh) {
         SearchHandler.getInstance().search(type, this, query, isRefresh);
+        displayClearOnInput();
     }
 
     private void cancelSearch() {
@@ -1007,23 +1011,14 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
 
     public void showMatchingTags(String tag) {
         search(Searcher.Type.TAGGED, tag, false);
-
-        clearButton.setVisibility(View.VISIBLE);
-        menuButton.setVisibility(View.INVISIBLE);
     }
 
     public void showUntagged() {
         search(Searcher.Type.UNTAGGED, null, false);
-
-        clearButton.setVisibility(View.VISIBLE);
-        menuButton.setVisibility(View.INVISIBLE);
     }
 
     public void showHistory() {
         search(Searcher.Type.HISTORY, null, false);
-
-        clearButton.setVisibility(View.VISIBLE);
-        menuButton.setVisibility(View.INVISIBLE);
     }
 
     public boolean isKissDefaultLauncher() {
@@ -1059,5 +1054,9 @@ public class MainActivity extends AppCompatActivity implements QueryInterface, K
 
     public void onKeyboardVisibilityChanged(boolean keyboardIsVisible) {
         systemUiVisibilityHelper.onKeyboardVisibilityChanged(keyboardIsVisible);
+    }
+
+    private boolean isMinimalisticModeEnabled() {
+        return prefs.getBoolean("history-hide", false);
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ExperienceTweaks.java
@@ -250,6 +250,7 @@ public class ExperienceTweaks extends Forwarder {
     void onResume() {
         keyboardManager.registerKeyboardListener(
                 mainActivity.findViewById(android.R.id.content),
+                shouldShowKeyboard(),
                 (keyboardIsVisible) -> {
                     mainActivity.onKeyboardVisibilityChanged(keyboardIsVisible);
                     if (isMinimalisticModeEnabled() && prefs.getBoolean("history-onkeyboard", false) &&
@@ -258,7 +259,6 @@ public class ExperienceTweaks extends Forwarder {
                             // If it's more than 200dp, it's most likely a keyboard.
                             if (mainActivity.adapter == null || mainActivity.adapter.isEmpty()) {
                                 mainActivity.showHistory();
-                                mainActivity.displayClearOnInput();
                             }
                         } else {
                             // we never want this triggered because the keyboard scroller did it

--- a/app/src/main/java/fr/neamar/kiss/searcher/SearchHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/SearchHandler.java
@@ -98,4 +98,8 @@ public class SearchHandler {
                 throw new UnsupportedOperationException();
         }
     }
+
+    public Searcher.Type getLastSearchType() {
+        return lastSearchType;
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/ui/KeyboardManager.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/KeyboardManager.java
@@ -3,6 +3,7 @@ package fr.neamar.kiss.ui;
 import android.view.View;
 import android.view.ViewTreeObserver;
 
+import androidx.annotation.NonNull;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
@@ -17,11 +18,11 @@ public class KeyboardManager {
         void onKeyboardVisibilityChanged(boolean isVisible);
     }
 
-    protected View contentView;
+    private View contentView;
     private ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener;
     private boolean keyboardIsVisible;
 
-    protected void setKeyboardIsVisible(boolean isVisible, final OnKeyboardListener listener) {
+    private void setKeyboardIsVisible(boolean isVisible, final OnKeyboardListener listener) {
         if (isVisible != keyboardIsVisible) {
             Log.d(TAG, "onKeyboardVisibilityChanged(" + isVisible + ")");
             keyboardIsVisible = isVisible;
@@ -31,9 +32,14 @@ public class KeyboardManager {
         }
     }
 
-    public void registerKeyboardListener(View view, final OnKeyboardListener listener) {
+    public void registerKeyboardListener(@NonNull View view, boolean initialIsVisible, final OnKeyboardListener listener) {
         this.contentView = view;
         unregisterKeyboardListener();
+
+        // initialize before listener is registered
+        // calls listener if `keyboardIsVisible` changes because of initialization
+        setKeyboardIsVisible(initialIsVisible, listener);
+
         onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
             private int previousHeight = 0;
 


### PR DESCRIPTION
- internal state must be initialized always before listening on changes of keyboard is started
- without initialization state can be wrong which results in #2585
- clear button was not always the same when history was shown from minimalistic ui
- fixes #2585

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
