### PR TITLE
More custom icons

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -265,6 +265,13 @@ public class IconsHandler {
     }
 
     public Drawable getDrawableIconForCodepoint(@NonNull Pojo pojo, @ColorInt int textColor, @ColorInt int backgroundColor) {
+        if (getIconPack().allowForCustomIcons()) {
+            ComponentName componentName = getCustomComponentName(pojo.getCustomIconId(), null);
+            if (componentName != null) {
+                return getDrawableIconForPackage(componentName, UserHandle.OWNER);
+            }
+        }
+
         int codePoint = pojo.getName().codePointAt(0);
         final IconShape shape = getShapeForGeneratingDrawable();
         Drawable drawable = DrawableUtils.generateCodepointDrawable(ctx, codePoint, textColor, backgroundColor, shape);

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -160,7 +160,7 @@ public class IconsHandler {
     /**
      * Get or generate icon for a shortcut.
      *
-     * @param pojo     shortcut pojo
+     * @param pojo         shortcut pojo
      * @param shortcutInfo related shortcut info
      * @return drawable
      */
@@ -275,7 +275,8 @@ public class IconsHandler {
         return forceIconMask(drawable, shape);
     }
 
-    public Drawable getDrawableIconForCodepoint(int codePoint, @ColorInt int textColor, @ColorInt int backgroundColor) {
+    public Drawable getDrawableIconForCodepoint(@NonNull Pojo pojo, @ColorInt int textColor, @ColorInt int backgroundColor) {
+        int codePoint = pojo.getName().codePointAt(0);
         final IconShape shape = getShapeForGeneratingDrawable();
         Drawable drawable = DrawableUtils.generateCodepointDrawable(ctx, codePoint, textColor, backgroundColor, shape);
         return forceIconMask(drawable, shape);

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -169,7 +169,11 @@ public class IconsHandler {
      */
     public Drawable getDrawableIconForShortcut(Pojo pojo, ShortcutInfo shortcutInfo) {
         Drawable icon = getCustomIcon(pojo);
-        if (icon == null && shortcutInfo != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+        if (icon != null) {
+            return icon;
+        }
+
+        if (shortcutInfo != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
             final LauncherApps launcherApps = ContextCompat.getSystemService(ctx, LauncherApps.class);
             assert launcherApps != null;
             try {
@@ -597,8 +601,8 @@ public class IconsHandler {
         return customComponents;
     }
 
-    private ComponentName getCustomComponentName(String id, ComponentName defaultComponent) {
-        return getCustomComponents().getOrDefault(id, defaultComponent);
+    private ComponentName getCustomComponentName(String id, ComponentName defaultComponentName) {
+        return getCustomComponents().getOrDefault(id, defaultComponentName);
     }
 
     private Drawable getCustomIcon(@NonNull Pojo pojo) {

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -37,6 +37,7 @@ import fr.neamar.kiss.icons.SystemIconPack;
 import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.result.AppResult;
+import fr.neamar.kiss.result.Result;
 import fr.neamar.kiss.result.TagDummyResult;
 import fr.neamar.kiss.utils.DrawableUtils;
 import fr.neamar.kiss.utils.IconShape;
@@ -187,18 +188,6 @@ public class IconsHandler {
             icon = applyIconMask(ctx, icon);
         }
         return icon;
-    }
-
-    /**
-     * Get or generate icon for an app.
-     * Uses no cache and no custom icons.
-     *
-     * @param componentName component name
-     * @param userHandle    user handle
-     * @return drawable
-     */
-    public Drawable getOriginalDrawableIconForPackage(@NonNull ComponentName componentName, @NonNull UserHandle userHandle) {
-        return getDrawableIconForPackage(componentName, userHandle, false, false);
     }
 
     /**
@@ -545,13 +534,16 @@ public class IconsHandler {
         }
     }
 
-    public void setCustomComponent(AppResult result, ComponentName componentName) {
-        // cleanup deprecated custom icons
-        long customIconId = getDataHandler().removeCustomAppIcon(result.getComponentName());
-        removeStoredDrawable(customIconFileName(result.getComponentName(), customIconId));
+    public void setCustomComponent(Result<?> result, ComponentName componentName) {
+        if (result instanceof AppResult) {
+            // cleanup deprecated custom icons
+            AppResult appResult = (AppResult) result;
+            long customIconId = getDataHandler().removeCustomAppIcon(appResult.getComponentName());
+            removeStoredDrawable(customIconFileName(appResult.getComponentName(), customIconId));
+        }
 
         // set component for custom icon
-        DBHelper.setCustomComponent(ctx, result.getClassName().flattenToString(), componentName);
+        DBHelper.setCustomComponent(ctx, result.getCustomIconId(), componentName);
         result.clearIcon();
         cacheClear();
         getDataHandler().refreshFavorites();

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -168,16 +168,20 @@ public class IconsHandler {
     public Drawable getDrawableIconForShortcut(Pojo pojo, ShortcutInfo shortcutInfo) {
         Drawable icon = null;
         if (shortcutInfo != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            final LauncherApps launcherApps = ContextCompat.getSystemService(ctx, LauncherApps.class);
-            assert launcherApps != null;
-            try {
-                icon = launcherApps.getShortcutIconDrawable(shortcutInfo, 0);
-            } catch (IllegalStateException e) {
-                // do nothing if user is locked or not running
-                Log.w(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "', user is locked or not running", e);
-            } catch (NullPointerException e) {
-                // shortcuts may use invalid icons, see https://github.com/Neamar/KISS/issues/2158
-                Log.e(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "'", e);
+            icon = getCustomIcon(pojo, new UserHandle(ctx, shortcutInfo.getUserHandle()));
+
+            if (icon == null) {
+                final LauncherApps launcherApps = ContextCompat.getSystemService(ctx, LauncherApps.class);
+                assert launcherApps != null;
+                try {
+                    icon = launcherApps.getShortcutIconDrawable(shortcutInfo, 0);
+                } catch (IllegalStateException e) {
+                    // do nothing if user is locked or not running
+                    Log.w(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "', user is locked or not running", e);
+                } catch (NullPointerException e) {
+                    // shortcuts may use invalid icons, see https://github.com/Neamar/KISS/issues/2158
+                    Log.e(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "'", e);
+                }
             }
         }
         if (icon == null) {
@@ -265,11 +269,9 @@ public class IconsHandler {
     }
 
     public Drawable getDrawableIconForCodepoint(@NonNull Pojo pojo, @ColorInt int textColor, @ColorInt int backgroundColor) {
-        if (getIconPack().allowForCustomIcons()) {
-            ComponentName componentName = getCustomComponentName(pojo.getCustomIconId(), null);
-            if (componentName != null) {
-                return getDrawableIconForPackage(componentName, UserHandle.OWNER);
-            }
+        Drawable icon = getCustomIcon(pojo, UserHandle.OWNER);
+        if (icon != null) {
+            return icon;
         }
 
         int codePoint = pojo.getName().codePointAt(0);
@@ -599,5 +601,15 @@ public class IconsHandler {
 
     private ComponentName getCustomComponentName(String id, ComponentName defaultComponent) {
         return getCustomComponents().getOrDefault(id, defaultComponent);
+    }
+
+    private Drawable getCustomIcon(@NonNull Pojo pojo, @NonNull UserHandle userHandle) {
+        if (getIconPack().allowForCustomIcons()) {
+            ComponentName componentName = getCustomComponentName(pojo.getCustomIconId(), null);
+            if (componentName != null) {
+                return getDrawableIconForPackage(componentName, userHandle);
+            }
+        }
+        return null;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/IconsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/IconsHandler.java
@@ -14,9 +14,11 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
 import android.os.Build;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
@@ -166,22 +168,18 @@ public class IconsHandler {
      * @return drawable
      */
     public Drawable getDrawableIconForShortcut(Pojo pojo, ShortcutInfo shortcutInfo) {
-        Drawable icon = null;
-        if (shortcutInfo != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            icon = getCustomIcon(pojo, new UserHandle(ctx, shortcutInfo.getUserHandle()));
-
-            if (icon == null) {
-                final LauncherApps launcherApps = ContextCompat.getSystemService(ctx, LauncherApps.class);
-                assert launcherApps != null;
-                try {
-                    icon = launcherApps.getShortcutIconDrawable(shortcutInfo, 0);
-                } catch (IllegalStateException e) {
-                    // do nothing if user is locked or not running
-                    Log.w(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "', user is locked or not running", e);
-                } catch (NullPointerException e) {
-                    // shortcuts may use invalid icons, see https://github.com/Neamar/KISS/issues/2158
-                    Log.e(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "'", e);
-                }
+        Drawable icon = getCustomIcon(pojo);
+        if (icon == null && shortcutInfo != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            final LauncherApps launcherApps = ContextCompat.getSystemService(ctx, LauncherApps.class);
+            assert launcherApps != null;
+            try {
+                icon = launcherApps.getShortcutIconDrawable(shortcutInfo, 0);
+            } catch (IllegalStateException e) {
+                // do nothing if user is locked or not running
+                Log.w(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "', user is locked or not running", e);
+            } catch (NullPointerException e) {
+                // shortcuts may use invalid icons, see https://github.com/Neamar/KISS/issues/2158
+                Log.e(TAG, "Unable to get shortcut icon for '" + pojo.getName() + "'", e);
             }
         }
         if (icon == null) {
@@ -269,7 +267,7 @@ public class IconsHandler {
     }
 
     public Drawable getDrawableIconForCodepoint(@NonNull Pojo pojo, @ColorInt int textColor, @ColorInt int backgroundColor) {
-        Drawable icon = getCustomIcon(pojo, UserHandle.OWNER);
+        Drawable icon = getCustomIcon(pojo);
         if (icon != null) {
             return icon;
         }
@@ -603,13 +601,40 @@ public class IconsHandler {
         return getCustomComponents().getOrDefault(id, defaultComponent);
     }
 
-    private Drawable getCustomIcon(@NonNull Pojo pojo, @NonNull UserHandle userHandle) {
+    private Drawable getCustomIcon(@NonNull Pojo pojo) {
         if (getIconPack().allowForCustomIcons()) {
             ComponentName componentName = getCustomComponentName(pojo.getCustomIconId(), null);
             if (componentName != null) {
-                return getDrawableIconForPackage(componentName, userHandle);
+                return getDrawableIconForPackage(componentName, pojo.getUserHandle());
             }
         }
         return null;
+    }
+
+    public Drawable getThemedDrawable(@NonNull Pojo pojo, @DrawableRes int resId, @ColorInt int backgroundColor, @ColorInt int textColor, @ColorInt int themeFillColor) {
+        Drawable icon = getCustomIcon(pojo);
+        if (icon != null) {
+            return icon;
+        }
+
+        icon = ResourcesCompat.getDrawable(ctx.getResources(), resId, ctx.getTheme());
+        if (DrawableUtils.isAdaptiveIconDrawable(icon)) {
+            return icon;
+        } else if (DrawableUtils.hasThemedIcons() &&
+                DrawableUtils.isThemedIconEnabled(ctx)) {
+            Drawable background = getBackgroundDrawable(backgroundColor);
+            int insetX = (int) (background.getIntrinsicWidth() * 0.15);
+            int insetY = (int) (background.getIntrinsicHeight() * 0.15);
+
+            icon.setTint(textColor);
+
+            LayerDrawable combined = new LayerDrawable(new Drawable[]{background, icon});
+            combined.setLayerInset(1, insetX, insetY, insetX, insetY);
+
+            return combined;
+        } else {
+            icon.setTint(themeFillColor);
+            return icon;
+        }
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/PhoneProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/PhoneProvider.java
@@ -47,8 +47,9 @@ public class PhoneProvider extends SimpleProvider<PhonePojo> {
      */
     private PhonePojo getResult(String phoneNumber, boolean fromSearch) {
         String historyId = PHONE_SCHEME + phoneNumber;
-        String id = fromSearch ? PHONE_SCHEME + "search" : historyId;
-        PhonePojo pojo = new PhonePojo(id, historyId, phoneNumber);
+        String searchId = PHONE_SCHEME + "search";
+        String id = fromSearch ? searchId : historyId;
+        PhonePojo pojo = new PhonePojo(id, historyId, phoneNumber, searchId);
 
         String phoneNumberAfterFirstCharacter = phoneNumber.substring(1);
         if (!phoneNumberAfterFirstCharacter.contains("*") && !phoneNumberAfterFirstCharacter.contains("+")) {

--- a/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/AppPojo.java
@@ -1,5 +1,9 @@
 package fr.neamar.kiss.pojo;
 
+import android.content.ComponentName;
+
+import androidx.annotation.NonNull;
+
 import fr.neamar.kiss.utils.UserHandle;
 
 public final class AppPojo extends PojoWithTags {
@@ -11,6 +15,7 @@ public final class AppPojo extends PojoWithTags {
 
     public final String packageName;
     public final String activityName;
+    private final ComponentName componentName;
     public final UserHandle userHandle;
 
     private boolean excluded;
@@ -21,7 +26,7 @@ public final class AppPojo extends PojoWithTags {
     private boolean excludedShortcuts;
     private final boolean disabled;
 
-    public AppPojo(String id, String packageName, String activityName, UserHandle userHandle,
+    public AppPojo(String id, @NonNull String packageName, @NonNull String activityName, @NonNull UserHandle userHandle,
                    boolean isExcluded, boolean isExcludedFromHistory, boolean isExcludedShortcuts, boolean disabled) {
         super(id);
 
@@ -33,6 +38,7 @@ public final class AppPojo extends PojoWithTags {
         this.excludedFromHistory = isExcludedFromHistory;
         this.excludedShortcuts = isExcludedShortcuts;
         this.disabled = disabled;
+        this.componentName = new ComponentName(packageName, activityName);
     }
 
     public String getComponentName() {
@@ -75,5 +81,14 @@ public final class AppPojo extends PojoWithTags {
     @Override
     public UserHandle getUserHandle() {
         return userHandle;
+    }
+
+    public ComponentName getComponent() {
+        return componentName;
+    }
+
+    @Override
+    public String getCustomIconId() {
+        return getComponent().flattenToString();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/pojo/ContactsPojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/ContactsPojo.java
@@ -101,4 +101,16 @@ public final class ContactsPojo extends Pojo {
             this.normalizedPhoneticName = null;
         }
     }
+
+    /**
+     * @return id if icon is set and some default string if no icon is set
+     */
+    @Override
+    public String getCustomIconId() {
+        if (icon != null) {
+            return id;
+        } else {
+            return "contact://default";
+        }
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/pojo/PhonePojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/PhonePojo.java
@@ -3,15 +3,22 @@ package fr.neamar.kiss.pojo;
 public final class PhonePojo extends Pojo {
     public final String phone;
     private final String historyId;
+    private final String customIconId;
 
-    public PhonePojo(String id, String historyId, String phone) {
+    public PhonePojo(String id, String historyId, String phone, String customIconId) {
         super(id);
         this.historyId = historyId;
         this.phone = phone;
+        this.customIconId = customIconId;
     }
 
     @Override
     public String getHistoryId() {
         return historyId;
+    }
+
+    @Override
+    public String getCustomIconId() {
+        return customIconId;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/Pojo.java
@@ -94,4 +94,11 @@ public abstract class Pojo {
     public UserHandle getUserHandle() {
         return UserHandle.OWNER;
     }
+
+    /**
+     * ID to use for custom icons
+     */
+    public String getCustomIconId() {
+        return id;
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/pojo/SearchPojoType.java
+++ b/app/src/main/java/fr/neamar/kiss/pojo/SearchPojoType.java
@@ -1,9 +1,25 @@
 package fr.neamar.kiss.pojo;
 
+import androidx.annotation.DrawableRes;
+
+import fr.neamar.kiss.R;
+
 public enum SearchPojoType {
-    SEARCH_QUERY,
-    URL_QUERY,
-    CALCULATOR_QUERY,
-    URI_QUERY,
-    TIMER_QUERY
+    SEARCH_QUERY(R.drawable.ic_search),
+    URL_QUERY(R.drawable.ic_public),
+    CALCULATOR_QUERY(R.drawable.ic_functions),
+    URI_QUERY(R.drawable.ic_public),
+    TIMER_QUERY(R.drawable.ic_timer);
+
+    @DrawableRes
+    private final int iconId;
+
+    SearchPojoType(@DrawableRes int iconId) {
+        this.iconId = iconId;
+    }
+
+    @DrawableRes
+    public int getIconId() {
+        return iconId;
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -29,13 +29,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
-import fr.neamar.kiss.CustomIconDialog;
 import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.UIColors;
 import fr.neamar.kiss.adapter.RecordAdapter;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.notification.NotificationListener;
 import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.ui.ListPopup;
@@ -47,13 +47,10 @@ import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
 public class AppResult extends ResultWithTags<AppPojo> {
 
     private static final String TAG = AppResult.class.getSimpleName();
-    private final ComponentName className;
     private volatile Drawable icon = null;
 
     AppResult(@NonNull AppPojo pojo) {
         super(pojo);
-
-        className = new ComponentName(pojo.packageName, pojo.activityName);
     }
 
     @NonNull
@@ -104,19 +101,11 @@ public class AppResult extends ResultWithTags<AppPojo> {
     }
 
     @Override
-    protected ListPopup buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
-        if (!(context instanceof MainActivity) || ((MainActivity) context).isViewingSearchResults()) {
-            adapter.add(new ListPopup.Item(context, R.string.menu_remove));
-        }
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        super.buildPopupMenu(context, adapter);
+
         adapter.add(new ListPopup.Item(context, R.string.menu_exclude));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_add));
         adapter.add(new ListPopup.Item(context, R.string.menu_app_rename));
-        // only display this option if we're using a custom icon pack, as it is not useful otherwise
-        if (KissApplication.getApplication(context).getIconsHandler().getIconPack().allowForCustomIcons()) {
-            adapter.add(new ListPopup.Item(context, R.string.menu_custom_icon));
-        }
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_remove));
-        adapter.add(new ListPopup.Item(context, R.string.menu_tags_edit));
         if (!pojo.isDisabled()) {
             adapter.add(new ListPopup.Item(context, R.string.menu_app_details));
         }
@@ -145,8 +134,6 @@ public class AppResult extends ResultWithTags<AppPojo> {
         if (KissApplication.getApplication(context).getRootHandler().isRootActivated() && KissApplication.getApplication(context).getRootHandler().isRootAvailable()) {
             adapter.add(new ListPopup.Item(context, R.string.menu_app_hibernate));
         }
-
-        return inflatePopupMenu(adapter, context);
     }
 
     @Override
@@ -188,9 +175,6 @@ public class AppResult extends ResultWithTags<AppPojo> {
             return true;
         } else if (stringId == R.string.menu_app_rename) {
             launchRenameDialog(context, parent, pojo);
-            return true;
-        } else if (stringId == R.string.menu_custom_icon) {
-            launchCustomIcon(context, parent);
             return true;
         }
 
@@ -261,24 +245,13 @@ public class AppResult extends ResultWithTags<AppPojo> {
         ((TextView) dialog.findViewById(R.id.rename)).setText(app.getName());
     }
 
-    private void launchCustomIcon(Context context, RecordAdapter parent) {
-        //TODO: launch a DialogFragment or Activity
-        CustomIconDialog dialog = new CustomIconDialog();
-
-        dialog.setOnConfirmListener(componentName -> {
-            KissApplication.getApplication(context).getIconsHandler().setCustomComponent(this, componentName);
-        });
-
-        parent.showDialog(dialog);
-    }
-
     /**
      * Open an activity displaying details regarding the current package
      */
     private void launchAppDetails(Context context) {
         LauncherApps launcher = ContextCompat.getSystemService(context, LauncherApps.class);
         assert launcher != null;
-        launcher.startAppDetailsActivity(className, pojo.userHandle.getRealHandle(), null, null);
+        launcher.startAppDetailsActivity(getClassName(), pojo.userHandle.getRealHandle(), null, null);
     }
 
     private void launchAppStore(Context context) {
@@ -326,7 +299,7 @@ public class AppResult extends ResultWithTags<AppPojo> {
             synchronized (this) {
                 if (icon == null) {
                     IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
-                    icon = iconsHandler.getDrawableIconForPackage(className, this.pojo.userHandle);
+                    icon = iconsHandler.getDrawableIconForPackage(getClassName(), this.pojo.userHandle);
                 }
             }
         }
@@ -359,7 +332,7 @@ public class AppResult extends ResultWithTags<AppPojo> {
                 }
             }
 
-            launcher.startMainActivity(className, pojo.userHandle.getRealHandle(), sourceBounds, opts);
+            launcher.startMainActivity(getClassName(), pojo.userHandle.getRealHandle(), sourceBounds, opts);
         } catch (ActivityNotFoundException | NullPointerException | SecurityException e) {
             Log.w(TAG, "Unable to launch activity", e);
             // Application was just removed?
@@ -385,6 +358,21 @@ public class AppResult extends ResultWithTags<AppPojo> {
     }
 
     public ComponentName getClassName() {
-        return className;
+        return pojo.getComponent();
+    }
+
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return true;
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return !(context instanceof MainActivity) || ((MainActivity) context).isViewingSearchResults();
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return true;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/AppResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/AppResult.java
@@ -372,7 +372,7 @@ public class AppResult extends ResultWithTags<AppPojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
         return true;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -17,7 +17,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.res.ResourcesCompat;
 import androidx.preference.PreferenceManager;
 
 import java.io.IOException;
@@ -219,7 +218,7 @@ public class ContactsResult extends CallResult<ContactsPojo> {
 
                     // Default icon
                     if (icon == null) {
-                        icon = ResourcesCompat.getDrawable(context.getResources(), R.drawable.ic_contact, context.getTheme());
+                        icon = getThemedDrawable(context, pojo, R.drawable.ic_contact);
                     }
                 }
             }
@@ -290,8 +289,14 @@ public class ContactsResult extends CallResult<ContactsPojo> {
         return true;
     }
 
+    /**
+     *
+     * @param context
+     * @param iconPack
+     * @return true, if contact has no icon set
+     */
     @Override
     protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
-        return false;
+        return pojo.icon == null;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -26,8 +26,8 @@ import java.io.InputStream;
 import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
-import fr.neamar.kiss.UIColors;
 import fr.neamar.kiss.adapter.RecordAdapter;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.ContactsPojo;
 import fr.neamar.kiss.searcher.QueryInterface;
 import fr.neamar.kiss.ui.ImprovedQuickContactBadge;
@@ -173,13 +173,10 @@ public class ContactsResult extends CallResult<ContactsPojo> {
     }
 
     @Override
-    protected ListPopup buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
-        adapter.add(new ListPopup.Item(context, R.string.menu_remove));
-        adapter.add(new ListPopup.Item(context, R.string.menu_contact_copy_phone));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_add));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_remove));
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        super.buildPopupMenu(context, adapter);
 
-        return inflatePopupMenu(adapter, context);
+        adapter.add(new ListPopup.Item(context, R.string.menu_contact_copy_phone));
     }
 
     @Override
@@ -283,4 +280,18 @@ public class ContactsResult extends CallResult<ContactsPojo> {
         }
     }
 
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return true;
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return true;
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return false;
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ContactsResult.java
@@ -291,7 +291,7 @@ public class ContactsResult extends CallResult<ContactsPojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
         return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -94,7 +94,7 @@ public class PhoneResult extends CallResult<PhonePojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
         return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.PhonePojo;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
@@ -45,14 +46,11 @@ public class PhoneResult extends CallResult<PhonePojo> {
     }
 
     @Override
-    protected ListPopup buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
-        adapter.add(new ListPopup.Item(context, R.string.menu_remove));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_add));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_remove));
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        super.buildPopupMenu(context, adapter);
+
         adapter.add(new ListPopup.Item(context, R.string.menu_phone_create));
         adapter.add(new ListPopup.Item(context, R.string.ui_item_contact_hint_message));
-
-        return inflatePopupMenu(adapter, context);
     }
 
     @Override
@@ -83,5 +81,20 @@ public class PhoneResult extends CallResult<PhonePojo> {
     @Override
     protected void doLaunch(Context context, View v) {
         launchCall(context, v, pojo.phone);
+    }
+
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return true;
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return true;
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/PhoneResult.java
@@ -75,7 +75,7 @@ public class PhoneResult extends CallResult<PhonePojo> {
 
     @Override
     public Drawable getDrawable(Context context) {
-        return getThemedDrawable(context, R.drawable.ic_phone);
+        return getThemedDrawable(context, pojo, R.drawable.ic_phone);
     }
 
     @Override
@@ -95,6 +95,6 @@ public class PhoneResult extends CallResult<PhonePojo> {
 
     @Override
     protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
-        return false;
+        return true;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -272,7 +272,7 @@ public abstract class Result<T extends Pojo> {
             }
         }
         IconPack iconPack = KissApplication.getApplication(context).getIconsHandler().getIconPack();
-        if (canHaveCustomIcon(iconPack)) {
+        if (canHaveCustomIcon(context, iconPack)) {
             // only display this option if we're using a custom icon pack, as it is not useful otherwise
             if (iconPack.allowForCustomIcons()) {
                 adapter.add(new ListPopup.Item(context, R.string.menu_custom_icon));
@@ -599,7 +599,7 @@ public abstract class Result<T extends Pojo> {
 
     protected abstract boolean canRemoveFromHistory(Context context);
 
-    protected abstract boolean canHaveCustomIcon(IconPack iconPack);
+    protected abstract boolean canHaveCustomIcon(Context context, IconPack iconPack);
 
     public String getCustomIconId() {
         return pojo.getCustomIconId();

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -8,7 +8,6 @@ import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.LayerDrawable;
 import android.os.Handler;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -31,7 +30,6 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
-import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 
 import java.util.ArrayList;
@@ -45,7 +43,6 @@ import java.util.function.Supplier;
 
 import fr.neamar.kiss.BuildConfig;
 import fr.neamar.kiss.CustomIconDialog;
-import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.UIColors;
@@ -509,26 +506,8 @@ public abstract class Result<T extends Pojo> {
         }
     }
 
-    protected Drawable getThemedDrawable(Context context, int resId) {
-        if (DrawableUtils.hasThemedIcons() &&
-                DrawableUtils.isThemedIconEnabled(context)) {
-            IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
-            Drawable background = iconsHandler.getBackgroundDrawable(getBackgroundColor(context));
-            int insetX = (int) (background.getIntrinsicWidth() * 0.15);
-            int insetY = (int) (background.getIntrinsicHeight() * 0.15);
-
-            Drawable foregroud = ContextCompat.getDrawable(context, resId);
-            foregroud.setTint(getTextColor(context));
-
-            LayerDrawable combined = new LayerDrawable(new Drawable[]{background, foregroud});
-            combined.setLayerInset(1, insetX, insetY, insetX, insetY);
-
-            return combined;
-        } else {
-            Drawable drawable = ContextCompat.getDrawable(context, resId);
-            drawable.setTint(getThemeFillColor(context));
-            return drawable;
-        }
+    protected Drawable getThemedDrawable(@NonNull Context context, @NonNull Pojo pojo, @DrawableRes int resId) {
+        return KissApplication.getApplication(context).getIconsHandler().getThemedDrawable(pojo, resId, getBackgroundColor(context), getTextColor(context), getThemeFillColor(context));
     }
 
     @ColorInt
@@ -601,7 +580,7 @@ public abstract class Result<T extends Pojo> {
 
     protected abstract boolean canHaveCustomIcon(Context context, IconPack iconPack);
 
-    public String getCustomIconId() {
+    public final String getCustomIconId() {
         return pojo.getCustomIconId();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.result;
 
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -43,12 +44,14 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import fr.neamar.kiss.BuildConfig;
+import fr.neamar.kiss.CustomIconDialog;
 import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.UIColors;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.db.DBHelper;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.normalizer.StringNormalizer;
 import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.ContactsPojo;
@@ -163,7 +166,7 @@ public abstract class Result<T extends Pojo> {
     }
 
     protected boolean displayHighlighted(StringNormalizer.Result normalized, String text, FuzzyScore fuzzyScore,
-                               TextView view, Context context) {
+                                         TextView view, Context context) {
         MatchInfo matchInfo = fuzzyScore.match(normalized.codePoints);
 
         if (!matchInfo.match) {
@@ -234,7 +237,8 @@ public abstract class Result<T extends Pojo> {
      */
     public ListPopup getPopupMenu(final Context context, final RecordAdapter parent, final View parentView) {
         ArrayAdapter<ListPopup.Item> popupMenuAdapter = new ArrayAdapter<>(context, R.layout.popup_list_item);
-        ListPopup menu = buildPopupMenu(context, popupMenuAdapter);
+        buildPopupMenu(context, popupMenuAdapter);
+        ListPopup menu = inflatePopupMenu(popupMenuAdapter, context);
 
         menu.setOnItemClickListener((adapter, view, position) -> {
             ListPopup.Item item = (ListPopup.Item) adapter.getItem(position);
@@ -251,47 +255,39 @@ public abstract class Result<T extends Pojo> {
 
     /**
      * Default popup menu implementation, can be overridden by children class to display a more specific menu
-     *
-     * @return an inflated, listener-free PopupMenu
      */
-    ListPopup buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
-        adapter.add(new ListPopup.Item(context, R.string.menu_remove));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_add));
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_remove));
-        return inflatePopupMenu(adapter, context);
-    }
-
-    ListPopup inflatePopupMenu(ArrayAdapter<ListPopup.Item> adapter, Context context) {
-        ListPopup menu = new ListPopup(context);
-        menu.setAdapter(adapter);
-
-        // If app already pinned, do not display the "add to favorite" option
-        // otherwise don't show the "remove favorite button"
-        String favApps = PreferenceManager.getDefaultSharedPreferences(context).
-                getString("favorite-apps-list", "");
-        if (favApps.contains(this.pojo.id + ";")) {
-            for (int i = 0; i < adapter.getCount(); i += 1) {
-                ListPopup.Item item = adapter.getItem(i);
-                assert item != null;
-                if (item.stringId == R.string.menu_favorites_add) {
-                    adapter.remove(item);
-                }
-            }
-        } else {
-            for (int i = 0; i < adapter.getCount(); i += 1) {
-                ListPopup.Item item = adapter.getItem(i);
-                assert item != null;
-                if (item.stringId == R.string.menu_favorites_remove) {
-                    adapter.remove(item);
-                }
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        if (canRemoveFromHistory(context)) {
+            adapter.add(new ListPopup.Item(context, R.string.menu_remove));
+        }
+        if (isAllowedAsFavorite()) {
+            // If app already pinned, do not display the "add to favorite" option
+            // otherwise don't show the "remove favorite button"
+            String favApps = PreferenceManager.getDefaultSharedPreferences(context).
+                    getString("favorite-apps-list", "");
+            if (!favApps.contains(this.pojo.id + ";")) {
+                adapter.add(new ListPopup.Item(context, R.string.menu_favorites_add));
+            } else {
+                adapter.add(new ListPopup.Item(context, R.string.menu_favorites_remove));
             }
         }
+        IconPack iconPack = KissApplication.getApplication(context).getIconsHandler().getIconPack();
+        if (canHaveCustomIcon(iconPack)) {
+            // only display this option if we're using a custom icon pack, as it is not useful otherwise
+            if (iconPack.allowForCustomIcons()) {
+                adapter.add(new ListPopup.Item(context, R.string.menu_custom_icon));
+            }
+        }
+    }
 
+    private ListPopup inflatePopupMenu(ArrayAdapter<ListPopup.Item> adapter, Context context) {
         if (BuildConfig.DEBUG) {
             adapter.add(new ListPopup.Item("Relevance: " + pojo.relevance));
             adapter.add(new ListPopup.Item("ID: " + pojo.id));
         }
 
+        ListPopup menu = new ListPopup(context);
+        menu.setAdapter(adapter);
         return menu;
     }
 
@@ -311,6 +307,9 @@ public abstract class Result<T extends Pojo> {
         } else if (stringId == R.string.menu_favorites_remove) {
             launchRemoveFromFavorites(context, pojo);
             return true;
+        } else if (stringId == R.string.menu_custom_icon) {
+            launchCustomIcon(context, parent);
+            return true;
         }
 
         return false;
@@ -326,6 +325,17 @@ public abstract class Result<T extends Pojo> {
         String msg = context.getResources().getString(R.string.toast_favorites_removed);
         KissApplication.getApplication(context).getDataHandler().removeFromFavorites(pojo.getFavoriteId());
         Toast.makeText(context, String.format(msg, pojo.getName()), Toast.LENGTH_SHORT).show();
+    }
+
+    private void launchCustomIcon(Context context, RecordAdapter parent) {
+        //TODO: launch a DialogFragment or Activity
+        CustomIconDialog dialog = new CustomIconDialog();
+        dialog.setOnConfirmListener(componentName -> this.setCustomIcon(context, componentName));
+        parent.showDialog(dialog);
+    }
+
+    private void setCustomIcon(Context context, ComponentName componentName) {
+        KissApplication.getApplication(context).getIconsHandler().setCustomComponent(this, componentName);
     }
 
     /**
@@ -368,6 +378,7 @@ public abstract class Result<T extends Pojo> {
 
     /**
      * to check if launch can be added to history
+     *
      * @return true, if launch can be added to history
      */
     protected boolean canAddToHistory() {
@@ -582,5 +593,15 @@ public abstract class Result<T extends Pojo> {
 
     protected void setTranscriptModeDisabled(RecordAdapter adapter) {
         adapter.updateTranscriptMode(AbsListView.TRANSCRIPT_MODE_DISABLED);
+    }
+
+    protected abstract boolean isAllowedAsFavorite();
+
+    protected abstract boolean canRemoveFromHistory(Context context);
+
+    protected abstract boolean canHaveCustomIcon(IconPack iconPack);
+
+    public String getCustomIconId() {
+        return pojo.getCustomIconId();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -419,11 +419,11 @@ public abstract class Result<T extends Pojo> {
         setDrawableCache(null);
     }
 
-    protected void setAsyncDrawable(ImageView view) {
+    protected void setAsyncDrawable(@NonNull ImageView view) {
         setAsyncDrawable(view, android.R.color.transparent);
     }
 
-    protected void setAsyncDrawable(ImageView view, @DrawableRes int resId) {
+    protected void setAsyncDrawable(@NonNull ImageView view, @DrawableRes int resId) {
         setAsyncDrawable(view, resId, false, this::isDrawableCached, this::getDrawable, this::setDrawableCache);
     }
 

--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -269,9 +269,9 @@ public abstract class Result<T extends Pojo> {
             }
         }
         IconPack iconPack = KissApplication.getApplication(context).getIconsHandler().getIconPack();
-        if (canHaveCustomIcon(context, iconPack)) {
-            // only display this option if we're using a custom icon pack, as it is not useful otherwise
-            if (iconPack.allowForCustomIcons()) {
+        // only display this option if we're using a custom icon pack, as it is not useful otherwise
+        if (iconPack.allowForCustomIcons()) {
+            if (canHaveCustomIcon(context, iconPack)) {
                 adapter.add(new ListPopup.Item(context, R.string.menu_custom_icon));
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/result/ResultWithTags.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ResultWithTags.java
@@ -16,6 +16,7 @@ import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.pojo.PojoWithTags;
+import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.SpaceTokenizer;
 import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
 
@@ -24,6 +25,14 @@ public abstract class ResultWithTags<T extends PojoWithTags> extends Result<T> {
     protected ResultWithTags(@NonNull T pojo) {
         super(pojo);
     }
+
+    @Override
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        super.buildPopupMenu(context, adapter);
+
+        adapter.add(new ListPopup.Item(context, R.string.menu_tags_edit));
+    }
+
 
     @Override
     boolean popupMenuClickHandler(Context context, RecordAdapter parent, @StringRes int stringId, View parentView) {

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -135,7 +135,7 @@ public class SearchResult extends Result<SearchPojo> {
     }
 
     private void setImage(Context context, ImageView image, int resId) {
-        image.setImageDrawable(getThemedDrawable(context, resId));
+        image.setImageDrawable(getThemedDrawable(context, pojo, resId));
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -28,6 +28,7 @@ import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.SearchPojo;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.ClipboardUtils;
@@ -229,10 +230,10 @@ public class SearchResult extends Result<SearchPojo> {
     }
 
     @Override
-    protected ListPopup buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
-        adapter.add(new ListPopup.Item(context, R.string.share));
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        super.buildPopupMenu(context, adapter);
 
-        return inflatePopupMenu(adapter, context);
+        adapter.add(new ListPopup.Item(context, R.string.share));
     }
 
     @Override
@@ -248,5 +249,20 @@ public class SearchResult extends Result<SearchPojo> {
         }
 
         return super.popupMenuClickHandler(context, parent, stringId, parentView);
+    }
+
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return false;
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return false;
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -262,7 +262,7 @@ public class SearchResult extends Result<SearchPojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
         return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SearchResult.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -30,6 +31,7 @@ import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
 import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.SearchPojo;
+import fr.neamar.kiss.pojo.SearchPojoType;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.ClipboardUtils;
 import fr.neamar.kiss.utils.Log;
@@ -39,6 +41,8 @@ import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
 public class SearchResult extends Result<SearchPojo> {
 
     private static final String TAG = SearchResult.class.getSimpleName();
+
+    private volatile Drawable icon = null;
 
     SearchResult(@NonNull SearchPojo pojo) {
         super(pojo);
@@ -52,78 +56,43 @@ public class SearchResult extends Result<SearchPojo> {
 
         TextView searchText = view.findViewById(R.id.item_search_text);
         ImageView image = view.findViewById(R.id.item_search_icon);
-        String text;
-        int pos;
-        int len;
 
         boolean hideIcons = isHideIcons(context);
         if (hideIcons) {
             image.setImageDrawable(null);
+        } else {
+            this.setAsyncDrawable(image);
         }
 
+        String text;
+        int pos;
+        int len;
         switch (pojo.type) {
             case URL_QUERY:
                 text = context.getString(R.string.ui_item_visit, this.pojo.getName());
                 pos = text.indexOf(this.pojo.getName());
                 len = this.pojo.getName().length();
-                if (!hideIcons) {
-                    setImage(context, image, R.drawable.ic_public);
-                    Intent intent = createSearchQueryIntent();
-                    Drawable icon = getIconByIntent(context, intent);
-                    if (icon != null) {
-                        image.setImageDrawable(icon);
-                    }
-                }
                 break;
             case SEARCH_QUERY:
                 text = context.getString(R.string.ui_item_search, this.pojo.getName(), pojo.query);
                 pos = text.indexOf(pojo.query);
                 len = pojo.query.length();
-                if (!hideIcons) {
-                    setImage(context, image, R.drawable.ic_search);
-                    Intent intent = createSearchQueryIntent();
-                    Drawable icon = getIconByIntent(context, intent);
-                    if (icon != null) {
-                        image.setImageDrawable(icon);
-                    }
-                }
                 break;
             case CALCULATOR_QUERY:
                 text = pojo.query;
                 pos = text.indexOf("=");
                 len = text.length() - pos;
-                if (!hideIcons) {
-                    setImage(context, image, R.drawable.ic_functions);
-                }
                 break;
             case TIMER_QUERY:
-                try {
-                    String elapsedTime = DateUtils.formatElapsedTime(Long.parseLong(pojo.url));
-                    text = context.getString(R.string.ui_item_timer, elapsedTime);
-                    pos = text.indexOf(elapsedTime);
-                    len = elapsedTime.length();
-                } catch (NumberFormatException e) {
-                    Log.w(TAG, "Invalid timer duration: " + pojo.url, e);
-                    text = pojo.query;
-                    pos = 0;
-                    len = text.length();
-                }
-                if (!hideIcons) {
-                    setImage(context, image, R.drawable.ic_timer);
-                }
+                String elapsedTime = DateUtils.formatElapsedTime(parseSeconds(pojo.url));
+                text = context.getString(R.string.ui_item_timer, elapsedTime);
+                pos = text.indexOf(elapsedTime);
+                len = elapsedTime.length();
                 break;
             case URI_QUERY:
                 text = context.getString(R.string.ui_item_open, this.pojo.query);
                 pos = text.indexOf(pojo.query);
                 len = pojo.query.length();
-                if (!hideIcons) {
-                    setImage(context, image, R.drawable.ic_public);
-                    Intent intent = createUriQueryIntent();
-                    Drawable icon = getIconByIntent(context, intent);
-                    if (icon != null) {
-                        image.setImageDrawable(icon);
-                    }
-                }
                 break;
             default:
                 throw new IllegalArgumentException("Following type isn't supported: " + pojo.type);
@@ -134,8 +103,30 @@ public class SearchResult extends Result<SearchPojo> {
         return view;
     }
 
-    private void setImage(Context context, ImageView image, int resId) {
-        image.setImageDrawable(getThemedDrawable(context, pojo, resId));
+    @Override
+    boolean isDrawableCached() {
+        return icon != null;
+    }
+
+    @Override
+    void setDrawableCache(Drawable drawable) {
+        icon = drawable;
+    }
+
+    @Override
+    public Drawable getDrawable(Context context) {
+        if (icon == null) {
+            synchronized (this) {
+                if (icon == null) {
+                    Intent intent = getLaunchIntent();
+                    icon = getIconByIntent(context, intent);
+                    if (icon == null) {
+                        icon = getThemedDrawable(context, pojo, pojo.type.getIconId());
+                    }
+                }
+            }
+        }
+        return icon;
     }
 
     /**
@@ -177,7 +168,8 @@ public class SearchResult extends Result<SearchPojo> {
      * @param intent
      * @return icon, of best matching app for given intent
      */
-    private Drawable getIconByIntent(Context context, Intent intent) {
+    @Nullable
+    private Drawable getIconByIntent(@NonNull Context context, @Nullable Intent intent) {
         ComponentName componentName = PackageManagerUtils.getComponentName(context, intent);
         if (componentName != null) {
             IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
@@ -191,41 +183,52 @@ public class SearchResult extends Result<SearchPojo> {
         switch (pojo.type) {
             case URL_QUERY:
             case SEARCH_QUERY:
-                Intent search = createSearchQueryIntent();
-                setSourceBounds(search, v);
-                try {
-                    context.startActivity(search);
-                } catch (ActivityNotFoundException e) {
-                    Log.w(TAG, "Unable to run search for url: " + pojo.url);
+            case TIMER_QUERY:
+            case URI_QUERY:
+                Intent intent = getLaunchIntent();
+                if (intent != null) {
+                    setSourceBounds(intent, v);
+                    try {
+                        context.startActivity(intent);
+                    } catch (ActivityNotFoundException e) {
+                        Log.w(TAG, "Unable to launch activity for " + pojo.type + "(query=" + pojo.query + ", url=" + pojo.url + ")");
+                    }
                 }
                 break;
             case CALCULATOR_QUERY:
                 ClipboardUtils.setClipboard(context, pojo.query.substring(pojo.query.indexOf("=") + 2));
                 Toast.makeText(context, R.string.copy_confirmation, Toast.LENGTH_SHORT).show();
                 break;
+        }
+    }
+
+    private Intent getLaunchIntent() {
+        switch (pojo.type) {
+            case URL_QUERY:
+            case SEARCH_QUERY:
+                return createSearchQueryIntent();
             case TIMER_QUERY:
-                try {
-                    int seconds = Integer.parseInt(pojo.url);
-                    Intent timerIntent = new Intent(AlarmClock.ACTION_SET_TIMER);
-                    timerIntent.putExtra(AlarmClock.EXTRA_LENGTH, seconds);
-                    timerIntent.putExtra(AlarmClock.EXTRA_SKIP_UI, true);
-                    String elapsedTime = DateUtils.formatElapsedTime(seconds);
-                    timerIntent.putExtra(AlarmClock.EXTRA_MESSAGE, elapsedTime);
-                    timerIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    context.startActivity(timerIntent);
-                } catch (ActivityNotFoundException | NumberFormatException e) {
-                    Log.w(TAG, "Unable to start timer for query: " + pojo.query, e);
-                }
-                break;
+                int seconds = parseSeconds(pojo.url);
+                Intent timerIntent = new Intent(AlarmClock.ACTION_SET_TIMER);
+                timerIntent.putExtra(AlarmClock.EXTRA_LENGTH, seconds);
+                timerIntent.putExtra(AlarmClock.EXTRA_SKIP_UI, true);
+                String elapsedTime = DateUtils.formatElapsedTime(seconds);
+                timerIntent.putExtra(AlarmClock.EXTRA_MESSAGE, elapsedTime);
+                timerIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                return timerIntent;
             case URI_QUERY:
-                Intent intent = createUriQueryIntent();
-                setSourceBounds(intent, v);
-                try {
-                    context.startActivity(intent);
-                } catch (ActivityNotFoundException e) {
-                    Log.w(TAG, "Unable to run search for uri: " + pojo.url);
-                }
-                break;
+                return createUriQueryIntent();
+            case CALCULATOR_QUERY:
+            default:
+                return null;
+        }
+    }
+
+    private int parseSeconds(@NonNull String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return 0;
         }
     }
 
@@ -263,6 +266,6 @@ public class SearchResult extends Result<SearchPojo> {
 
     @Override
     protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
-        return false;
+        return pojo.type == SearchPojoType.CALCULATOR_QUERY;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
@@ -47,7 +47,7 @@ public class SettingsResult extends Result<SettingPojo> {
     @Override
     public Drawable getDrawable(Context context) {
         if (pojo.icon != -1) {
-            return getThemedDrawable(context, pojo.icon);
+            return getThemedDrawable(context, pojo, pojo.icon);
         }
 
         return null;
@@ -82,6 +82,6 @@ public class SettingsResult extends Result<SettingPojo> {
 
     @Override
     protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
-        return false;
+        return true;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 
 import fr.neamar.kiss.R;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.SettingPojo;
 import fr.neamar.kiss.utils.Log;
 import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
@@ -67,5 +68,20 @@ public class SettingsResult extends Result<SettingPojo> {
             Log.w(TAG, "Unable to launch activity", e);
             Toast.makeText(context, R.string.application_not_found, Toast.LENGTH_LONG).show();
         }
+    }
+
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return true;
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return true;
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/SettingsResult.java
@@ -81,7 +81,7 @@ public class SettingsResult extends Result<SettingPojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
         return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -26,6 +26,7 @@ import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.adapter.RecordAdapter;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.ShortcutPojo;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.utils.DrawableUtils;
@@ -211,21 +212,15 @@ public class ShortcutsResult extends ResultWithTags<ShortcutPojo> {
     }
 
     @Override
-    ListPopup buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
-        if (!this.pojo.isDynamic() || this.pojo.isPinned()) {
-            adapter.add(new ListPopup.Item(context, R.string.menu_favorites_add));
-        }
-        adapter.add(new ListPopup.Item(context, R.string.menu_favorites_remove));
-        adapter.add(new ListPopup.Item(context, R.string.menu_tags_edit));
-        adapter.add(new ListPopup.Item(context, R.string.menu_remove));
+    protected void buildPopupMenu(Context context, ArrayAdapter<ListPopup.Item> adapter) {
+        super.buildPopupMenu(context, adapter);
+
         if (!this.pojo.isPinned() && this.pojo.isOreoShortcut() && !PackageManagerUtils.isPrivateProfile(context, this.pojo.getUserHandle())) {
             adapter.add(new ListPopup.Item(context, R.string.menu_shortcut_pin));
         }
         if (this.pojo.isPinned() && !PackageManagerUtils.isPrivateProfile(context, this.pojo.getUserHandle())) {
             adapter.add(new ListPopup.Item(context, R.string.menu_shortcut_remove));
         }
-
-        return inflatePopupMenu(adapter, context);
     }
 
     @Override
@@ -252,4 +247,18 @@ public class ShortcutsResult extends ResultWithTags<ShortcutPojo> {
         dataHandler.pinShortcut(pojo);
     }
 
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return !this.pojo.isDynamic() || this.pojo.isPinned();
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return true;
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return false;
+    }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -247,6 +247,9 @@ public class ShortcutsResult extends ResultWithTags<ShortcutPojo> {
         dataHandler.pinShortcut(pojo);
     }
 
+    /**
+     * @return true, if shortcut will not be changed by providing app anymore
+     */
     @Override
     protected boolean isAllowedAsFavorite() {
         return !this.pojo.isDynamic() || this.pojo.isPinned();
@@ -257,8 +260,11 @@ public class ShortcutsResult extends ResultWithTags<ShortcutPojo> {
         return true;
     }
 
+    /**
+     * @return true, if shortcut will not be changed by providing app anymore
+     */
     @Override
     protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
-        return false;
+        return isAllowedAsFavorite();
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ShortcutsResult.java
@@ -258,7 +258,7 @@ public class ShortcutsResult extends ResultWithTags<ShortcutPojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
         return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
@@ -17,6 +17,7 @@ import fr.neamar.kiss.IconsHandler;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.R;
+import fr.neamar.kiss.icons.IconPack;
 import fr.neamar.kiss.pojo.TagDummyPojo;
 import fr.neamar.kiss.utils.fuzzy.FuzzyScore;
 
@@ -72,7 +73,8 @@ public class TagDummyResult extends Result<TagDummyPojo> {
 
         ImageView favoriteBackground = favoriteView.findViewById(android.R.id.background);
         if (favoriteBackground != null) {
-            setAsyncDrawable(favoriteBackground, R.drawable.ic_launcher_white, true, this::isShapeCached, this::getShape, drawable -> {});
+            setAsyncDrawable(favoriteBackground, R.drawable.ic_launcher_white, true, this::isShapeCached, this::getShape, drawable -> {
+            });
         }
 
         TextView favoriteText = favoriteView.findViewById(android.R.id.text1);
@@ -120,5 +122,20 @@ public class TagDummyResult extends Result<TagDummyPojo> {
         if (context instanceof MainActivity) {
             ((MainActivity) context).showMatchingTags(pojo.getName());
         }
+    }
+
+    @Override
+    protected boolean isAllowedAsFavorite() {
+        return true;
+    }
+
+    @Override
+    protected boolean canRemoveFromHistory(Context context) {
+        return true;
+    }
+
+    @Override
+    protected boolean canHaveCustomIcon(IconPack iconPack) {
+        return false;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
@@ -98,7 +98,7 @@ public class TagDummyResult extends Result<TagDummyPojo> {
             synchronized (this) {
                 if (icon == null) {
                     IconsHandler iconsHandler = KissApplication.getApplication(context).getIconsHandler();
-                    icon = iconsHandler.getDrawableIconForCodepoint(pojo.getName().codePointAt(0), getTextColor(context), getBackgroundColor(context));
+                    icon = iconsHandler.getDrawableIconForCodepoint(pojo, getTextColor(context), getBackgroundColor(context));
                 }
             }
         }

--- a/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
+++ b/app/src/main/java/fr/neamar/kiss/result/TagDummyResult.java
@@ -135,7 +135,8 @@ public class TagDummyResult extends Result<TagDummyPojo> {
     }
 
     @Override
-    protected boolean canHaveCustomIcon(IconPack iconPack) {
-        return false;
+    protected boolean canHaveCustomIcon(Context context, IconPack iconPack) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return prefs.getBoolean("pref-fav-tags-drawable", false);
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -7,13 +7,12 @@ import android.os.AsyncTask;
 import androidx.annotation.CallSuper;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
@@ -141,10 +140,13 @@ public abstract class Searcher extends AsyncTask<Void, Result<?>, Void> {
             while (queue.size() > maxResults) {
                 queue.poll();
             }
-            List<Result<?>> results = queue.stream()
-                    .filter(Objects::nonNull)
-                    .map(pojo -> Result.fromPojo(activity, pojo))
-                    .collect(Collectors.toList());
+            List<Result<?>> results = new ArrayList<>(queue.size());
+            while (queue.peek() != null) {
+                Pojo pojo = queue.poll();
+                if (pojo != null) {
+                    results.add(Result.fromPojo(activity, pojo));
+                }
+            }
 
             activity.beforeListChange();
 

--- a/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/Searcher.java
@@ -7,12 +7,13 @@ import android.os.AsyncTask;
 import androidx.annotation.CallSuper;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
@@ -137,12 +138,13 @@ public abstract class Searcher extends AsyncTask<Void, Result<?>, Void> {
         } else {
             PriorityQueue<Pojo> queue = this.processedPojos;
             int maxResults = getMaxResultCount();
-            while (queue.size() > maxResults)
+            while (queue.size() > maxResults) {
                 queue.poll();
-            List<Result<?>> results = new ArrayList<>(queue.size());
-            while (queue.peek() != null) {
-                results.add(Result.fromPojo(activity, queue.poll()));
             }
+            List<Result<?>> results = queue.stream()
+                    .filter(Objects::nonNull)
+                    .map(pojo -> Result.fromPojo(activity, pojo))
+                    .collect(Collectors.toList());
 
             activity.beforeListChange();
 

--- a/app/src/main/java/fr/neamar/kiss/utils/IconPackCache.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/IconPackCache.java
@@ -28,7 +28,7 @@ public class IconPackCache {
     public void clearCache(KissApplication app) {
         mCache.evictAll();
         IconPack customIconPack = app.getIconsHandler().getIconPack();
-        if (customIconPack.isSystemIconPack())
+        if (!customIconPack.isSystemIconPack())
             mCache.put(customIconPack.getPackPackageName(), customIconPack);
     }
 

--- a/app/src/main/java/fr/neamar/kiss/utils/PackageManagerUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/PackageManagerUtils.java
@@ -47,7 +47,8 @@ public class PackageManagerUtils {
      * @param intent  intent
      * @return ResolveInfo for best matching app by intent
      */
-    public static ResolveInfo getBestResolve(Context context, Intent intent) {
+    @Nullable
+    public static ResolveInfo getBestResolve(@NonNull Context context, @Nullable Intent intent) {
         if (intent == null) {
             return null;
         }
@@ -93,7 +94,7 @@ public class PackageManagerUtils {
      * @return component name of best matching app for given intent
      */
     @Nullable
-    public static ComponentName getComponentName(Context context, Intent intent) {
+    public static ComponentName getComponentName(@NonNull Context context, @Nullable Intent intent) {
         ResolveInfo resolveInfo = getBestResolve(context, intent);
         if (resolveInfo != null && resolveInfo.activityInfo != null) {
             return new ComponentName(resolveInfo.activityInfo.packageName, resolveInfo.activityInfo.name);

--- a/app/src/main/res/drawable/ic_timer.xml
+++ b/app/src/main/res/drawable/ic_timer.xml
@@ -1,9 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="#FFFFFF">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="@android:color/white"
         android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8zM12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z"/>
 </vector>


### PR DESCRIPTION
- enable custom icons for tags (if `Generate icons for fav tags` is enabled in settings)
- enable custom icons for shortcuts (which are pinned or not created dynamically)
- enable custom icons for phone result (when searching for phone number)
- enable custom icons for settings results
- enable custom icons for contact results (when default icon is visible)
- relates to #1314, #1624, #1779, #1881, #2441
<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
