### PR TITLE
Add support for percentage based calculation, e.g. 80 + 20%

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
+++ b/app/src/main/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProvider.java
@@ -3,6 +3,7 @@ package fr.neamar.kiss.dataprovider.simpleprovider;
 import androidx.annotation.VisibleForTesting;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.text.NumberFormat;
 import java.util.ArrayDeque;
 import java.util.regex.Matcher;
@@ -21,13 +22,18 @@ public class CalculatorProvider extends SimpleProvider<SearchPojo> {
     final Pattern computableRegexp;
     // A regexp to detect plain numbers (including phone numbers)
     private final Pattern numberOnlyRegexp;
+    // Trailing "+ N%" / "- N%" applied to the preceding base expression.
+    // Group 1: base expression (must not contain '%'). Group 2: '+' or '-'. Group 3: percentage value.
+    private final Pattern trailingPercentRegexp;
     private final NumberFormat LOCALIZED_NUMBER_FORMATTER = NumberFormat.getInstance();
+    private static final BigDecimal HUNDRED = new BigDecimal(100);
 
     public CalculatorProvider() {
         //This should try to match as much as possible without going out of the expression,
         //even if the expression is not actually a computable operation.
         computableRegexp = Pattern.compile("^[\\-.,\\d+*×x/÷^'()%]+$");
         numberOnlyRegexp = Pattern.compile("^\\+?[.,()\\d]+$");
+        trailingPercentRegexp = Pattern.compile("^([^%]+?)([+\\-])(\\d+(?:[.,]\\d+)?)%$");
     }
 
     @Override
@@ -41,40 +47,47 @@ public class CalculatorProvider extends SimpleProvider<SearchPojo> {
             }
 
             String operation = m.group();
-
-            Result<ArrayDeque<Tokenizer.Token>> tokenized = Tokenizer.tokenize(operation);
-            String readableResult;
-
-            if (tokenized.syntacticalError) {
+            BigDecimal value = compute(operation);
+            if (value == null) {
                 return;
-            } else if (tokenized.arithmeticalError) {
-                return;
-            } else {
-                Result<ArrayDeque<Tokenizer.Token>> posfixed = ShuntingYard.infixToPostfix(tokenized.result);
-
-                if (posfixed.syntacticalError) {
-                    return;
-                } else if (posfixed.arithmeticalError) {
-                    return;
-                } else {
-                    Result<BigDecimal> result = Calculator.calculateExpression(posfixed.result);
-
-                    if (result.syntacticalError) {
-                        return;
-                    } else if (result.arithmeticalError) {
-                        return;
-                    } else {
-                        String localizedNumber = LOCALIZED_NUMBER_FORMATTER.format(result.result);
-                        readableResult = " = " + localizedNumber;
-                    }
-                }
             }
 
-            String queryProcessed = operation + readableResult;
+            String queryProcessed = operation + " = " + LOCALIZED_NUMBER_FORMATTER.format(value);
             SearchPojo pojo = new SearchPojo("calculator://", queryProcessed, "", SearchPojoType.CALCULATOR_QUERY);
 
             pojo.relevance = 19;
             searcher.addResult(pojo);
         }
+    }
+
+    @VisibleForTesting
+    BigDecimal compute(String spacelessQuery) {
+        Matcher percentMatcher = trailingPercentRegexp.matcher(spacelessQuery);
+        if (percentMatcher.matches()) {
+            BigDecimal base = evaluate(percentMatcher.group(1));
+            if (base == null) {
+                return null;
+            }
+            BigDecimal percent = new BigDecimal(percentMatcher.group(3).replace(",", "."));
+            BigDecimal delta = base.multiply(percent).divide(HUNDRED, MathContext.DECIMAL32);
+            return percentMatcher.group(2).equals("+") ? base.add(delta) : base.subtract(delta);
+        }
+        return evaluate(spacelessQuery);
+    }
+
+    private static BigDecimal evaluate(String expression) {
+        Result<ArrayDeque<Tokenizer.Token>> tokenized = Tokenizer.tokenize(expression);
+        if (tokenized.syntacticalError || tokenized.arithmeticalError) {
+            return null;
+        }
+        Result<ArrayDeque<Tokenizer.Token>> postfixed = ShuntingYard.infixToPostfix(tokenized.result);
+        if (postfixed.syntacticalError || postfixed.arithmeticalError) {
+            return null;
+        }
+        Result<BigDecimal> result = Calculator.calculateExpression(postfixed.result);
+        if (result.syntacticalError || result.arithmeticalError) {
+            return null;
+        }
+        return result.result;
     }
 }

--- a/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
+++ b/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
@@ -68,9 +68,14 @@ public class CalculatorProviderTest {
 				Arguments.of("100-100%", "0"),
 				Arguments.of("100+0%", "100"),
 
+				// Negative base: percentage is applied with the base's sign
+				Arguments.of("-5+10%", "-5.5"),
+
 				// Pattern doesn't match: % keeps its modulo meaning
 				Arguments.of("17%5", "2"),
-				Arguments.of("100%5", "0")
+				Arguments.of("100%5", "0"),
+				// Trailing char after % blocks the percent path; falls through to modulo
+				Arguments.of("5+2%2", "5")
 		);
 	}
 

--- a/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
+++ b/app/src/test/java/fr/neamar/kiss/dataprovider/simpleprovider/CalculatorProviderTest.java
@@ -1,18 +1,22 @@
 package fr.neamar.kiss.dataprovider.simpleprovider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.math.BigDecimal;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public class CalculatorProviderTest {
-	private static final Pattern pattern = new CalculatorProvider().computableRegexp;
+	private static final CalculatorProvider provider = new CalculatorProvider();
+	private static final Pattern pattern = provider.computableRegexp;
 
 	@ParameterizedTest
 	@MethodSource("expressionProvider")
@@ -42,6 +46,47 @@ public class CalculatorProviderTest {
 				Arguments.of("89.*(1+1)/2.", "89.*(1+1)/2."),
 
 				Arguments.of("8,009.*(1+1)/2.", "8,009.*(1+1)/2.")
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("percentageProvider")
+	public void testPercentage(String expression, String expected) {
+		BigDecimal value = provider.compute(expression);
+		assertThat(value, comparesEqualTo(new BigDecimal(expected)));
+	}
+
+	private static Stream<Arguments> percentageProvider() {
+		return Stream.of(
+				// Trailing +/- N% applied to the base
+				Arguments.of("100+10%", "110"),
+				Arguments.of("200-25%", "150"),
+				Arguments.of("(50+50)+10%", "110"),
+				Arguments.of("1500*2-10%", "2700"),
+				Arguments.of("100+12.5%", "112.5"),
+				Arguments.of("100+12,5%", "112.5"),
+				Arguments.of("100-100%", "0"),
+				Arguments.of("100+0%", "100"),
+
+				// Pattern doesn't match: % keeps its modulo meaning
+				Arguments.of("17%5", "2"),
+				Arguments.of("100%5", "0")
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("rejectedProvider")
+	public void testRejected(String expression) {
+		assertThat(provider.compute(expression), is(nullValue()));
+	}
+
+	private static Stream<Arguments> rejectedProvider() {
+		return Stream.of(
+				// Multiple %: trailing-% pattern doesn't match (base would contain '%'),
+				// fall-through evaluates 100 mod 0 (from the inner 10%+5...) -> arithmetic error.
+				Arguments.of("100+10%+5%"),
+				// Pattern matches but base is malformed -> no result.
+				Arguments.of("100++10%")
 		);
 	}
 }


### PR DESCRIPTION
Skip all complex cases (like 5+2%*8%/2) that would lead to non-sensical math. Any serious scientist shouldn't use this, but this can be helpful for tax/discount/tipping: 85.25+6% works as expected.

Modulo is still available when used as an operator. Overall, I tried to maintain 'normal scientific behavior' everywhere, and only graft the percent mechanism where it's obviously user intent.

Edge case: 5+2%2 will be 5 (5 plus two modulus two), even though the final two may be a typo here.