### PR TITLE
Hide unused tags from settings

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -982,7 +982,7 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
         }
     }
 
-    private Pojo getPojo(String id) {
+    public Pojo getPojo(String id) {
         // Ask all providers if they know this id
         for (ProviderEntry entry : this.providers.values()) {
             if (entry.provider != null && entry.provider.mayFindById(id)) {

--- a/app/src/main/java/fr/neamar/kiss/TagsHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/TagsHandler.java
@@ -74,6 +74,31 @@ public class TagsHandler {
         return tags;
     }
 
+    /**
+     * Tags whose record id still resolves to a known pojo. Drops orphans
+     * (e.g. tags from uninstalled apps) so settings pickers don't list them.
+     * Falls back to {@link #getAllTagsAsSet()} until every provider is loaded,
+     * because we can't tell live ids from orphans before then.
+     */
+    public Set<String> getValidTagsAsSet() {
+        DataHandler dataHandler = KissApplication.getApplication(context).getDataHandler();
+        if (!dataHandler.isAllProvidersLoaded()) {
+            return getAllTagsAsSet();
+        }
+        Set<String> tags = new HashSet<>();
+        for (Map.Entry<String, String> entry : tagsCache.entrySet()) {
+            String value = entry.getValue();
+            if (TextUtils.isEmpty(value)) {
+                continue;
+            }
+            if (dataHandler.getPojo(entry.getKey()) == null) {
+                continue;
+            }
+            tags.addAll(Arrays.asList(value.split("\\s+")));
+        }
+        return tags;
+    }
+
     public Map<String, String> getTags() {
         return tagsCache;
     }

--- a/app/src/main/java/fr/neamar/kiss/preference/TagsSelectPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/TagsSelectPreference.java
@@ -39,10 +39,10 @@ public class TagsSelectPreference extends MultiSelectListPreference {
     }
 
     private void setEntries() {
-        // get all possible tags
+        // get all possible tags, hiding tags only attached to records that no longer exist
         Set<String> tagsSet = getDataHandler()
                 .getTagsHandler()
-                .getAllTagsAsSet();
+                .getValidTagsAsSet();
 
         // make sure we can toggle off the tags that are in the favs now
         Set<String> selectedTags = getSelectedTags();


### PR DESCRIPTION
If you've used KISS for a long time, you can get to a state where many tags displayed don't actually have any associated record.
This filters them out at display (so tags can still 'resurrect' if you install back a previously tagged application).
Any tag the user has currently selected remains added no matter what.


<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->