### PR TITLE
Respect tag hiding behavior when selecting a favorite tag

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/ResultWithTags.java
+++ b/app/src/main/java/fr/neamar/kiss/result/ResultWithTags.java
@@ -83,7 +83,7 @@ public abstract class ResultWithTags<T extends PojoWithTags> extends Result<T> {
         if (TextUtils.isEmpty(pojo.getTags())) {
             tagsView.setVisibility(View.GONE);
         } else if (displayHighlighted(pojo.getNormalizedTags(), pojo.getTags(),
-                fuzzyScore, tagsView, context) || isTagsVisible(context)) {
+                fuzzyScore, tagsView, context) && isTagsVisible(context)) {
             tagsView.setVisibility(View.VISIBLE);
         } else {
             tagsView.setVisibility(View.GONE);


### PR DESCRIPTION
Rather simple - so much so that I'm wondering whether this is intended behavior I'm misunderstanding.

Currently, when disabling "Show tags" from the User Experience menu, it correctly hides tags in search results... but not for favorite tags. This comes up a lot for me as 3 out of 6 of my quick launch are all favorite tags. 

<img width="579" height="283" alt="image" src="https://github.com/user-attachments/assets/58354ed4-db68-47bc-8003-8961ba792290" />

With this change we hide tags in all contexts (including with favorites) if Show Tags is disabled.

<img width="603" height="317" alt="image" src="https://github.com/user-attachments/assets/db5577d3-722f-450b-9fc0-7dc0cd588c6c" />

If showing tags when a favorite is selected is actually the intended behavior, I can instead break this out into a separate config option - but that seems less clean overall.
