### PR TITLE
add toggle to demote disabled and suspended apps

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/result/Result.java
+++ b/app/src/main/java/fr/neamar/kiss/result/Result.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
@@ -389,7 +390,9 @@ public abstract class Result<T extends Pojo> {
 
     protected final void recordLaunch(Context context, @Nullable QueryInterface queryInterface) {
         // Save in history
-        if (canAddToHistory()) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean demoteDisabled = prefs.getBoolean("demote-disabled-apps", true);
+        if (canAddToHistory() || (!demoteDisabled && pojo.isDisabled())) {
             KissApplication.getApplication(context).getDataHandler().addToHistory(pojo.getHistoryId());
         }
         // Record the launch after some period,

--- a/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/HistorySearcher.java
@@ -92,10 +92,11 @@ public class HistorySearcher extends Searcher {
             return false;
         }
 
+        boolean demoteDisabled = prefs.getBoolean("demote-disabled-apps", true);
         DataHandler dataHandler = KissApplication.getApplication(activity).getDataHandler();
         if (dataHandler.getHistoryMode() != HistoryMode.ALPHABETICALLY) {
             for (Pojo pojo : pojos) {
-                if (pojo.isDisabled()) {
+                if (pojo.isDisabled() && demoteDisabled) {
                     // Give penalty for disabled items, these should not be preferred
                     pojo.relevance -= 200;
                 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -49,10 +49,13 @@ public class QuerySearcher extends Searcher {
 
     @Override
     public boolean addResults(List<? extends Pojo> pojos) {
+        boolean demoteDisabled = prefs.getBoolean("demote-disabled-apps", true);
         for (Pojo pojo : pojos) {
             if (pojo.isDisabled()) {
-                // Give penalty for disabled items, these should not be preferred
-                pojo.relevance -= 200;
+                if (demoteDisabled) {
+                    // Give penalty for disabled items, these should not be preferred
+                    pojo.relevance -= 200;
+                }
             } else {
                 // Give a boost if item was previously selected for this query
                 Integer value = knownIds.get(pojo.id);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="contacts_name">Contacts</string>
     <string name="contacts_call_on_click">Click to call contacts</string>
     <string name="search_results_options">Search results</string>
+    <string name="demote_disabled_apps">Demote suspended/disabled apps</string>
+    <string name="demote_disabled_apps_summary">Lower priority of apps in focus mode/frozen in search results</string>
     <string name="search_name">Web search providers</string>
     <string name="search_provider_toggle">Links to web search providers</string>
     <string name="settings_name">Device settings</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -160,6 +160,11 @@
                 app:key="pref-result-highlighting"
                 app:summary="@string/pref_result_highlighting_summary"
                 app:title="@string/pref_result_highlighting" />
+            <SwitchPreference
+                app:defaultValue="true"
+                app:key="demote-disabled-apps"
+                app:summary="@string/demote_disabled_apps_summary"
+                app:title="@string/demote_disabled_apps" />
         </PreferenceCategory>
         <PreferenceCategory
             app:key="colors-section"


### PR DESCRIPTION
KISS currently automatically demotes suspended and disabled apps from search results.  This PR adds the ability to toggle this behaviour "off".

I added this for myself because i use digital well being features to basically suspend almost all apps after 5 minutes.  And this feature allows me to quickly open them up through KISS search restuls when required.

Tested on google pixel 9a.

AI was used to make the changes.
