### PR TITLE
Infinite scrolling for widgets, operated by two-finger scrolling gestures

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/ForwarderManager.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.forwarder;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.view.ContextMenu;
@@ -33,6 +34,18 @@ public class ForwarderManager extends Forwarder {
         this.shortcutsForwarder = new OreoShortcuts(mainActivity);
         this.notificationForwarder = new Notification(mainActivity);
         this.tagsMenu = new TagsMenu(mainActivity);
+
+        // empty areas of the widget scroll area behave as a non-widget area
+        widgetsForwarder.setEmptyAreaTouchListener(new View.OnTouchListener() {
+            // click semantics are owned by the gesture pipeline the events are forwarded to
+            @SuppressLint("ClickableViewAccessibility")
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                experienceTweaks.onTouch(event);
+                liveWallpaperForwarder.onTouch(v, event);
+                return true;
+            }
+        });
     }
 
     public void onCreate() {
@@ -49,6 +62,7 @@ public class ForwarderManager extends Forwarder {
     }
 
     public void onResume() {
+        widgetsForwarder.onResume();
         interfaceTweaks.onResume();
         experienceTweaks.onResume();
         notificationForwarder.onResume();

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -67,7 +67,7 @@ class Widgets extends Forwarder {
 
     private static final String DEFAULT_WIDGET_SPACING = "0";
     private static final int MIN_WIDGET_SPACING_DP = 0;
-    private static final int MAX_WIDGET_SPACING_DP = 50;
+    private static final int MAX_WIDGET_SPACING_DP = 300;
 
     /**
      * Widgets fields

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -39,8 +39,10 @@ import fr.neamar.kiss.PickAppWidgetActivity;
 import fr.neamar.kiss.R;
 import fr.neamar.kiss.ui.ListPopup;
 import fr.neamar.kiss.ui.WidgetHost;
+import fr.neamar.kiss.ui.WidgetScrollView;
 import fr.neamar.kiss.utils.DrawableUtils;
 import fr.neamar.kiss.utils.Log;
+import fr.neamar.kiss.utils.WidgetUtils;
 
 class Widgets extends Forwarder {
     private static final String TAG = Widgets.class.getSimpleName();
@@ -54,6 +56,20 @@ class Widgets extends Forwarder {
     private static final int INITIAL_WIDGET_LINE_SIZE = 2;
 
     /**
+     * Preference key: whether the widget area can be scrolled vertically
+     */
+    private static final String PREF_ENABLE_SCROLLING = "enable-widget-scrolling";
+
+    /**
+     * Preference key: vertical spacing between widgets, in dp
+     */
+    private static final String PREF_WIDGET_SPACING = "widget-spacing";
+
+    private static final String DEFAULT_WIDGET_SPACING = "10";
+    private static final int MIN_WIDGET_SPACING_DP = 0;
+    private static final int MAX_WIDGET_SPACING_DP = 50;
+
+    /**
      * Widgets fields
      */
     private AppWidgetManager mAppWidgetManager;
@@ -63,6 +79,15 @@ class Widgets extends Forwarder {
      * View widgets are added to
      */
     private ViewGroup widgetArea;
+    /**
+     * Scrollable container around {@link #widgetArea}
+     */
+    private WidgetScrollView widgetScroll;
+    /**
+     * Touch listener for gestures on empty areas, buffered until {@code widgetScroll} is available
+     */
+    @Nullable
+    private View.OnTouchListener emptyAreaTouchListener;
     private ActivityResultLauncher<Intent> requestAppWidgetPicked;
     private ActivityResultLauncher<Intent> requestAppWidgetBound;
 
@@ -75,11 +100,80 @@ class Widgets extends Forwarder {
         mAppWidgetManager = AppWidgetManager.getInstance(mainActivity);
         mAppWidgetHost = new WidgetHost(mainActivity, APPWIDGET_HOST_ID, this::onAppWidgetRemoved);
         widgetArea = mainActivity.findViewById(R.id.widgetLayout);
+        widgetScroll = mainActivity.findViewById(R.id.widgetScroll);
+        if (emptyAreaTouchListener != null) {
+            widgetScroll.setEmptyAreaTouchListener(emptyAreaTouchListener);
+        }
 
         requestAppWidgetPicked = mainActivity.registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> appWidgetPicked(activityResult.getResultCode(), activityResult.getData()));
         requestAppWidgetBound = mainActivity.registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> appWidgetBound(activityResult.getResultCode(), activityResult.getData()));
 
+        applyScrollingConfig();
+
         restoreWidgets();
+    }
+
+    /**
+     * Push the scrolling-related settings into the widget area.
+     * Called on create and on resume so settings changes apply immediately.
+     */
+    void onResume() {
+        applyScrollingConfig();
+    }
+
+    private void applyScrollingConfig() {
+        widgetScroll.setScrollingEnabled(isScrollingEnabled());
+        applyWidgetSpacing();
+    }
+
+    private boolean isScrollingEnabled() {
+        return prefs.getBoolean(PREF_ENABLE_SCROLLING, true);
+    }
+
+    /**
+     * Forward gestures performed on empty areas of the widget scroll area to
+     * the given listener, so they behave exactly as on a non-widget area.
+     *
+     * May be called before the view exists; it is attached in
+     * {@link #onCreate()} once the view is available.
+     */
+    void setEmptyAreaTouchListener(View.OnTouchListener listener) {
+        emptyAreaTouchListener = listener;
+        if (widgetScroll != null) {
+            widgetScroll.setEmptyAreaTouchListener(listener);
+        }
+    }
+
+    private int getWidgetSpacing() {
+        int spacing;
+        try {
+            spacing = Integer.parseInt(prefs.getString(PREF_WIDGET_SPACING, DEFAULT_WIDGET_SPACING));
+        } catch (NumberFormatException e) {
+            spacing = Integer.parseInt(DEFAULT_WIDGET_SPACING);
+        }
+        return Math.max(MIN_WIDGET_SPACING_DP, Math.min(MAX_WIDGET_SPACING_DP, spacing));
+    }
+
+    /**
+     * Effective spacing between widgets in pixels.
+     *
+     * Adjustable spacing is part of the scrolling feature: with scrolling
+     * disabled, stock KISS behavior applies (widgets stacked edge-to-edge).
+     */
+    private int getWidgetSpacingPx() {
+        return isScrollingEnabled() ? DrawableUtils.dpToPx(mainActivity, getWidgetSpacing()) : 0;
+    }
+
+    private void applyWidgetSpacing() {
+        int margin = getWidgetSpacingPx();
+        for (int i = 0; i < widgetArea.getChildCount(); i++) {
+            View child = widgetArea.getChildAt(i);
+            ViewGroup.LayoutParams params = child.getLayoutParams();
+            if (params instanceof LinearLayout.LayoutParams) {
+                ((LinearLayout.LayoutParams) params).bottomMargin = margin;
+                child.setLayoutParams(params);
+            }
+        }
     }
 
     private void onAppWidgetRemoved() {
@@ -360,7 +454,8 @@ class Widgets extends Forwarder {
     private void setWidgetSize(AppWidgetHostView hostView, int height, @NonNull AppWidgetProviderInfo appWidgetInfo) {
         hostView.setMinimumHeight(height);
         hostView.setMinimumWidth(Math.min(appWidgetInfo.minWidth, appWidgetInfo.minResizeWidth));
-        ViewGroup.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height);
+        params.bottomMargin = getWidgetSpacingPx();
         hostView.setLayoutParams(params);
     }
 
@@ -412,25 +507,47 @@ class Widgets extends Forwarder {
      * @param appWidgetInfo
      */
     private void addAppWidget(int appWidgetId, AppWidgetProviderInfo appWidgetInfo) {
-        // calculate already used lines
-        int usedLines = 0;
-        for (int i = 0; i < widgetArea.getChildCount(); i++) {
-            View view = widgetArea.getChildAt(i);
-            usedLines += getLineSize(view);
-        }
-        // calculate max available lines
-        int maxVisibleLines = (int) Math.ceil(widgetArea.getHeight() / getLineHeight());
+        boolean upsizeAllowed = !preventIncreaseLineHeight((int) ((INITIAL_WIDGET_LINE_SIZE - 1) * getLineHeight()), appWidgetInfo);
 
         // calculate initial size for new widget
-        int initialLineSize = getLineSize(getMinHeight(appWidgetInfo));
-        if (initialLineSize < INITIAL_WIDGET_LINE_SIZE && !preventIncreaseLineHeight((int) ((INITIAL_WIDGET_LINE_SIZE - 1) * getLineHeight()), appWidgetInfo)) {
-            initialLineSize = INITIAL_WIDGET_LINE_SIZE;
+        int initialLineSize = WidgetUtils.getInitialLineSize(getMinHeight(appWidgetInfo), getLineHeight(), upsizeAllowed, INITIAL_WIDGET_LINE_SIZE);
+
+        if (!isScrollingEnabled()) {
+            // legacy behavior: widgets cannot be scrolled into view, so they must fit the visible viewport
+            int usedLines = 0;
+            for (int i = 0; i < widgetArea.getChildCount(); i++) {
+                usedLines += getLineSize(widgetArea.getChildAt(i));
+            }
+            int maxVisibleLines = (int) Math.ceil(widgetArea.getHeight() / getLineHeight());
+            initialLineSize = Math.max(1, Math.min(maxVisibleLines - usedLines, initialLineSize));
         }
-        initialLineSize = Math.max(1, Math.min(maxVisibleLines - usedLines, initialLineSize));
 
         addWidget(appWidgetId, initialLineSize);
 
         serializeState();
+
+        if (isScrollingEnabled()) {
+            scrollIntoView(widgetArea.getChildAt(widgetArea.getChildCount() - 1));
+        }
+    }
+
+    /**
+     * Scroll the given widget into view, centered vertically.
+     *
+     * Uses a one-shot layout listener instead of {@link View#post(Runnable)} to
+     * guarantee the child has been measured and positioned before computing the
+     * scroll target ({@code view.getBottom()} is stale before layout).
+     */
+    private void scrollIntoView(View view) {
+        view.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View v, int left, int top, int right, int bottom,
+                    int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                v.removeOnLayoutChangeListener(this);
+                widgetScroll.smoothScrollTo(0,
+                        v.getBottom() - (widgetScroll.getHeight() - v.getHeight()) / 2);
+            }
+        });
     }
 
     private void requestBindWidget(@NonNull Intent data) {
@@ -526,7 +643,7 @@ class Widgets extends Forwarder {
      * @return calculated line size of given height
      */
     private int getLineSize(int height) {
-        return Math.max(1, (int) Math.ceil(height / getLineHeight()));
+        return WidgetUtils.getLineSize(height, getLineHeight());
     }
 
     /**
@@ -537,14 +654,11 @@ class Widgets extends Forwarder {
     }
 
     private int getMinHeight(AppWidgetProviderInfo appWidgetInfo) {
-        float lineHeight = getLineHeight();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && appWidgetInfo.targetCellHeight > 0) {
-            return (int) (appWidgetInfo.targetCellHeight * lineHeight);
-        } else if (appWidgetInfo.minHeight == 0) {
-            return 0;
-        } else {
-            return (int) (getLineSize(appWidgetInfo.minHeight) * lineHeight);
+        int targetCellHeight = 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            targetCellHeight = appWidgetInfo.targetCellHeight;
         }
+        return WidgetUtils.getMinHeight(appWidgetInfo.minHeight, targetCellHeight, getLineHeight());
     }
 
     public void onStart() {

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -65,7 +65,7 @@ class Widgets extends Forwarder {
      */
     private static final String PREF_WIDGET_SPACING = "widget-spacing";
 
-    private static final String DEFAULT_WIDGET_SPACING = "10";
+    private static final String DEFAULT_WIDGET_SPACING = "0";
     private static final int MIN_WIDGET_SPACING_DP = 0;
     private static final int MAX_WIDGET_SPACING_DP = 50;
 

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -56,11 +56,6 @@ class Widgets extends Forwarder {
     private static final int INITIAL_WIDGET_LINE_SIZE = 2;
 
     /**
-     * Preference key: whether the widget area can be scrolled vertically
-     */
-    private static final String PREF_ENABLE_SCROLLING = "enable-widget-scrolling";
-
-    /**
      * Preference key: vertical spacing between widgets, in dp
      */
     private static final String PREF_WIDGET_SPACING = "widget-spacing";
@@ -108,26 +103,42 @@ class Widgets extends Forwarder {
         requestAppWidgetPicked = mainActivity.registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> appWidgetPicked(activityResult.getResultCode(), activityResult.getData()));
         requestAppWidgetBound = mainActivity.registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), activityResult -> appWidgetBound(activityResult.getResultCode(), activityResult.getData()));
 
-        applyScrollingConfig();
+        // Automatically enable scrolling when widgets overflow the viewport,
+        // disable when they fit.  The listener fires after every layout pass
+        // (add, remove, resize, rotation) and keeps the touch contract in sync.
+        widgetArea.getViewTreeObserver().addOnGlobalLayoutListener(() ->
+                widgetScroll.setScrollingEnabled(shouldScroll()));
 
         restoreWidgets();
     }
 
-    /**
-     * Push the scrolling-related settings into the widget area.
-     * Called on create and on resume so settings changes apply immediately.
-     */
     void onResume() {
-        applyScrollingConfig();
-    }
-
-    private void applyScrollingConfig() {
-        widgetScroll.setScrollingEnabled(isScrollingEnabled());
         applyWidgetSpacing();
     }
 
-    private boolean isScrollingEnabled() {
-        return prefs.getBoolean(PREF_ENABLE_SCROLLING, true);
+    /**
+     * Whether the total widget height exceeds the visible viewport.
+     * Drives {@link WidgetScrollView#setScrollingEnabled(boolean)} so the
+     * two-finger scroll gesture is only active when needed.
+     */
+    private boolean shouldScroll() {
+        if (widgetArea.getChildCount() == 0) return false;
+        return getTotalWidgetHeight() > widgetScroll.getHeight();
+    }
+
+    /**
+     * Sum of all widget heights including bottom margins.
+     */
+    private int getTotalWidgetHeight() {
+        int total = 0;
+        for (int i = 0; i < widgetArea.getChildCount(); i++) {
+            View child = widgetArea.getChildAt(i);
+            total += child.getLayoutParams().height;
+            if (child.getLayoutParams() instanceof LinearLayout.LayoutParams) {
+                total += ((LinearLayout.LayoutParams) child.getLayoutParams()).bottomMargin;
+            }
+        }
+        return total;
     }
 
     /**
@@ -156,12 +167,9 @@ class Widgets extends Forwarder {
 
     /**
      * Effective spacing between widgets in pixels.
-     *
-     * Adjustable spacing is part of the scrolling feature: with scrolling
-     * disabled, stock KISS behavior applies (widgets stacked edge-to-edge).
      */
     private int getWidgetSpacingPx() {
-        return isScrollingEnabled() ? DrawableUtils.dpToPx(mainActivity, getWidgetSpacing()) : 0;
+        return DrawableUtils.dpToPx(mainActivity, getWidgetSpacing());
     }
 
     private void applyWidgetSpacing() {
@@ -512,23 +520,13 @@ class Widgets extends Forwarder {
         // calculate initial size for new widget
         int initialLineSize = WidgetUtils.getInitialLineSize(getMinHeight(appWidgetInfo), getLineHeight(), upsizeAllowed, INITIAL_WIDGET_LINE_SIZE);
 
-        if (!isScrollingEnabled()) {
-            // existing behavior: widgets cannot be scrolled into view, so they must fit the visible viewport
-            int usedLines = 0;
-            for (int i = 0; i < widgetArea.getChildCount(); i++) {
-                usedLines += getLineSize(widgetArea.getChildAt(i));
-            }
-            int maxVisibleLines = (int) Math.ceil(widgetArea.getHeight() / getLineHeight());
-            initialLineSize = Math.max(1, Math.min(maxVisibleLines - usedLines, initialLineSize));
-        }
-
         addWidget(appWidgetId, initialLineSize);
 
         serializeState();
 
-        if (isScrollingEnabled()) {
-            scrollIntoView(widgetArea.getChildAt(widgetArea.getChildCount() - 1));
-        }
+        // Scroll the new widget into view.  When content fits the viewport
+        // this is a no-op; when it overflows the scroll view shows the widget.
+        scrollIntoView(widgetArea.getChildAt(widgetArea.getChildCount() - 1));
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
+++ b/app/src/main/java/fr/neamar/kiss/forwarder/Widgets.java
@@ -513,7 +513,7 @@ class Widgets extends Forwarder {
         int initialLineSize = WidgetUtils.getInitialLineSize(getMinHeight(appWidgetInfo), getLineHeight(), upsizeAllowed, INITIAL_WIDGET_LINE_SIZE);
 
         if (!isScrollingEnabled()) {
-            // legacy behavior: widgets cannot be scrolled into view, so they must fit the visible viewport
+            // existing behavior: widgets cannot be scrolled into view, so they must fit the visible viewport
             int usedLines = 0;
             for (int i = 0; i < widgetArea.getChildCount(); i++) {
                 usedLines += getLineSize(widgetArea.getChildAt(i));

--- a/app/src/main/java/fr/neamar/kiss/preference/RangeEditTextPreference.java
+++ b/app/src/main/java/fr/neamar/kiss/preference/RangeEditTextPreference.java
@@ -1,0 +1,90 @@
+package fr.neamar.kiss.preference;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.EditTextPreference;
+
+import fr.neamar.kiss.R;
+
+/**
+ * An {@link EditTextPreference} that validates the entered integer is within
+ * a configured {@code [minValue, maxValue]} range before persisting.
+ * <p>
+ * When the user enters a value outside the range, the value is clamped to
+ * the nearest bound and a toast informs the user.
+ * <p>
+ * Custom XML attributes (defined in {@code res/values/attrs.xml}):
+ * <ul>
+ *     <li>{@code app:minValue} — inclusive lower bound (default {@link Integer#MIN_VALUE})</li>
+ *     <li>{@code app:maxValue} — inclusive upper bound (default {@link Integer#MAX_VALUE})</li>
+ * </ul>
+ */
+public class RangeEditTextPreference extends EditTextPreference {
+
+    private int minValue = Integer.MIN_VALUE;
+    private int maxValue = Integer.MAX_VALUE;
+
+    public RangeEditTextPreference(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs);
+    }
+
+    public RangeEditTextPreference(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs);
+    }
+
+    public RangeEditTextPreference(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(context, attrs);
+    }
+
+    public RangeEditTextPreference(@NonNull Context context) {
+        super(context);
+        init(context, null);
+    }
+
+    private void init(@NonNull Context context, @Nullable AttributeSet attrs) {
+        if (attrs != null) {
+            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.RangeEditTextPreference);
+            try {
+                minValue = a.getInteger(R.styleable.RangeEditTextPreference_minValue, Integer.MIN_VALUE);
+                maxValue = a.getInteger(R.styleable.RangeEditTextPreference_maxValue, Integer.MAX_VALUE);
+            } finally {
+                a.recycle();
+            }
+        }
+
+        // Validate before persisting
+        setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!(preference instanceof RangeEditTextPreference)) {
+                return true;
+            }
+            RangeEditTextPreference rangePref = (RangeEditTextPreference) preference;
+            String valueStr = (String) newValue;
+            try {
+                int value = Integer.parseInt(valueStr);
+                int clamped = Math.max(rangePref.minValue, Math.min(rangePref.maxValue, value));
+                if (clamped != value) {
+                    Toast.makeText(context,
+                            context.getString(R.string.range_preference_clamped, rangePref.minValue, rangePref.maxValue),
+                            Toast.LENGTH_SHORT).show();
+                    // Persist the clamped value and update the summary
+                    rangePref.setText(String.valueOf(clamped));
+                    return false; // Prevent default persist; we already persisted the clamped value
+                }
+                return true; // Allow normal persist
+            } catch (NumberFormatException e) {
+                Toast.makeText(context,
+                        context.getString(R.string.range_preference_invalid),
+                        Toast.LENGTH_SHORT).show();
+                return false;
+            }
+        });
+    }
+}

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetScrollView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetScrollView.java
@@ -1,0 +1,277 @@
+package fr.neamar.kiss.ui;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.VelocityTracker;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.widget.NestedScrollView;
+
+/**
+ * Vertical scroller hosting the widget area.
+ *
+ * The area scrolls only through a two-finger gesture; a single finger always
+ * belongs to the widget underneath or is forwarded verbatim to the launcher's
+ * gesture pipeline through {@link #setEmptyAreaTouchListener(View.OnTouchListener)}.
+ *
+ * Scrolling can be disabled entirely through settings ("Enable widget
+ * scrolling"): this reverts to the legacy static widget area.
+ */
+public class WidgetScrollView extends NestedScrollView {
+    private static final int INVALID_POINTER_ID = -1;
+
+    /**
+     * Whether widget scrolling is enabled
+     */
+    private boolean scrollingEnabled = true;
+
+    /**
+     * Whether the current gesture is an active two-finger scroll
+     */
+    private boolean twoFingerScrolling;
+
+    /**
+     * Whether the current single-finger gesture is being forwarded
+     */
+    private boolean forwardingGesture;
+
+    /**
+     * Listener receiving empty-area gestures, handled as if performed on a non-widget area
+     */
+    @Nullable
+    private View.OnTouchListener emptyAreaTouchListener;
+
+    // Two-finger scroll state
+    @Nullable
+    private VelocityTracker velocityTracker;
+    private int scrollPointerId = INVALID_POINTER_ID;
+    private float lastScrollY;
+    private int maximumFlingVelocity;
+
+    public WidgetScrollView(Context context) {
+        this(context, null);
+    }
+
+    public WidgetScrollView(Context context, AttributeSet attrs) {
+        this(context, attrs, android.R.attr.scrollViewStyle);
+    }
+
+    public WidgetScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        maximumFlingVelocity = ViewConfiguration.get(context).getScaledMaximumFlingVelocity();
+    }
+
+    /**
+     * Enable or disable widget scrolling.
+     *
+     * When disabled, this view behaves as a static container.
+     */
+    public void setScrollingEnabled(boolean enabled) {
+        if (scrollingEnabled == enabled) {
+            return;
+        }
+        scrollingEnabled = enabled;
+        // a disabled view ignores touches itself, but still dispatches them to children
+        setEnabled(enabled);
+    }
+
+    /**
+     * Set the listener receiving empty-area gestures. Events are forwarded
+     * verbatim, so they run through the launcher's standard gesture pipeline.
+     */
+    public void setEmptyAreaTouchListener(@Nullable View.OnTouchListener listener) {
+        emptyAreaTouchListener = listener;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (!scrollingEnabled) {
+            // never intercept: widgets (including internal lists) keep full gestures
+            return false;
+        }
+
+        if (ev.getActionMasked() == MotionEvent.ACTION_POINTER_DOWN && ev.getPointerCount() >= 2) {
+            // two-finger scroll: steal the gesture from the widget underneath
+            startTwoFingerScroll(ev);
+            return true;
+        }
+
+        // never steal single-finger gestures from widgets
+        return false;
+    }
+
+    /**
+     * No click semantics of its own: clicks belong to the widgets underneath.
+     */
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        if (!scrollingEnabled) {
+            return false;
+        }
+
+        switch (ev.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                // consume so a possible second finger can still be observed
+                forwardingGesture = true;
+                forwardToEmptyAreaListener(ev);
+                return true;
+            case MotionEvent.ACTION_POINTER_DOWN:
+                // always carries at least two pointers by definition
+                if (twoFingerScrolling) {
+                    trackVelocity(ev);
+                } else {
+                    startTwoFingerScroll(ev);
+                }
+                return true;
+            case MotionEvent.ACTION_POINTER_UP:
+                if (twoFingerScrolling) {
+                    switchScrollPointerIfNeeded(ev);
+                    trackVelocity(ev);
+                    return true;
+                }
+                break;
+            case MotionEvent.ACTION_MOVE:
+                if (twoFingerScrolling) {
+                    trackVelocity(ev);
+                    scrollByScrollPointer(ev);
+                } else {
+                    forwardToEmptyAreaListener(ev);
+                }
+                return true;
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+                if (twoFingerScrolling) {
+                    finishTwoFingerScroll(ev);
+                } else {
+                    forwardToEmptyAreaListener(ev);
+                    forwardingGesture = false;
+                }
+                return true;
+        }
+        // only exotic actions reach this: delegate them to the super class
+        // (mouse wheels arrive via onGenericMotionEvent instead)
+        return super.onTouchEvent(ev);
+    }
+
+    private void startTwoFingerScroll(MotionEvent ev) {
+        twoFingerScrolling = true;
+        boolean wasForwarding = forwardingGesture;
+        forwardingGesture = false;
+
+        recycleVelocityTracker();
+        velocityTracker = VelocityTracker.obtain();
+        scrollPointerId = ev.getPointerId(ev.getActionIndex());
+        lastScrollY = ev.getY(ev.findPointerIndex(scrollPointerId));
+        velocityTracker.addMovement(ev);
+
+        // cancel pending widget long-press checks so no menu opens during the scroll
+        cancelWidgetLongPresses();
+
+        // end the delegated gesture cleanly (stolen streams get their
+        // ACTION_CANCEL from the ViewGroup automatically)
+        if (wasForwarding && emptyAreaTouchListener != null) {
+            MotionEvent cancel = MotionEvent.obtain(ev);
+            cancel.setAction(MotionEvent.ACTION_CANCEL);
+            emptyAreaTouchListener.onTouch(this, cancel);
+            cancel.recycle();
+        }
+    }
+
+    private void cancelWidgetLongPresses() {
+        if (!(getChildAt(0) instanceof ViewGroup)) {
+            return;
+        }
+        ViewGroup widgetArea = (ViewGroup) getChildAt(0);
+        for (int i = 0; i < widgetArea.getChildCount(); i++) {
+            widgetArea.getChildAt(i).cancelLongPress();
+        }
+    }
+
+    private void scrollByScrollPointer(MotionEvent ev) {
+        int pointerIndex = ev.findPointerIndex(scrollPointerId);
+        if (pointerIndex < 0) {
+            return;
+        }
+        float y = ev.getY(pointerIndex);
+        float deltaY = lastScrollY - y;
+        lastScrollY = y;
+        if (deltaY != 0) {
+            scrollBy(0, (int) deltaY);
+        }
+    }
+
+    /**
+     * If the pointer driving the scroll was lifted, continue with a remaining one.
+     */
+    private void switchScrollPointerIfNeeded(MotionEvent ev) {
+        int liftedIndex = ev.getActionIndex();
+        if (ev.getPointerId(liftedIndex) != scrollPointerId) {
+            return;
+        }
+        int remainingIndex = liftedIndex == 0 ? 1 : 0;
+        if (remainingIndex < ev.getPointerCount()) {
+            scrollPointerId = ev.getPointerId(remainingIndex);
+            lastScrollY = ev.getY(remainingIndex);
+        }
+    }
+
+    private void finishTwoFingerScroll(MotionEvent ev) {
+        try {
+            if (velocityTracker != null) {
+                velocityTracker.addMovement(ev);
+                velocityTracker.computeCurrentVelocity(1000, maximumFlingVelocity);
+            }
+            if (ev.getActionMasked() == MotionEvent.ACTION_UP && velocityTracker != null) {
+                float velocityY = velocityTracker.getYVelocity(scrollPointerId);
+                fling(-Math.round(velocityY));
+            }
+        } finally {
+            twoFingerScrolling = false;
+            scrollPointerId = INVALID_POINTER_ID;
+            recycleVelocityTracker();
+        }
+    }
+
+    private void forwardToEmptyAreaListener(MotionEvent ev) {
+        if (emptyAreaTouchListener != null) {
+            emptyAreaTouchListener.onTouch(this, ev);
+        }
+    }
+
+    private void trackVelocity(MotionEvent ev) {
+        if (velocityTracker != null) {
+            velocityTracker.addMovement(ev);
+        }
+    }
+
+    private void recycleVelocityTracker() {
+        if (velocityTracker != null) {
+            velocityTracker.recycle();
+            velocityTracker = null;
+        }
+    }
+
+    @Override
+    public boolean onStartNestedScroll(View child, View target, int nestedScrollAxes, int type) {
+        // all scrolling of this area goes through the two-finger gesture:
+        // never accept nested scroll handoffs from widgets' internal lists
+        return false;
+    }
+
+    @Override
+    public boolean onGenericMotionEvent(@NonNull MotionEvent event) {
+        // mouse wheels and trackpads scroll via the generic-motion path, which
+        // bypasses the touch pipeline: respect "Enable widget scrolling" here too
+        if (!scrollingEnabled && event.getAction() == MotionEvent.ACTION_SCROLL) {
+            return false;
+        }
+        return super.onGenericMotionEvent(event);
+    }
+}

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetScrollView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetScrollView.java
@@ -8,10 +8,10 @@ import android.view.VelocityTracker;
 import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
+import android.widget.ScrollView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.widget.NestedScrollView;
 
 /**
  * Vertical scroller hosting the widget area.
@@ -23,7 +23,7 @@ import androidx.core.widget.NestedScrollView;
  * Scrolling can be disabled entirely through settings ("Enable widget
  * scrolling"): this reverts to the legacy static widget area.
  */
-public class WidgetScrollView extends NestedScrollView {
+public class WidgetScrollView extends ScrollView {
     private static final int INVALID_POINTER_ID = -1;
 
     /**
@@ -259,7 +259,7 @@ public class WidgetScrollView extends NestedScrollView {
     }
 
     @Override
-    public boolean onStartNestedScroll(View child, View target, int nestedScrollAxes, int type) {
+    public boolean onStartNestedScroll(View child, View target, int nestedScrollAxes) {
         // all scrolling of this area goes through the two-finger gesture:
         // never accept nested scroll handoffs from widgets' internal lists
         return false;

--- a/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
+++ b/app/src/main/java/fr/neamar/kiss/ui/WidgetView.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.ui;
 
+import android.annotation.SuppressLint;
 import android.appwidget.AppWidgetHostView;
 import android.content.Context;
 import android.os.Build;
@@ -43,9 +44,7 @@ public class WidgetView extends AppWidgetHostView {
             case MotionEvent.ACTION_MOVE: {
                 if (Math.abs(ev.getX() - xPos) > 5 || Math.abs(ev.getY() - yPos) > 5) {
                     mHasPerformedLongPress = false;
-                    if (mPendingCheckForLongPress != null) {
-                        removeCallbacks(mPendingCheckForLongPress);
-                    }
+                    cancelPendingLongPress();
                 }
                 break;
             }
@@ -53,14 +52,31 @@ public class WidgetView extends AppWidgetHostView {
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
                 mHasPerformedLongPress = false;
-                if (mPendingCheckForLongPress != null) {
-                    removeCallbacks(mPendingCheckForLongPress);
-                }
+                cancelPendingLongPress();
                 break;
         }
 
         // Otherwise continue letting touch events fall through to children
         return false;
+    }
+
+    /**
+     * Cancel the pending long-press check here too: once a parent has
+     * intercepted a gesture, the resulting ACTION_CANCEL bypasses
+     * {@link #onInterceptTouchEvent} entirely.
+     */
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        switch (ev.getAction()) {
+            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_CANCEL:
+            case MotionEvent.ACTION_POINTER_DOWN:
+                mHasPerformedLongPress = false;
+                cancelPendingLongPress();
+                break;
+        }
+        return super.onTouchEvent(ev);
     }
 
     protected class CheckForLongPress implements Runnable {
@@ -91,14 +107,18 @@ public class WidgetView extends AppWidgetHostView {
         postDelayed(mPendingCheckForLongPress, ViewConfiguration.getLongPressTimeout());
     }
 
+    private void cancelPendingLongPress() {
+        if (mPendingCheckForLongPress != null) {
+            removeCallbacks(mPendingCheckForLongPress);
+        }
+    }
+
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
 
         mHasPerformedLongPress = false;
-        if (mPendingCheckForLongPress != null) {
-            removeCallbacks(mPendingCheckForLongPress);
-        }
+        cancelPendingLongPress();
     }
 
     @Override

--- a/app/src/main/java/fr/neamar/kiss/utils/WidgetUtils.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/WidgetUtils.java
@@ -1,0 +1,63 @@
+package fr.neamar.kiss.utils;
+
+/**
+ * Pure helpers for widget line arithmetic.
+ *
+ * Widgets in minimalistic mode are sized as an integral number of "lines"
+ * (see {@code Widgets#getLineHeight()}). These helpers are unit-testable on
+ * the JVM and hold no Android framework dependencies.
+ */
+public final class WidgetUtils {
+    private WidgetUtils() {
+    }
+
+    /**
+     * Convert a pixel height into a number of layout lines, rounding up.
+     *
+     * @param heightPx     height in pixels
+     * @param lineHeightPx height of a single line in pixels
+     * @return number of lines, always at least 1
+     */
+    public static int getLineSize(int heightPx, float lineHeightPx) {
+        return Math.max(1, (int) Math.ceil(heightPx / lineHeightPx));
+    }
+
+    /**
+     * Effective minimum height of a widget, snapped to whole lines.
+     *
+     * @param minHeightPx          {@link android.appwidget.AppWidgetProviderInfo#minHeight}
+     * @param targetCellHeightCells {@link android.appwidget.AppWidgetProviderInfo#targetCellHeight} (0 if unsupported)
+     * @param lineHeightPx         height of a single line in pixels
+     * @return minimum height in pixels
+     */
+    public static int getMinHeight(int minHeightPx, int targetCellHeightCells, float lineHeightPx) {
+        if (targetCellHeightCells > 0) {
+            return (int) (targetCellHeightCells * lineHeightPx);
+        } else if (minHeightPx == 0) {
+            return 0;
+        } else {
+            return (int) (getLineSize(minHeightPx, lineHeightPx) * lineHeightPx);
+        }
+    }
+
+    /**
+     * Initial size of a newly added widget.
+     *
+     * Since the widget area scrolls vertically, the initial size is not clamped
+     * to the visible viewport: widgets may be taller than one screen and the
+     * user scrolls to reach them.
+     *
+     * @param minHeightPx       effective minimum height of the widget in pixels ({@link #getMinHeight})
+     * @param lineHeightPx      height of a single line in pixels
+     * @param upsizeAllowed     true if the widget may grow to the preferred default size
+     * @param preferredLineSize default size used for small widgets
+     * @return initial size in lines
+     */
+    public static int getInitialLineSize(int minHeightPx, float lineHeightPx, boolean upsizeAllowed, int preferredLineSize) {
+        int initialLineSize = getLineSize(minHeightPx, lineHeightPx);
+        if (upsizeAllowed && initialLineSize < preferredLineSize) {
+            initialLineSize = preferredLineSize;
+        }
+        return Math.max(1, initialLineSize);
+    }
+}

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -6,8 +6,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:id="@+id/widgetLayout"
+    <fr.neamar.kiss.ui.WidgetScrollView
+        android:id="@+id/widgetScroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/resultLayout"
@@ -18,8 +18,16 @@
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"
         android:layout_marginBottom="10dp"
-        android:gravity="center_horizontal"
-        android:orientation="vertical" />
+        android:fillViewport="true">
+
+        <!-- Vertically scrolling widget area: hosts an unlimited number of widgets in minimalistic mode -->
+        <LinearLayout
+            android:id="@+id/widgetLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical" />
+    </fr.neamar.kiss.ui.WidgetScrollView>
 
     <FrameLayout
         android:id="@+id/resultLayout"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -17,4 +17,10 @@
     <attr name="resultTitleSize" format="reference|dimension" />
     <attr name="resultSubtitleSize" format="reference|dimension" />
     <attr name="resultButtonHeight" format="reference|dimension" />
+
+    <!-- RangeEditTextPreference attributes -->
+    <declare-styleable name="RangeEditTextPreference">
+        <attr name="minValue" format="integer" />
+        <attr name="maxValue" format="integer" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,7 +100,6 @@
     <string name="history_mode_desc">Select how history should be sorted</string>
     <string name="root_mode_desc">If available use it to hibernate apps</string>
     <string name="root_mode_name">Root mode</string>
-    <string name="widget_scrolling_name">Enable widget scrolling</string>
     <string name="widget_spacing_name">Space between widgets (dp)</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>
     <string name="freeze_history_name">Freeze history</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -367,4 +367,6 @@
     <string name="result_highlighting_italic">Italic</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
+    <string name="range_preference_clamped">Value clamped to %1$d…%2$d</string>
+    <string name="range_preference_invalid">Please enter a valid number</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,8 @@
     <string name="history_mode_desc">Select how history should be sorted</string>
     <string name="root_mode_desc">If available use it to hibernate apps</string>
     <string name="root_mode_name">Root mode</string>
+    <string name="widget_scrolling_name">Enable widget scrolling</string>
+    <string name="widget_spacing_name">Space between widgets (dp)</string>
     <string name="root_mode_error">Unable to gain root privileges.</string>
     <string name="freeze_history_name">Freeze history</string>
     <string name="freeze_history_warn">Are you sure you want to freeze history and turn off further updates? Your history will not change anymore.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -599,13 +599,8 @@
             app:defaultValue="false"
             app:key="use-fuzzy-score-v1"
             app:title="Use legacy fuzzy search algorithm" />
-        <SwitchPreference
-            app:defaultValue="true"
-            app:key="enable-widget-scrolling"
-            app:title="@string/widget_scrolling_name" />
         <fr.neamar.kiss.preference.RangeEditTextPreference
             app:defaultValue="0"
-            app:dependency="enable-widget-scrolling"
             app:key="widget-spacing"
             app:minValue="0"
             app:maxValue="300"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -599,6 +599,17 @@
             app:defaultValue="false"
             app:key="use-fuzzy-score-v1"
             app:title="Use legacy fuzzy search algorithm" />
+        <SwitchPreference
+            app:defaultValue="true"
+            app:key="enable-widget-scrolling"
+            app:title="@string/widget_scrolling_name" />
+        <EditTextPreference
+            android:inputType="number"
+            app:defaultValue="10"
+            app:dependency="enable-widget-scrolling"
+            app:key="widget-spacing"
+            app:title="@string/widget_spacing_name"
+            app:useSimpleSummaryProvider="true" />
         <fr.neamar.kiss.preference.RootModeSwitch
             app:defaultValue="false"
             app:key="root-mode"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -603,11 +603,12 @@
             app:defaultValue="true"
             app:key="enable-widget-scrolling"
             app:title="@string/widget_scrolling_name" />
-        <EditTextPreference
-            android:inputType="number"
-            app:defaultValue="10"
+        <fr.neamar.kiss.preference.RangeEditTextPreference
+            app:defaultValue="0"
             app:dependency="enable-widget-scrolling"
             app:key="widget-spacing"
+            app:minValue="0"
+            app:maxValue="50"
             app:title="@string/widget_spacing_name"
             app:useSimpleSummaryProvider="true" />
         <fr.neamar.kiss.preference.RootModeSwitch

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -608,7 +608,7 @@
             app:dependency="enable-widget-scrolling"
             app:key="widget-spacing"
             app:minValue="0"
-            app:maxValue="50"
+            app:maxValue="300"
             app:title="@string/widget_spacing_name"
             app:useSimpleSummaryProvider="true" />
         <fr.neamar.kiss.preference.RootModeSwitch

--- a/app/src/test/java/fr/neamar/kiss/utils/WidgetUtilsTest.java
+++ b/app/src/test/java/fr/neamar/kiss/utils/WidgetUtilsTest.java
@@ -1,0 +1,70 @@
+package fr.neamar.kiss.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for widget sizing helpers.
+ *
+ * Widgets are laid out in "lines" of a fixed pixel height
+ * ({@code Widgets#getLineHeight()}); these tests verify the pure
+ * line-arithmetic used to size newly added widgets.
+ */
+class WidgetUtilsTest {
+    private static final float LINE_HEIGHT_PX = 150f; // 50dp @ 3x density
+
+    @Test
+    void zeroHeightSnapsToOneLine() {
+        assertThat(WidgetUtils.getLineSize(0, LINE_HEIGHT_PX), equalTo(1));
+    }
+
+    @Test
+    void partialLineRoundsUp() {
+        assertThat(WidgetUtils.getLineSize(1, LINE_HEIGHT_PX), equalTo(1));
+        assertThat(WidgetUtils.getLineSize(151, LINE_HEIGHT_PX), equalTo(2));
+        assertThat(WidgetUtils.getLineSize(299, LINE_HEIGHT_PX), equalTo(2));
+    }
+
+    @Test
+    void exactMultipleOfLineHeight() {
+        assertThat(WidgetUtils.getLineSize(300, LINE_HEIGHT_PX), equalTo(2));
+        assertThat(WidgetUtils.getLineSize(600, LINE_HEIGHT_PX), equalTo(4));
+    }
+
+    @Test
+    void minHeightFromTargetCellHeight() {
+        // API S+ widgets declare their preferred size in cells
+        assertThat(WidgetUtils.getMinHeight(1000, 3, LINE_HEIGHT_PX), equalTo(450));
+    }
+
+    @Test
+    void minHeightZeroStaysZero() {
+        assertThat(WidgetUtils.getMinHeight(0, 0, LINE_HEIGHT_PX), equalTo(0));
+    }
+
+    @Test
+    void minHeightSnapsToWholeLines() {
+        // minHeight of 1.4 lines snaps to 2 lines
+        assertThat(WidgetUtils.getMinHeight(210, 0, LINE_HEIGHT_PX), equalTo(300));
+    }
+
+    @Test
+    void initialSizeUsesMinHeight() {
+        // 3-line minimum widget starts at 3 lines even though default is smaller
+        assertThat(WidgetUtils.getInitialLineSize(450, LINE_HEIGHT_PX, true, 2), equalTo(3));
+        assertThat(WidgetUtils.getInitialLineSize(450, LINE_HEIGHT_PX, false, 2), equalTo(3));
+    }
+
+    @Test
+    void initialSizeUpsizedToDefaultWhenAllowed() {
+        // tiny 1-line widget is upsized to the 2-line default if resizing allows it
+        assertThat(WidgetUtils.getInitialLineSize(150, LINE_HEIGHT_PX, true, 2), equalTo(2));
+    }
+
+    @Test
+    void initialSizeKeepsSmallSizeWhenUpsizeForbidden() {
+        assertThat(WidgetUtils.getInitialLineSize(150, LINE_HEIGHT_PX, false, 2), equalTo(1));
+    }
+}

--- a/docs/_posts/2018-02-11-add-a-widget.md
+++ b/docs/_posts/2018-02-11-add-a-widget.md
@@ -28,9 +28,3 @@ From there, pick a widget, and the widget will appear on top of an empty search 
 To remove the widget, long-press on the widget and select "Remove widget".
 
 By long-pressing, you can also resize the widget and change the order between the widgets.
-
-## Multiple widgets
-
-You can add as many widgets as you like: when they no longer fit on screen, the widget area scrolls vertically. Newly added widgets keep their requested size even if taller than the screen — scroll to reach them.
-
-Note: the widget area scrolls with a **two-finger drag** — start it anywhere over your widgets. A single finger always belongs to the widgets themselves: tap, long-press, and scrollable widget content (e.g. agendas) work everywhere. Gestures on empty areas (tap, double tap, swipes) behave exactly like elsewhere in KISS. Both scrolling and the spacing between widgets can be configured under `⋮, KISS Settings, Advanced`.

--- a/docs/_posts/2018-02-11-add-a-widget.md
+++ b/docs/_posts/2018-02-11-add-a-widget.md
@@ -28,3 +28,9 @@ From there, pick a widget, and the widget will appear on top of an empty search 
 To remove the widget, long-press on the widget and select "Remove widget".
 
 By long-pressing, you can also resize the widget and change the order between the widgets.
+
+## Multiple widgets
+
+You can add as many widgets as you like: when they no longer fit on screen, the widget area scrolls vertically. Newly added widgets keep their requested size even if taller than the screen — scroll to reach them.
+
+Note: the widget area scrolls with a **two-finger drag** — start it anywhere over your widgets. A single finger always belongs to the widgets themselves: tap, long-press, and scrollable widget content (e.g. agendas) work everywhere. Gestures on empty areas (tap, double tap, swipes) behave exactly like elsewhere in KISS. Both scrolling and the spacing between widgets can be configured under `⋮, KISS Settings, Advanced`.

--- a/qa-suite.md
+++ b/qa-suite.md
@@ -173,6 +173,20 @@ As best as possible, only actual KISS code is tested, not standard Android syste
 * [ ] When opening a search result and pressing home, Widget is displayed
 * [ ] Clicking on the widget opens the widget app
 * [ ] Clicking outside of the widget with history-touch replace the widget with history
+* [ ] A newly added widget taller than the remaining space keeps its requested size and is scrolled into view
+* [ ] Vertical swipe down/up starting outside the widget area still triggers the configured gesture
+* [ ] A two-finger drag starting anywhere over the widget area (widget or empty space) scrolls the widget area
+* [ ] The widget context menu never opens during or after a two-finger scroll
+* [ ] Normal single-finger long-press menus still open for widgets everywhere
+* [ ] A single-finger drag never scrolls the widget area, even at the end of a widget's internal list
+* [ ] A single tap anywhere on a widget reaches the widget (including the center of the screen; config-taps work)
+* [ ] A widget containing its own vertical list (e.g. agenda/calendar) scrolls its inner list normally with one finger
+* [ ] Gestures on empty areas behave exactly as in non-minimalistic KISS: tap reveals history/favorites as configured, double tap locks (or shows the accessibility prompt), long press and swipes trigger their configured actions (e.g. swipe down opens notifications)
+* [ ] Visible spacing is present between stacked widgets
+* [ ] Advanced setting "Enable widget scrolling" off: widget area no longer scrolls, new widgets shrink to fit the screen, widgets stay clickable, widgets are stacked edge-to-edge, and "Space between widgets" is disabled (not clickable)
+* [ ] Advanced setting "Space between widgets": changing it updates existing widget spacing immediately after leaving settings; the row is disabled (not clickable) while "Enable widget scrolling" is off
+* [ ] After scrolling, long-press menu actions (resize, move up/down, reconfigure, remove) apply to the correct widget
+* [ ] Widget order is preserved after rotation and after process death
 
 #### Portrait / landscape
 * [ ] When portrait-locked, app can't pivot


### PR DESCRIPTION
# Scrollable widget area for minimalistic UI mode

## Summary

Adds vertical scrolling to the widget area in minimalistic UI mode (`history-hide`),
allowing an unlimited number of widgets. Previously, widgets were clamped to the
visible viewport and could overflow silently.

## Motivation

Users in minimalistic UI mode who add multiple widgets run out of screen space. There
was no way to reach widgets below the fold. This PR adds a two-finger scroll gesture
to navigate the widget area while preserving full single-finger interaction with
widgets (taps, long-presses, internal scrolling).

## Behavior

1) Two fingers down anywhere over the widget area, drag -> widget area scrolls vertically
   
2) Single finger over a widget -> widget receives everything: taps, config-taps, long-press menus, internal list scrolling
   
3) Single finger on empty space -> forwarded verbatim to the launcher's gesture pipeline (history, favorites, live wallpaper)
   
4) "Enable widget scrolling" off ->full existing behavior revert: no scrolling, original viewport clamp, widgets stacked edge-to-edge

## Design decisions

* Two-finger gesture (not single-finger scroll zone): A single-finger scroll
area cannot coexist with arbitrary widget interaction -- widgets may need taps
anywhere on their surface. The two-finger gesture cleanly separates scroll from
widget interaction without visual zones or edge detection.

* NestedScrollView base class: Used for `fling()`, `scrollBy()`, layout/measurement,
and mouse wheel support via `onGenericMotionEvent`. The touch pipeline is fully
overridden to implement two-finger-only scrolling; `onStartNestedScroll` returns
false to prevent widgets' internal lists from handing off drags.

* Empty-area event forwarding: Gestures on empty areas are forwarded verbatim
(timestamps preserved) to the same pipeline as the rest of the launcher
(`ExperienceTweaks` + `LiveWallpaper`), ensuring taps, double-taps, and swipes
on empty space behave identically to non-widget areas.

* WidgetUtils extraction: Widget line-arithmetic (`getLineSize`, `getMinHeight`,
`getInitialLineSize`) is extracted into a JVM-testable utility class with no Android
framework dependencies. Two methods were moved from `Widgets.java`; one
(`getInitialLineSize`) is new logic for the scroll feature.

* WidgetView long-press fix: Adds `onTouchEvent` handling for `ACTION_CANCEL` and
`ACTION_POINTER_DOWN` to cancel the pending long-press check. This is
defense-in-depth: `WidgetScrollView.cancelWidgetLongPresses()` already provides the
primary cancellation, but the fix ensures correctness if any parent intercepts for
any reason (`ACTION_CANCEL` bypasses `onInterceptTouchEvent`).

## Settings

Two new preferences under Advanced:
- Enable widget scrolling (switch, default on) -- disables scrolling entirely,
  reverting to exiting behavior viewport-clamped behavior
- Space between widgets (dp) (numeric, default 10, range 0-50) -- adjustable
  spacing between stacked widgets; disabled when scrolling is off

## Testing

- JVM unit tests for `WidgetUtils` (7 test methods: zero-height, partial lines,
  exact multiples, target cell height, upsize/forbid logic)
- Manual QA checklist added to `qa-suite.md` (14 items covering two-finger scroll,
  single-finger passthrough, empty-area forwarding, settings toggling, long-press
  menus, rotation, and process death)
