### PR TITLE
fixes related to search result boost depending on history

### DIFF
--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -35,6 +35,7 @@ import fr.neamar.kiss.pojo.AppPojo;
 import fr.neamar.kiss.pojo.NameComparator;
 import fr.neamar.kiss.pojo.Pojo;
 import fr.neamar.kiss.pojo.ShortcutPojo;
+import fr.neamar.kiss.searcher.SearchHandler;
 import fr.neamar.kiss.searcher.Searcher;
 import fr.neamar.kiss.utils.Log;
 import fr.neamar.kiss.utils.PackageManagerUtils;
@@ -52,7 +53,6 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
 
     private TagsHandler tagsHandler;
     final private Context context;
-    private String currentQuery;
     private final Map<ProviderName, ProviderEntry> providers = new HashMap<>();
 
     /**
@@ -302,7 +302,6 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
      * @param searcher the searcher currently running
      */
     public void requestResults(String query, Searcher searcher) {
-        currentQuery = query;
         for (ProviderEntry entry : this.providers.values()) {
             if (searcher.isCancelled())
                 break;
@@ -946,7 +945,7 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
         Set<String> excludedFromHistory = getExcludedFromHistory();
 
         if (!frozen && !excludedFromHistory.contains(id)) {
-            DBHelper.insertHistory(this.context, currentQuery, id);
+            DBHelper.insertHistory(this.context, SearchHandler.getInstance().getLastSearchQuery(), id);
         }
     }
 

--- a/app/src/main/java/fr/neamar/kiss/DataHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/DataHandler.java
@@ -354,15 +354,14 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
 
         // Read history
         HistoryMode historyMode = getHistoryMode();
-        List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, extendedItemCount, historyMode);
+        List<ValuedHistoryRecord> historyRecords = DBHelper.getHistory(context, extendedItemCount, historyMode);
 
         // Find associated items
-        int size = ids.size();
-        for (int i = 0; i < ids.size(); i++) {
+        for (ValuedHistoryRecord historyRecord : historyRecords) {
             // Ask all providers if they know this id
-            Pojo pojo = getPojo(ids.get(i).record);
+            Pojo pojo = getPojo(historyRecord.record);
 
-            if (pojo == null) {
+            if (pojo == null || history.contains(pojo)) {
                 continue;
             }
 
@@ -370,11 +369,7 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
                 continue;
             }
 
-            if (historyMode == HistoryMode.ALPHABETICALLY) {
-                pojo.relevance = 0;
-            } else {
-                pojo.relevance = size - i;
-            }
+            pojo.relevance = historyRecord.relevance;
             history.add(pojo);
         }
 
@@ -404,12 +399,10 @@ public class DataHandler implements SharedPreferences.OnSharedPreferenceChangeLi
             // If only number of displayed elements is used, this will result in more entries to be sorted by name.
             int historyLength = getHistoryLength();
 
-            Map<String, Integer> relevance = new HashMap<>();
-            List<ValuedHistoryRecord> ids = DBHelper.getHistory(context, historyLength, historyMode);
-            int size = ids.size();
-            for (int i = 0; i < size; i++) {
-                relevance.put(ids.get(i).record, size - i);
-            }
+            Map<String, Integer> relevance = DBHelper.getHistory(context, historyLength, historyMode)
+                    .stream()
+                    .collect(Collectors.toMap(historyRecord -> historyRecord.record,
+                            historyRecord -> historyRecord.relevance));
 
             for (Pojo pojo : pojos) {
                 Integer calculated = relevance.get(pojo.id);

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -35,7 +35,7 @@ public class DBHelper {
         return database;
     }
 
-    private static List<ValuedHistoryRecord> readCursor(Cursor cursor) {
+    private static List<ValuedHistoryRecord> readCursor(@NonNull Cursor cursor) {
         cursor.moveToFirst();
 
         List<ValuedHistoryRecord> records = new ArrayList<>(cursor.getCount());
@@ -60,7 +60,7 @@ public class DBHelper {
      * @param query   query to insert
      * @param record  record to insert
      */
-    public static void insertHistory(Context context, String query, String record) {
+    public static void insertHistory(@NonNull Context context, @Nullable String query, @NonNull String record) {
         SQLiteDatabase db = getDatabase(context);
         ContentValues values = new ContentValues();
         values.put("query", query);
@@ -77,17 +77,17 @@ public class DBHelper {
         }
     }
 
-    public static void removeFromHistory(Context context, String record) {
+    public static void removeFromHistory(@NonNull Context context, @NonNull String record) {
         SQLiteDatabase db = getDatabase(context);
         db.delete("history", "record = ?", new String[]{record});
     }
 
-    public static void clearHistory(Context context) {
+    public static void clearHistory(@NonNull Context context) {
         SQLiteDatabase db = getDatabase(context);
         db.delete("history", "", null);
     }
 
-    private static Cursor getHistoryByFrecency(SQLiteDatabase db, int limit, @Nullable String query) {
+    private static Cursor getHistoryByFrecency(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         // Since smart history sql uses a group by we don't use the whole history but a limit of recent apps
         int historyWindowSize = limit * 30;
 
@@ -125,7 +125,7 @@ public class DBHelper {
         }
     }
 
-    private static Cursor getHistoryByFrequency(SQLiteDatabase db, int limit, @Nullable String query) {
+    private static Cursor getHistoryByFrequency(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         if (query == null) {
             // order history based on frequency
             String sql = "SELECT record, count(*) FROM history" +
@@ -144,7 +144,7 @@ public class DBHelper {
         }
     }
 
-    private static Cursor getHistoryByRecency(SQLiteDatabase db, int limit, @Nullable String query) {
+    private static Cursor getHistoryByRecency(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         if (query == null) {
             return db.query(true, "history", new String[]{"record", "1"}, null, null,
                     null, null, "_id DESC", Integer.toString(limit));
@@ -161,7 +161,7 @@ public class DBHelper {
      * @param limit Maximum result size
      * @return Cursor
      */
-    private static Cursor getHistoryByAdaptive(SQLiteDatabase db, int limit, @Nullable String query) {
+    private static Cursor getHistoryByAdaptive(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         // how many hours back we want to test frequency against
         int hours = 36;
         if (query == null) {
@@ -200,7 +200,7 @@ public class DBHelper {
      * @param limit Maximum result size
      * @return Cursor
      */
-    private static Cursor getHistoryByTime(SQLiteDatabase db, int limit, @Nullable String query) {
+    private static Cursor getHistoryByTime(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         final long now = System.currentTimeMillis();
         final long MS_24_DAYS_AGO = now - 2073600000L;
         if (query == null) {
@@ -230,7 +230,7 @@ public class DBHelper {
      * @param limit   max number of items to retrieve
      * @return records with number of use
      */
-    public static List<ValuedHistoryRecord> getHistory(Context context, int limit, HistoryMode historyMode) {
+    public static List<ValuedHistoryRecord> getHistory(@NonNull Context context, int limit, HistoryMode historyMode) {
         return getHistory(context, limit, historyMode, null);
     }
 
@@ -242,7 +242,7 @@ public class DBHelper {
      * @param query   search query
      * @return records with number of use
      */
-    public static List<ValuedHistoryRecord> getHistory(Context context, int limit, HistoryMode historyMode, @Nullable String query) {
+    public static List<ValuedHistoryRecord> getHistory(@NonNull Context context, int limit, HistoryMode historyMode, @Nullable String query) {
         List<ValuedHistoryRecord> records;
 
         SQLiteDatabase db = getDatabase(context);
@@ -295,28 +295,6 @@ public class DBHelper {
             cursor.moveToFirst();
             return cursor.getInt(0);
         }
-    }
-
-    /**
-     * Retrieve previously selected items for the query
-     *
-     * @param context android context
-     * @param query   query to run
-     * @return records with number of use
-     */
-    public static List<ValuedHistoryRecord> getPreviousResultsForQuery(Context context,
-                                                                       String query) {
-        List<ValuedHistoryRecord> records;
-        SQLiteDatabase db = getDatabase(context);
-
-        // Cursor query (String table, String[] columns, String selection,
-        // String[] selectionArgs, String groupBy, String having, String
-        // orderBy)
-        Cursor cursor = db.query("history", new String[]{"record", "COUNT(*) AS count"},
-                "query LIKE ?", new String[]{query + "%"}, "record", null, "COUNT(*) DESC", "10");
-        records = readCursor(cursor);
-        cursor.close();
-        return records;
     }
 
     /**

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -35,15 +35,17 @@ public class DBHelper {
         return database;
     }
 
-    private static List<ValuedHistoryRecord> readCursor(@NonNull Cursor cursor) {
+    private static List<ValuedHistoryRecord> readCursor(@NonNull Cursor cursor, boolean withRelevance) {
         cursor.moveToFirst();
 
-        List<ValuedHistoryRecord> records = new ArrayList<>(cursor.getCount());
+        int count = cursor.getCount();
+        List<ValuedHistoryRecord> records = new ArrayList<>(count);
         while (!cursor.isAfterLast()) {
             ValuedHistoryRecord entry = new ValuedHistoryRecord();
 
             entry.record = cursor.getString(0);
             entry.value = cursor.getInt(1);
+            entry.relevance = withRelevance ? count - cursor.getPosition() : 0;
 
             records.add(entry);
             cursor.moveToNext();
@@ -128,17 +130,17 @@ public class DBHelper {
     private static Cursor getHistoryByFrequency(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         if (query == null) {
             // order history based on frequency
-            String sql = "SELECT record, count(*) FROM history" +
+            String sql = "SELECT record, count(*) AS value FROM history" +
                     " GROUP BY record " +
-                    " ORDER BY count(*) DESC " +
+                    " ORDER BY value DESC " +
                     " LIMIT " + limit;
             return db.rawQuery(sql, null);
         } else {
             // order history based on frequency
-            String sql = "SELECT record, count(*) FROM history" +
+            String sql = "SELECT record, count(*) AS value FROM history" +
                     " WHERE query LIKE ? " +
                     " GROUP BY record " +
-                    " ORDER BY count(*) DESC " +
+                    " ORDER BY value DESC " +
                     " LIMIT " + limit;
             return db.rawQuery(sql, new String[]{query + "%"});
         }
@@ -146,11 +148,11 @@ public class DBHelper {
 
     private static Cursor getHistoryByRecency(@NonNull SQLiteDatabase db, int limit, @Nullable String query) {
         if (query == null) {
-            return db.query(true, "history", new String[]{"record", "1"}, null, null,
-                    null, null, "_id DESC", Integer.toString(limit));
+            return db.query(true, "history", new String[]{"record", "MAX(_id) AS value"}, null, null,
+                    "record", null, "value DESC", Integer.toString(limit));
         } else {
-            return db.query(true, "history", new String[]{"record", "1"}, "query LIKE ?", new String[]{query + "%"},
-                    null, null, "_id DESC", Integer.toString(limit));
+            return db.query(true, "history", new String[]{"record", "MAX(_id) AS value"}, "query LIKE ?", new String[]{query + "%"},
+                    "record", null, "value DESC", Integer.toString(limit));
         }
     }
 
@@ -166,21 +168,21 @@ public class DBHelper {
         int hours = 36;
         if (query == null) {
             // order history based on frequency
-            String sql = "SELECT record, count(*) FROM history " +
+            String sql = "SELECT record, count(*) AS value FROM history " +
                     " WHERE timeStamp >= 0 " +
                     " AND timeStamp >" + (System.currentTimeMillis() - (hours * 3600000L)) +
                     " GROUP BY record " +
-                    " ORDER BY count(*) DESC " +
+                    " ORDER BY value DESC " +
                     " LIMIT " + limit;
             return db.rawQuery(sql, null);
         } else {
             // order history based on frequency
-            String sql = "SELECT record, count(*) FROM history " +
+            String sql = "SELECT record, count(*) AS value FROM history " +
                     " WHERE timeStamp >= 0 " +
                     " AND timeStamp >" + (System.currentTimeMillis() - (hours * 3600000L)) +
                     " AND query LIKE ? " +
                     " GROUP BY record " +
-                    " ORDER BY count(*) DESC " +
+                    " ORDER BY value DESC " +
                     " LIMIT " + limit;
             return db.rawQuery(sql, new String[]{query + "%"});
         }
@@ -271,7 +273,7 @@ public class DBHelper {
                 break;
         }
 
-        records = readCursor(cursor);
+        records = readCursor(cursor, historyMode != HistoryMode.ALPHABETICALLY);
         cursor.close();
 
         return records;

--- a/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
+++ b/app/src/main/java/fr/neamar/kiss/db/DBHelper.java
@@ -87,57 +87,103 @@ public class DBHelper {
         db.delete("history", "", null);
     }
 
-    private static Cursor getHistoryByFrecency(SQLiteDatabase db, int limit) {
+    private static Cursor getHistoryByFrecency(SQLiteDatabase db, int limit, @Nullable String query) {
         // Since smart history sql uses a group by we don't use the whole history but a limit of recent apps
         int historyWindowSize = limit * 30;
 
-        // order history based on frequency * recency
-        // frequency = #launches_for_app / #all_launches
-        // recency = 1 / position_of_app_in_normal_history
-        String sql = "SELECT record, count(*) FROM " +
-                " (" +
-                "   SELECT * FROM history ORDER BY _id DESC " +
-                "   LIMIT " + historyWindowSize +
-                " ) small_history " +
-                " GROUP BY record " +
-                " ORDER BY " +
-                "   count(*) * 1.0 / (select count(*) from history LIMIT " + historyWindowSize + ") / ((SELECT _id FROM history ORDER BY _id DESC LIMIT 1) - max(_id) + 0.001) " +
-                " DESC " +
-                " LIMIT " + limit;
-        return db.rawQuery(sql, null);
+        if (query == null) {
+            // order history based on frequency * recency
+            // frequency = #launches_for_app / #all_launches
+            // recency = 1 / position_of_app_in_normal_history
+            String sql = "SELECT record, count(*) FROM " +
+                    " (" +
+                    "   SELECT * FROM history ORDER BY _id DESC " +
+                    "   LIMIT " + historyWindowSize +
+                    " ) small_history " +
+                    " GROUP BY record " +
+                    " ORDER BY " +
+                    "   count(*) * 1.0 / (select count(*) from history LIMIT " + historyWindowSize + ") / ((SELECT _id FROM history ORDER BY _id DESC LIMIT 1) - max(_id) + 0.001) " +
+                    " DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, null);
+        } else {
+            // order history based on frequency * recency
+            // frequency = #launches_for_app / #all_launches
+            // recency = 1 / position_of_app_in_normal_history
+            String sql = "SELECT record, count(*) FROM " +
+                    " (" +
+                    "   SELECT * FROM history ORDER BY _id DESC " +
+                    "   LIMIT " + historyWindowSize +
+                    " ) small_history " +
+                    " WHERE query LIKE ? " +
+                    " GROUP BY record " +
+                    " ORDER BY " +
+                    "   count(*) * 1.0 / (select count(*) from history LIMIT " + historyWindowSize + ") / ((SELECT _id FROM history ORDER BY _id DESC LIMIT 1) - max(_id) + 0.001) " +
+                    " DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, new String[]{query + "%"});
+        }
     }
 
-    private static Cursor getHistoryByFrequency(SQLiteDatabase db, int limit) {
-        // order history based on frequency
-        String sql = "SELECT record, count(*) FROM history" +
-                " GROUP BY record " +
-                " ORDER BY count(*) DESC " +
-                " LIMIT " + limit;
-        return db.rawQuery(sql, null);
+    private static Cursor getHistoryByFrequency(SQLiteDatabase db, int limit, @Nullable String query) {
+        if (query == null) {
+            // order history based on frequency
+            String sql = "SELECT record, count(*) FROM history" +
+                    " GROUP BY record " +
+                    " ORDER BY count(*) DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, null);
+        } else {
+            // order history based on frequency
+            String sql = "SELECT record, count(*) FROM history" +
+                    " WHERE query LIKE ? " +
+                    " GROUP BY record " +
+                    " ORDER BY count(*) DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, new String[]{query + "%"});
+        }
     }
 
-    private static Cursor getHistoryByRecency(SQLiteDatabase db, int limit) {
-        return db.query(true, "history", new String[]{"record", "1"}, null, null,
-                null, null, "_id DESC", Integer.toString(limit));
+    private static Cursor getHistoryByRecency(SQLiteDatabase db, int limit, @Nullable String query) {
+        if (query == null) {
+            return db.query(true, "history", new String[]{"record", "1"}, null, null,
+                    null, null, "_id DESC", Integer.toString(limit));
+        } else {
+            return db.query(true, "history", new String[]{"record", "1"}, "query LIKE ?", new String[]{query + "%"},
+                    null, null, "_id DESC", Integer.toString(limit));
+        }
     }
 
     /**
      * Get the most used history items adaptively based on a set period of time
      *
      * @param db    The SQL db
-     * @param hours How many hours back we want to test frequency against
      * @param limit Maximum result size
      * @return Cursor
      */
-    private static Cursor getHistoryByAdaptive(SQLiteDatabase db, int hours, int limit) {
-        // order history based on frequency
-        String sql = "SELECT record, count(*) FROM history " +
-                "WHERE timeStamp >= 0 " +
-                "AND timeStamp >" + (System.currentTimeMillis() - (hours * 3600000L)) +
-                " GROUP BY record " +
-                " ORDER BY count(*) DESC " +
-                " LIMIT " + limit;
-        return db.rawQuery(sql, null);
+    private static Cursor getHistoryByAdaptive(SQLiteDatabase db, int limit, @Nullable String query) {
+        // how many hours back we want to test frequency against
+        int hours = 36;
+        if (query == null) {
+            // order history based on frequency
+            String sql = "SELECT record, count(*) FROM history " +
+                    " WHERE timeStamp >= 0 " +
+                    " AND timeStamp >" + (System.currentTimeMillis() - (hours * 3600000L)) +
+                    " GROUP BY record " +
+                    " ORDER BY count(*) DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, null);
+        } else {
+            // order history based on frequency
+            String sql = "SELECT record, count(*) FROM history " +
+                    " WHERE timeStamp >= 0 " +
+                    " AND timeStamp >" + (System.currentTimeMillis() - (hours * 3600000L)) +
+                    " AND query LIKE ? " +
+                    " GROUP BY record " +
+                    " ORDER BY count(*) DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, new String[]{query + "%"});
+        }
     }
 
     /**
@@ -154,18 +200,28 @@ public class DBHelper {
      * @param limit Maximum result size
      * @return Cursor
      */
-    private static Cursor getHistoryByTime(SQLiteDatabase db, int limit) {
+    private static Cursor getHistoryByTime(SQLiteDatabase db, int limit, @Nullable String query) {
         final long now = System.currentTimeMillis();
         final long MS_24_DAYS_AGO = now - 2073600000L;
-        String sql = "SELECT record, MAX(ABS((" + now + " - timestamp) % 86400000 - 43200000) - (" + now + " - timestamp) / 48 ) AS value" +
-                " FROM history" +
-                " WHERE timestamp > " + MS_24_DAYS_AGO +
-                " GROUP BY record " +
-                " ORDER BY value DESC " +
-                " LIMIT " + limit;
-        return db.rawQuery(sql, null);
+        if (query == null) {
+            String sql = "SELECT record, MAX(ABS((" + now + " - timestamp) % 86400000 - 43200000) - (" + now + " - timestamp) / 48 ) AS value" +
+                    " FROM history" +
+                    " WHERE timestamp > " + MS_24_DAYS_AGO +
+                    " GROUP BY record " +
+                    " ORDER BY value DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, null);
+        } else {
+            String sql = "SELECT record, MAX(ABS((" + now + " - timestamp) % 86400000 - 43200000) - (" + now + " - timestamp) / 48 ) AS value" +
+                    " FROM history" +
+                    " WHERE timestamp > " + MS_24_DAYS_AGO +
+                    " AND query LIKE ? " +
+                    " GROUP BY record " +
+                    " ORDER BY value DESC " +
+                    " LIMIT " + limit;
+            return db.rawQuery(sql, new String[]{query + "%"});
+        }
     }
-
 
     /**
      * Retrieve previous query history
@@ -175,6 +231,18 @@ public class DBHelper {
      * @return records with number of use
      */
     public static List<ValuedHistoryRecord> getHistory(Context context, int limit, HistoryMode historyMode) {
+        return getHistory(context, limit, historyMode, null);
+    }
+
+    /**
+     * Retrieve previous query history
+     *
+     * @param context android context
+     * @param limit   max number of items to retrieve
+     * @param query   search query
+     * @return records with number of use
+     */
+    public static List<ValuedHistoryRecord> getHistory(Context context, int limit, HistoryMode historyMode, @Nullable String query) {
         List<ValuedHistoryRecord> records;
 
         SQLiteDatabase db = getDatabase(context);
@@ -182,23 +250,23 @@ public class DBHelper {
         Cursor cursor;
         switch (historyMode) {
             case FRECENCY:
-                cursor = getHistoryByFrecency(db, limit);
+                cursor = getHistoryByFrecency(db, limit, query);
                 break;
             case FREQUENCY:
-                cursor = getHistoryByFrequency(db, limit);
+                cursor = getHistoryByFrequency(db, limit, query);
                 break;
             case ADAPTIVE:
-                cursor = getHistoryByAdaptive(db, 36, limit);
+                cursor = getHistoryByAdaptive(db, limit, query);
                 break;
             case TIME:
-                cursor = getHistoryByTime(db, limit);
+                cursor = getHistoryByTime(db, limit, query);
                 break;
             case ALPHABETICALLY:
             case RECENCY:
-                cursor = getHistoryByRecency(db, limit);
+                cursor = getHistoryByRecency(db, limit, query);
                 break;
             default:
-                cursor = getHistoryByRecency(db, limit);
+                cursor = getHistoryByRecency(db, limit, query);
                 Log.e(TAG, "Fallback to 'recency' for unknown history mode " + historyMode);
                 break;
         }

--- a/app/src/main/java/fr/neamar/kiss/db/ValuedHistoryRecord.java
+++ b/app/src/main/java/fr/neamar/kiss/db/ValuedHistoryRecord.java
@@ -10,4 +10,9 @@ public class ValuedHistoryRecord {
      * Context dependant value, e.g. number of access
      */
     public int value;
+
+    /**
+     * Normalized relevance for record
+     */
+    public int relevance;
 }

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -1,5 +1,6 @@
 package fr.neamar.kiss.searcher;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 
 import androidx.preference.PreferenceManager;
@@ -10,6 +11,7 @@ import java.util.List;
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.db.DBHelper;
+import fr.neamar.kiss.db.HistoryMode;
 import fr.neamar.kiss.db.ValuedHistoryRecord;
 import fr.neamar.kiss.pojo.Pojo;
 
@@ -75,16 +77,24 @@ public class QuerySearcher extends Searcher {
         if (activity == null)
             return null;
 
-        // Have we ever made the same query and selected something ?
-        List<ValuedHistoryRecord> lastIdsForQuery = DBHelper.getPreviousResultsForQuery(activity, query);
+        // Have we ever made the same query and selected something?
+        HistoryMode historyMode = getHistoryMode(activity);
+        List<ValuedHistoryRecord> lastIdsForQuery = DBHelper.getHistory(activity, getMaxResultCount(), historyMode, query);
+
         knownIds = new HashMap<>();
-        for (ValuedHistoryRecord id : lastIdsForQuery) {
-            knownIds.put(id.record, id.value);
+        int size = lastIdsForQuery.size();
+        for (int i = 0; i < size; i++) {
+            knownIds.put(lastIdsForQuery.get(i).record, historyMode == HistoryMode.ALPHABETICALLY ? 0 : size - i);
         }
 
         // Request results via "addResult"
         KissApplication.getApplication(activity).getDataHandler().requestResults(query, this);
         return null;
+    }
+
+    public HistoryMode getHistoryMode(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        return HistoryMode.valueById(prefs.getString("history-mode", "recency"));
     }
 
     public static void clearMaxResultCountCache() {

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -1,18 +1,17 @@
 package fr.neamar.kiss.searcher;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 
 import androidx.preference.PreferenceManager;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import fr.neamar.kiss.KissApplication;
 import fr.neamar.kiss.MainActivity;
 import fr.neamar.kiss.db.DBHelper;
 import fr.neamar.kiss.db.HistoryMode;
-import fr.neamar.kiss.db.ValuedHistoryRecord;
 import fr.neamar.kiss.pojo.Pojo;
 
 /**
@@ -22,7 +21,8 @@ import fr.neamar.kiss.pojo.Pojo;
  */
 public class QuerySearcher extends Searcher {
     private static int MAX_RESULT_COUNT = -1;
-    private HashMap<String, Integer> knownIds;
+    private final HistoryMode historyMode;
+    private Map<String, Integer> knownIds;
     /**
      * Store user preferences
      */
@@ -31,6 +31,7 @@ public class QuerySearcher extends Searcher {
     public QuerySearcher(MainActivity activity, String query, boolean isRefresh) {
         super(activity, query, isRefresh);
         prefs = PreferenceManager.getDefaultSharedPreferences(activity);
+        historyMode = HistoryMode.valueById(prefs.getString("history-mode", "recency"));
     }
 
     @Override
@@ -57,9 +58,14 @@ public class QuerySearcher extends Searcher {
                 pojo.relevance -= 200;
             } else {
                 // Give a boost if item was previously selected for this query
+                // Always 200 for item with highest relevance and decreasing for others.
                 Integer value = knownIds.get(pojo.id);
                 if (value != null) {
-                    pojo.relevance += 25 * value;
+                    if (historyMode != HistoryMode.ALPHABETICALLY) {
+                        pojo.relevance += Math.max(0, 200 - Math.max(knownIds.size() - value, 0) * 10);
+                    } else {
+                        pojo.relevance += 200;
+                    }
                 }
             }
         }
@@ -78,23 +84,14 @@ public class QuerySearcher extends Searcher {
             return null;
 
         // Have we ever made the same query and selected something?
-        HistoryMode historyMode = getHistoryMode(activity);
-        List<ValuedHistoryRecord> lastIdsForQuery = DBHelper.getHistory(activity, getMaxResultCount(), historyMode, query);
-
-        knownIds = new HashMap<>();
-        int size = lastIdsForQuery.size();
-        for (int i = 0; i < size; i++) {
-            knownIds.put(lastIdsForQuery.get(i).record, historyMode == HistoryMode.ALPHABETICALLY ? 0 : size - i);
-        }
+        knownIds = DBHelper.getHistory(activity, getMaxResultCount(), historyMode, query)
+                .stream()
+                .collect(Collectors.toMap(historyRecord -> historyRecord.record,
+                        historyRecord -> historyRecord.relevance));
 
         // Request results via "addResult"
         KissApplication.getApplication(activity).getDataHandler().requestResults(query, this);
         return null;
-    }
-
-    public HistoryMode getHistoryMode(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        return HistoryMode.valueById(prefs.getString("history-mode", "recency"));
     }
 
     public static void clearMaxResultCountCache() {

--- a/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/QuerySearcher.java
@@ -57,14 +57,14 @@ public class QuerySearcher extends Searcher {
                 // Give penalty for disabled items, these should not be preferred
                 pojo.relevance -= 200;
             } else {
-                // Give a boost if item was previously selected for this query
-                // Always 200 for item with highest relevance and decreasing for others.
+                // Give a boost if item was previously selected for this query.
+                // Always 100 for item with highest relevance and decreasing for others.
                 Integer value = knownIds.get(pojo.id);
                 if (value != null) {
                     if (historyMode != HistoryMode.ALPHABETICALLY) {
-                        pojo.relevance += Math.max(0, 200 - Math.max(knownIds.size() - value, 0) * 10);
+                        pojo.relevance += Math.max(0, 100 - Math.max(knownIds.size() - value, 0) * 5);
                     } else {
-                        pojo.relevance += 200;
+                        pojo.relevance += 100;
                     }
                 }
             }

--- a/app/src/main/java/fr/neamar/kiss/searcher/SearchHandler.java
+++ b/app/src/main/java/fr/neamar/kiss/searcher/SearchHandler.java
@@ -1,6 +1,7 @@
 package fr.neamar.kiss.searcher;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import fr.neamar.kiss.MainActivity;
 
@@ -45,7 +46,7 @@ public class SearchHandler {
      * @param query     the search query
      * @param isRefresh true, if refresh of last search is needed
      */
-    public void search(@NonNull Searcher.Type type, @NonNull MainActivity activity, String query, boolean isRefresh) {
+    public void search(@NonNull Searcher.Type type, @NonNull MainActivity activity, @Nullable String query, boolean isRefresh) {
         cancelSearch();
 
         runningSearch = createSearcher(type, activity, query, isRefresh);
@@ -72,7 +73,7 @@ public class SearchHandler {
     }
 
     @NonNull
-    private Searcher createSearcher(@NonNull Searcher.Type type, @NonNull MainActivity activity, String query, boolean isRefresh) {
+    private Searcher createSearcher(@NonNull Searcher.Type type, @NonNull MainActivity activity, @Nullable String query, boolean isRefresh) {
         if (isRefresh && lastSearchType != null) {
             type = this.lastSearchType;
             query = this.lastSearchQuery;
@@ -99,7 +100,13 @@ public class SearchHandler {
         }
     }
 
+    @Nullable
     public Searcher.Type getLastSearchType() {
         return lastSearchType;
+    }
+
+    @Nullable
+    public String getLastSearchQuery() {
+        return lastSearchQuery;
     }
 }

--- a/app/src/main/java/fr/neamar/kiss/utils/fuzzy/FuzzyScoreV2.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/fuzzy/FuzzyScoreV2.java
@@ -58,7 +58,7 @@ public class FuzzyScoreV2 implements FuzzyScore {
         camel_bonus = 30;
         first_letter_bonus = 30;
         leading_letter_penalty = -5;
-        max_leading_letter_penalty = -30;
+        max_leading_letter_penalty = -45;
         unmatched_letter_penalty = -2;
         if (detailedMatchIndices) {
             matchInfo = new MatchInfo(patternLength);

--- a/app/src/main/java/fr/neamar/kiss/utils/fuzzy/FuzzyScoreV2.java
+++ b/app/src/main/java/fr/neamar/kiss/utils/fuzzy/FuzzyScoreV2.java
@@ -56,7 +56,7 @@ public class FuzzyScoreV2 implements FuzzyScore {
         adjacency_bonus = 15;
         separator_bonus = 30;
         camel_bonus = 30;
-        first_letter_bonus = 15;
+        first_letter_bonus = 30;
         leading_letter_penalty = -5;
         max_leading_letter_penalty = -30;
         unmatched_letter_penalty = -2;


### PR DESCRIPTION
- fixed a bug which resulted in recording of all app launches for last search query. Even if lauched from history or apps where no search is involved at all.
- result boost is now history mode as defined in KISS settings.
- results from history now always have a difference in relevance of 1. In case of history mode `Accessed at same time of day` these numbers were in the millions which was not working out well.
- max boost is now independent of number of results found for query. Always same for most relevant item and decreasing for less relevant items.
- fuzzy search improved. Bonus for matching first letter was increased to match camel bonus and separator bonus
- fuzzy search improved. Max penalty for not matching letters at begin of words was increased slightly.

<!--

Thanks for taking the time to make KISS better by contributing code!

Before you open the pull request, please make sure that:

* Your pull request title is clear enough -- ideally, reading the title should be enough to understand the content
* Your description explains what you're trying to do (ideally referencing some existing issues)
* If you made any tradeoffs, please mention them and explain why you think they were necessary
* Include screenshots of your changes
* If you add something slightly complex, feel free to create [a new documentation page](https://github.com/Neamar/KISS/tree/master/docs/_posts), users will thank you for that!

You might also want to have a look at the ["Before contributing..."](https://github.com/Neamar/KISS/blob/master/CONTRIBUTING.md#before-contributing) section ;)

Once again, thanks for your help! Feel free to remove all this text and start typing...

-->
